### PR TITLE
Fix Windows release checksum line endings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,7 +247,11 @@ jobs:
         run: |
           cd SSRVPN_Windows
           $hash = (Get-FileHash SSRVPN.zip -Algorithm SHA256).Hash.ToLower()
-          "$hash  SSRVPN.zip" | Out-File -Encoding ascii SSRVPN.zip.sha256
+          [System.IO.File]::WriteAllText(
+            (Join-Path (Get-Location) 'SSRVPN.zip.sha256'),
+            "$hash  SSRVPN.zip`n",
+            [System.Text.Encoding]::ASCII
+          )
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- write the Windows release SHA256 file with explicit LF line endings
- keep macOS/Linux `shasum -c` verification working on downloaded release assets

## Testing
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parses"'`