### PR TITLE
fix windows portable runtime packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,22 @@ jobs:
 
       - run: bash scripts/check-coverage-thresholds.sh ${{ matrix.directory }}
 
+      - name: Build Windows portable ZIP
+        if: matrix.directory == 'SSRVPN_Windows'
+        shell: powershell
+        run: |
+          cd SSRVPN_Windows
+          powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File tool\package_windows.ps1
+
+      - name: Upload Windows portable ZIP
+        if: matrix.directory == 'SSRVPN_Windows'
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-portable-pr
+          path: |
+            SSRVPN_Windows/SSRVPN.zip
+            SSRVPN_Windows/SSRVPN.zip.sha256
+
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'
@@ -294,6 +295,14 @@ jobs:
           $portableRoot = Join-Path $verifyRoot 'SSRVPN_Windows_Release'
           foreach ($relativePath in @(
             'ssrvpn_windows.exe',
+            'concrt140.dll',
+            'msvcp140.dll',
+            'msvcp140_1.dll',
+            'msvcp140_2.dll',
+            'msvcp140_atomic_wait.dll',
+            'msvcp140_codecvt_ids.dll',
+            'vcruntime140.dll',
+            'vcruntime140_1.dll',
             'bin\ssrvpn_windows_app.exe',
             'bin\mihomo.exe',
             'SHA256SUMS.txt',
@@ -336,6 +345,7 @@ jobs:
   # ── GitHub Release ──
   publish:
     name: Publish Release
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [build-android, build-macos, build-windows]
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.2] - 2026-07-07
+
+### Fixed
+- Fixed the Windows portable package so the root launcher includes the Visual C++ runtime DLLs it needs on clean Windows machines.
+- Improved the Windows Home connection module at 1280x720 and compact window sizes by using a denser connection panel and responsive power button sizing.
+
+### Changed
+- Added online CI validation and artifact upload for the Windows portable ZIP so release packaging regressions are caught before publishing.
+
 ## [2.4.1] - 2026-07-07
 
 ### Fixed

--- a/SSRVPN_Android/assets/geoip.metadb.gz
+++ b/SSRVPN_Android/assets/geoip.metadb.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2a032929ec7f68f6cfd586cdb864e464fd46ee308863563f2d6110b711afc3a
-size 4340828
+oid sha256:91f7ac96b924fc2b498852b9ed546d9462f26014b8451e32100cdd2c8e3ebfe1
+size 4352175

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 2.4.1+241
+version: 2.4.2+242
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/assets/geoip.metadb.gz
+++ b/SSRVPN_MacOS/assets/geoip.metadb.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2a032929ec7f68f6cfd586cdb864e464fd46ee308863563f2d6110b711afc3a
-size 4340828
+oid sha256:91f7ac96b924fc2b498852b9ed546d9462f26014b8451e32100cdd2c8e3ebfe1
+size 4352175

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 2.4.1+241
+version: 2.4.2+242
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/PORTABLE_README.txt
+++ b/SSRVPN_Windows/PORTABLE_README.txt
@@ -33,13 +33,13 @@ SSRVPN Windows 便携版 v2.0.6
 ═══════════════════════════════════════
 
 Q: 双击后什么反应都没有？
-A: 很可能是 SmartScreen 拦截或缺少渲染组件
+A: 很可能是 SmartScreen 拦截、主目录运行库缺失或缺少渲染组件
    1. 右键 exe → 属性 → 勾选"解除锁定"
    2. 运行 SSRVPN_Diag.bat 查看完整诊断
 
 Q: 提示缺少 DLL？
 A: 运行 SSRVPN_Diag.bat 会列出具体缺失的文件
-   正常发布包已自带 VC++ 运行库和 d3dcompiler_47.dll
+   正常发布包会在主目录和 bin 自带 VC++ 运行库，并在 bin 自带 d3dcompiler_47.dll
    如果缺失，通常是 ZIP 没有完整解压或文件被安全软件隔离
 
 Q: 杀毒软件报毒？

--- a/SSRVPN_Windows/README.md
+++ b/SSRVPN_Windows/README.md
@@ -81,6 +81,7 @@ SSRVPN_Windows_Release/
 ├── 使用教程.txt
 ├── SSRVPN_Diag.bat
 ├── SAFE_MODE_README.txt
+├── *.dll                      # 主启动器需要的 VC++ 运行库
 └── bin/
     ├── ssrvpn_windows_app.exe  # 内部 Flutter 程序
     ├── mihomo.exe              # Mihomo 核心
@@ -117,7 +118,7 @@ https://github.com/MetaCubeX/mihomo/releases
 
 ### 便携模式
 
-本软件为**绿色免安装版**，解压后主目录只有一个面向用户的 `ssrvpn_windows.exe`。应用内部文件放在 `bin` 目录，配置、订阅、缓存和日志默认存储在 `bin\ssrvpn` 文件夹内。系统代理模式运行期间会临时修改当前用户的 Windows 代理设置，断开或退出时自动恢复原设置。
+本软件为**绿色免安装版**，解压后主目录只有一个面向用户的 `ssrvpn_windows.exe`，并保留启动器必需的 VC++ 运行库 DLL。应用内部文件放在 `bin` 目录，配置、订阅、缓存和日志默认存储在 `bin\ssrvpn` 文件夹内。系统代理模式运行期间会临时修改当前用户的 Windows 代理设置，断开或退出时自动恢复原设置。
 
 如果程序目录不可写（例如放在受保护目录或只读介质），数据会自动回退到 `%LOCALAPPDATA%\SSRVPN\ssrvpn`。系统代理恢复快照属于当前电脑的运行状态，会单独保存在本机 LocalAppData 中，不会随便携目录复制到其他电脑。
 
@@ -127,6 +128,7 @@ SSRVPN_Windows_Portable/
 ├── 使用教程.txt
 ├── SSRVPN_Diag.bat
 ├── SAFE_MODE_README.txt
+├── *.dll                      # 主启动器需要的 VC++ 运行库
 └── bin/
     ├── ssrvpn_windows_app.exe  # 内部 Flutter 程序
     ├── mihomo.exe              # 代理核心

--- a/SSRVPN_Windows/SSRVPN_Diag.bat
+++ b/SSRVPN_Windows/SSRVPN_Diag.bat
@@ -39,7 +39,17 @@ echo.
 echo [2/6] 检查必备 DLL 文件...
 
 set MISSING_DLLS=0
+set ROOT_RUNTIME_DLL_LIST=concrt140.dll msvcp140.dll msvcp140_1.dll msvcp140_2.dll msvcp140_atomic_wait.dll msvcp140_codecvt_ids.dll vcruntime140.dll vcruntime140_1.dll
 set DLL_LIST=ssrvpn_windows_app.exe flutter_windows.dll screen_retriever_windows_plugin.dll system_tray_plugin.dll window_manager_plugin.dll mihomo.exe concrt140.dll msvcp140.dll msvcp140_1.dll msvcp140_2.dll msvcp140_atomic_wait.dll msvcp140_codecvt_ids.dll vcruntime140.dll vcruntime140_1.dll d3dcompiler_47.dll
+
+for %%d in (%ROOT_RUNTIME_DLL_LIST%) do (
+    if exist "%~dp0%%d" (
+        echo [OK]  %%d
+    ) else (
+        echo [MISS] %%d -- 主启动器运行库缺失！
+        set /a MISSING_DLLS+=1
+    )
+)
 
 for %%d in (%DLL_LIST%) do (
     if exist "%BIN_DIR%%%d" (

--- a/SSRVPN_Windows/assets/geoip.metadb.gz
+++ b/SSRVPN_Windows/assets/geoip.metadb.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2a032929ec7f68f6cfd586cdb864e464fd46ee308863563f2d6110b711afc3a
-size 4340828
+oid sha256:91f7ac96b924fc2b498852b9ed546d9462f26014b8451e32100cdd2c8e3ebfe1
+size 4352175

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 绿色免安装版)
 publish_to: 'none'
-version: 2.4.1+241
+version: 2.4.2+242
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/tool/package_windows.ps1
+++ b/SSRVPN_Windows/tool/package_windows.ps1
@@ -51,7 +51,7 @@ $requiredFiles = @(
   'bin\data\icudtl.dat',
   'bin\data\flutter_assets\assets\geoip.metadb.gz',
   'bin\data\flutter_assets\assets\icon.ico'
-) + ($runtimeDlls | ForEach-Object { "bin\$_" })
+) + $runtimeDlls + ($runtimeDlls | ForEach-Object { "bin\$_" })
 
 $transcriptStarted = $false
 if ($LogPath -and $LogPath.Trim().Length -gt 0) {
@@ -327,6 +327,9 @@ function Add-PortableRuntimeFiles {
   $runtimeDirs = Get-PortableRuntimeSearchDirectories
   foreach ($dll in $runtimeDlls) {
     Copy-PortableDependency -Name $dll -Directories $runtimeDirs `
+      -DestinationDirectory $releaseDir -RequireX64 `
+      -InstallHint 'Install Visual Studio 2022 with the C++ desktop workload, or install the Microsoft Visual C++ Redistributable 2015-2022 x64 on the build machine.'
+    Copy-PortableDependency -Name $dll -Directories $runtimeDirs `
       -DestinationDirectory $binDir -RequireX64 `
       -InstallHint 'Install Visual Studio 2022 with the C++ desktop workload, or install the Microsoft Visual C++ Redistributable 2015-2022 x64 on the build machine.'
   }
@@ -375,7 +378,7 @@ function Move-PortableInternalsToBin {
     'ssrvpn_cet_fix.ps1',
     'ssrvpn_cet_fix.bat',
     'SHA256SUMS.txt'
-  )
+  ) + $runtimeDlls
 
   Get-ChildItem -LiteralPath $releaseDir -Force | ForEach-Object {
     if ($_.Name -eq 'bin' -or $rootFilesToKeep -contains $_.Name) {
@@ -608,7 +611,7 @@ function Test-ReleaseContents {
     'bin\system_tray_plugin.dll',
     'bin\window_manager_plugin.dll',
     'bin\d3dcompiler_47.dll'
-  ) + ($runtimeDlls | ForEach-Object { "bin\$_" })
+  ) + $runtimeDlls + ($runtimeDlls | ForEach-Object { "bin\$_" })
   foreach ($relativePath in $peFiles) {
     $path = Join-Path $Root $relativePath
     if (-not (Test-X64PeFile -Path $path)) {

--- a/docs/GEOIP_SOURCE.txt
+++ b/docs/GEOIP_SOURCE.txt
@@ -1,6 +1,6 @@
 Repo: MetaCubeX/meta-rules-dat
 Release tag: latest
-Release name: Release 2026-07-06 07:33
+Release name: Release 2026-07-07 07:35
 Asset URL: https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip.metadb
-Upstream SHA256: 94bdc35c14af8b98fee3791baac26c54e87eea94ae2f57ec04e1b2f4541aa673
-Bundled gzip SHA256: e2a032929ec7f68f6cfd586cdb864e464fd46ee308863563f2d6110b711afc3a
+Upstream SHA256: 7fdcb786185fe40f957c34a7a14033953fbc7ecd171e30888007d9be15ffd689
+Bundled gzip SHA256: 91f7ac96b924fc2b498852b9ed546d9462f26014b8451e32100cdd2c8e3ebfe1

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -56,7 +56,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '2.4.1';
+  static const String appVersion = '2.4.2';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/packages/ssrvpn_shared/lib/desktop_ui/widgets/connection_button_part.dart
+++ b/packages/ssrvpn_shared/lib/desktop_ui/widgets/connection_button_part.dart
@@ -5,12 +5,14 @@ class ConnectionButton extends StatefulWidget {
   final bool isConnected;
   final bool isConnecting;
   final VoidCallback? onTap;
+  final double size;
 
   const ConnectionButton({
     super.key,
     required this.isConnected,
     this.isConnecting = false,
     this.onTap,
+    this.size = 140,
   });
 
   @override
@@ -72,11 +74,13 @@ class _ConnectionButtonState extends State<ConnectionButton>
 
   @override
   Widget build(BuildContext context) {
+    final scale = (widget.size / 140).clamp(0.68, 1.0).toDouble();
+
     return GestureDetector(
       onTap: widget.isConnecting ? null : widget.onTap,
       child: SizedBox(
-        width: 140,
-        height: 140,
+        width: widget.size,
+        height: widget.size,
         child: AnimatedBuilder(
           animation: Listenable.merge([_pulseCtrl, _ringCtrl, _breatheCtrl]),
           builder: (context, child) {
@@ -90,11 +94,11 @@ class _ConnectionButtonState extends State<ConnectionButton>
               ),
               child: Center(
                 child: widget.isConnecting
-                    ? const SizedBox(
-                        width: 36,
-                        height: 36,
+                    ? SizedBox(
+                        width: 36 * scale,
+                        height: 36 * scale,
                         child: CircularProgressIndicator(
-                          strokeWidth: 2.5,
+                          strokeWidth: 2.5 * scale,
                           color: Colors.white,
                         ),
                       )
@@ -104,7 +108,7 @@ class _ConnectionButtonState extends State<ConnectionButton>
                           Icon(
                             Icons.power_settings_new_rounded,
                             color: Colors.white,
-                            size: 36,
+                            size: 36 * scale,
                             shadows: [
                               Shadow(
                                 color: Colors.black.withValues(alpha: 0.3),
@@ -113,14 +117,14 @@ class _ConnectionButtonState extends State<ConnectionButton>
                               ),
                             ],
                           ),
-                          const SizedBox(height: 10),
+                          SizedBox(height: 10 * scale),
                           Text(
                             widget.isConnected ? '断开' : '连接',
                             style: TextStyle(
                               color: Colors.white.withValues(alpha: 0.9),
-                              fontSize: 13,
+                              fontSize: 13 * scale,
                               fontWeight: FontWeight.w700,
-                              letterSpacing: 3,
+                              letterSpacing: 3 * scale,
                             ),
                           ),
                         ],

--- a/packages/ssrvpn_shared/lib/desktop_ui/widgets/desktop_home_dashboard_part.dart
+++ b/packages/ssrvpn_shared/lib/desktop_ui/widgets/desktop_home_dashboard_part.dart
@@ -70,6 +70,7 @@ class _DesktopHomeDashboard extends StatelessWidget {
             publicIpInfo: publicIpInfo,
             isRefreshingPublicIp: isRefreshingPublicIp,
             publicIpError: publicIpError,
+            denseLayout: !wide || constraints.maxHeight < 640,
             glowAnimation: glowAnimation,
             onToggleConnection: onToggleConnection,
             onShowForceProxySites: onShowForceProxySites,
@@ -320,6 +321,7 @@ class _DesktopHomeStatusPanel extends StatelessWidget {
   final PublicIpInfo? publicIpInfo;
   final bool isRefreshingPublicIp;
   final String? publicIpError;
+  final bool denseLayout;
   final Animation<double> glowAnimation;
   final VoidCallback onToggleConnection;
   final VoidCallback onShowForceProxySites;
@@ -339,6 +341,7 @@ class _DesktopHomeStatusPanel extends StatelessWidget {
     required this.publicIpInfo,
     required this.isRefreshingPublicIp,
     required this.publicIpError,
+    required this.denseLayout,
     required this.glowAnimation,
     required this.onToggleConnection,
     required this.onShowForceProxySites,
@@ -353,12 +356,23 @@ class _DesktopHomeStatusPanel extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final compact = constraints.maxWidth < 430;
+        final shortHeight =
+            constraints.maxHeight.isFinite && constraints.maxHeight < 380;
+        final dense = denseLayout || compact || shortHeight;
+        final buttonSize = dense ? 108.0 : 140.0;
+        final outerHorizontalPadding = compact ? 16.0 : 28.0;
+        final outerVerticalPadding = dense ? 6.0 : 10.0;
+        final cardHorizontalPadding = compact ? 18.0 : 24.0;
+        final cardVerticalPadding = dense ? 18.0 : 28.0;
+        final buttonGap = dense ? 14.0 : 20.0;
+        final sectionGap = dense ? 12.0 : 16.0;
+        final connectedGap = dense ? 8.0 : 12.0;
         return Padding(
           padding: EdgeInsets.fromLTRB(
-            compact ? 20 : 28,
-            10,
-            compact ? 20 : 28,
-            10,
+            outerHorizontalPadding,
+            outerVerticalPadding,
+            outerHorizontalPadding,
+            outerVerticalPadding,
           ),
           child: AnimatedBuilder(
             animation: glowAnimation,
@@ -386,9 +400,9 @@ class _DesktopHomeStatusPanel extends StatelessWidget {
                   blur: 34,
                   opacity: isDark ? 0.055 : 0.58,
                   borderRadius: const BorderRadius.all(Radius.circular(24)),
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 28,
-                    horizontal: 24,
+                  padding: EdgeInsets.symmetric(
+                    vertical: cardVerticalPadding,
+                    horizontal: cardHorizontalPadding,
                   ),
                   borderOpacity: isDark ? 0.17 : 0.72,
                   shadowOpacity: isDark ? 0.42 : 0.1,
@@ -400,8 +414,9 @@ class _DesktopHomeStatusPanel extends StatelessWidget {
                             isConnected: isConnected,
                             isConnecting: isConnecting,
                             onTap: onToggleConnection,
+                            size: buttonSize,
                           ),
-                          const SizedBox(width: 20),
+                          SizedBox(width: buttonGap),
                           Expanded(
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
@@ -471,7 +486,7 @@ class _DesktopHomeStatusPanel extends StatelessWidget {
                           ),
                         ],
                       ),
-                      const SizedBox(height: 16),
+                      SizedBox(height: sectionGap),
                       if (isConnected) ...[
                         _DesktopPublicIpRow(
                           info: publicIpInfo,
@@ -480,7 +495,7 @@ class _DesktopHomeStatusPanel extends StatelessWidget {
                           subColor: subColor,
                           onRefresh: onRefreshPublicIp,
                         ),
-                        const SizedBox(height: 12),
+                        SizedBox(height: connectedGap),
                       ],
                       _DesktopConnectionOptions(
                         isDark: isDark,
@@ -731,7 +746,7 @@ class _DesktopConnectionOptions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
         color: isDark
             ? Colors.white.withValues(alpha: 4 / 255)
@@ -817,7 +832,7 @@ class _DesktopConnectionOptions extends StatelessWidget {
             ],
           );
 
-          if (constraints.maxWidth < 520) {
+          if (constraints.maxWidth < 300) {
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [modeControl, const SizedBox(height: 12), tunControl],
@@ -830,7 +845,7 @@ class _DesktopConnectionOptions extends StatelessWidget {
               Container(
                 width: 1,
                 height: 52,
-                margin: const EdgeInsets.symmetric(horizontal: 16),
+                margin: const EdgeInsets.symmetric(horizontal: 12),
                 color: isDark ? AppTheme.border : AppTheme.lightBorder,
               ),
               Expanded(child: tunControl),
@@ -873,8 +888,8 @@ class _DesktopTunChoice extends StatelessWidget {
       onTap: disabled ? null : () => onChanged(enableTun),
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 180),
-        margin: const EdgeInsets.only(top: 8),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        margin: const EdgeInsets.only(top: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
         decoration: BoxDecoration(
           color: selected
               ? AppTheme.primary.withValues(alpha: (isDark ? 28 : 18) / 255)

--- a/scripts/smoke-release-artifacts.sh
+++ b/scripts/smoke-release-artifacts.sh
@@ -111,11 +111,24 @@ root_exes = [name for name in root_files if name.lower().endswith(".exe")]
 if root_exes != ["ssrvpn_windows.exe"]:
     raise SystemExit(f"ZIP root must contain one user-facing exe: {root_exes}")
 
+runtime_dlls = [
+    "concrt140.dll",
+    "msvcp140.dll",
+    "msvcp140_1.dll",
+    "msvcp140_2.dll",
+    "msvcp140_atomic_wait.dll",
+    "msvcp140_codecvt_ids.dll",
+    "vcruntime140.dll",
+    "vcruntime140_1.dll",
+]
 required = {
     "SSRVPN_Windows_Release/bin/ssrvpn_windows_app.exe",
     "SSRVPN_Windows_Release/bin/mihomo.exe",
     "SSRVPN_Windows_Release/bin/data/flutter_assets/assets/geoip.metadb.gz",
 }
+for dll in runtime_dlls:
+    required.add(f"SSRVPN_Windows_Release/{dll}")
+    required.add(f"SSRVPN_Windows_Release/bin/{dll}")
 all_names = {path.as_posix() for path in names}
 missing = sorted(required - all_names)
 if missing:


### PR DESCRIPTION
## Summary

Fix the Windows portable ZIP so the root launcher can start on machines without a system-wide Visual C++ runtime installed, and make PR CI build the Windows portable ZIP artifact online.

## Root cause

The portable package already bundled the VC++ runtime DLLs under `bin/`, but the user-facing root `ssrvpn_windows.exe` is a native launcher that also depends on those DLLs before it can start the child Flutter process. On a clean Windows machine, the launcher exits before it can reach `bin/`.

## Changes

- Copy and require VC++ runtime DLLs in both the portable root and `bin/`.
- Keep those root DLLs when moving internal files into `bin/`.
- Extend Windows ZIP verification and smoke checks so bad release artifacts fail CI.
- Add PR CI Windows portable ZIP build/upload artifact step.
- Add `workflow_dispatch` for manual online release builds while keeping GitHub Release publishing tag-only.
- Update diagnostics and docs to explain root launcher runtime DLLs.
- Refresh GeoIP assets to unblock the existing CI `sync-geoip-metadb.py --check` gate.

## Validation

- Parsed `SSRVPN_Windows/tool/package_windows.ps1` with the PowerShell parser.
- Ran `git diff --check`.
- Executed the ZIP smoke-check Python block against a synthetic ZIP containing the required root/bin runtime DLL layout.
- Ran `scripts/sync-geoip-metadb.py --check` locally after refreshing GeoIP assets.

Note: full local Flutter Windows build was not run in this environment because Flutter is not installed here; the PR CI now builds and uploads the Windows portable ZIP online.