### PR TITLE
fix: preserve Windows package guide UTF-8 title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-07-11
+
+### 修复
+
+- 修复 Windows 便携 ZIP 中文教程标题在 Windows PowerShell 5.1 下被错误代码页解码而显示乱码的问题。
+- 让 ZIP 产物冒烟检查兼容 Windows 路径分隔符，并校验教程标题和版本格式，防止同类编码回归。
+
 ## [3.0.0] - 2026-07-11
 
 ### 新增

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.0.0+300
+version: 3.0.1+301
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.0.0+300
+version: 3.0.1+301
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 绿色免安装版)
 publish_to: 'none'
-version: 3.0.0+300
+version: 3.0.1+301
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/tool/package_windows.ps1
+++ b/SSRVPN_Windows/tool/package_windows.ps1
@@ -43,7 +43,9 @@ function Copy-PortableReadme {
   if ($lines.Count -eq 0) {
     throw "Portable readme is empty: $source"
   }
-  $lines[0] = "SSRVPN Windows 便携版 $(Get-AppDisplayVersion)"
+  # Preserve the UTF-8 title read from the guide. Windows PowerShell 5.1 may
+  # decode non-ASCII literals in a BOM-less .ps1 file using the active codepage.
+  $lines[0] = "$($lines[0]) $(Get-AppDisplayVersion)"
   $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
   [System.IO.File]::WriteAllLines($Destination, $lines, $utf8NoBom)
 }

--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -4,7 +4,7 @@ Last reviewed: 2026-07-11
 
 ## Current Status
 
-SSRVPN is a single Flutter monorepo for Android, macOS, Windows, and `ssrvpn_shared`. The `v3.0.0` release candidate combines the package-guide, Windows flag, conservative unlock, Android startup, and Clash responsibility-boundary work. It passed the full local gate, Android debug packaging, macOS Release/DMG packaging, macOS UI startup, and native lifecycle tests; remote three-platform CI remains mandatory before tagging.
+SSRVPN is a single Flutter monorepo for Android, macOS, Windows, and `ssrvpn_shared`. The `v3.0.1` release candidate combines the package-guide, Windows flag, conservative unlock, Android startup, and Clash responsibility-boundary work, plus a Windows PowerShell 5.1 UTF-8 guide-title fix discovered by downloading and inspecting the published `v3.0.0` artifacts. It passed the full local gate, Android debug packaging, macOS Release/DMG packaging, macOS UI startup, and native lifecycle tests; remote three-platform CI remains mandatory before tagging.
 
 | Area | Status | Notes |
 |---|---|---|
@@ -48,7 +48,7 @@ The macOS and Windows gates remain deliberately conservative. Raising them shoul
 
 ## Next Milestones
 
-1. Push the verified `v3.0.0` candidate, require all remote CI jobs, then complete the documented Windows real-device smoke matrix.
+1. Push the verified `v3.0.1` correction, require all remote CI jobs, then complete the documented Windows real-device smoke matrix.
 2. Add Developer ID/notarization and Windows Authenticode signing for trusted desktop distribution.
 3. Decide and document the macOS TUN architecture before implementation.
 4. Migrate Android to Built-in Kotlin before the next Flutter toolchain upgrade.

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -56,7 +56,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.0.0';
+  static const String appVersion = '3.0.1';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/scripts/check-package-guides.sh
+++ b/scripts/check-package-guides.sh
@@ -34,4 +34,10 @@ if [[ "$actual_windows" != "$expected_windows" ]]; then
   exit 1
 fi
 
+if ! grep -Fq '$lines[0] = "$($lines[0]) $(Get-AppDisplayVersion)"' \
+  "$ROOT/SSRVPN_Windows/tool/package_windows.ps1"; then
+  echo "package guide check failed: Windows package title must preserve the UTF-8 source line" >&2
+  exit 1
+fi
+
 echo "Package guide checks passed."

--- a/scripts/smoke-release-artifacts.sh
+++ b/scripts/smoke-release-artifacts.sh
@@ -94,13 +94,19 @@ check_zip() {
   done
   [[ -n "$zip" ]] || { missing "Windows ZIP"; return; }
   python3 - "$zip" <<'PY'
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
+import re
 import sys
 import zipfile
 
 zip_path = sys.argv[1]
 with zipfile.ZipFile(zip_path) as zf:
-    names = [PurePosixPath(name) for name in zf.namelist() if not name.endswith("/")]
+    raw_names = zf.namelist()
+names = [
+    PurePosixPath(name.replace("\\", "/"))
+    for name in raw_names
+    if not name.endswith(("/", "\\"))
+]
 
 roots = {path.parts[0] for path in names if path.parts}
 if "SSRVPN_Windows_Release" not in roots:
@@ -139,8 +145,20 @@ missing = sorted(required - all_names)
 if missing:
     raise SystemExit(f"ZIP missing required files: {missing}")
 
+guide_path = "SSRVPN_Windows_Release/使用教程.txt"
+guide_entry = next(
+    name for name in raw_names if name.replace("\\", "/") == guide_path
+)
 with zipfile.ZipFile(zip_path) as zf:
-    guide = zf.read("SSRVPN_Windows_Release/使用教程.txt").decode("utf-8-sig")
+    guide = zf.read(guide_entry).decode("utf-8-sig")
+first_line = guide.splitlines()[0] if guide.splitlines() else ""
+pubspec = Path("SSRVPN_Windows/pubspec.yaml").read_text(encoding="utf-8")
+version_match = re.search(r"^version:\s+([^+\s]+)", pubspec, re.MULTILINE)
+if version_match is None:
+    raise SystemExit("Windows pubspec version is missing")
+expected_title = f"SSRVPN Windows 便携版 v{version_match.group(1)}"
+if first_line != expected_title:
+    raise SystemExit(f"ZIP tutorial title is invalid: {first_line!r}")
 expected_steps = [
     "1、下载完 ZIP 后，使用解压软件解压出来。",
     "2、双击 ssrvpn_windows.exe 打开软件。",


### PR DESCRIPTION
## 问题

从公开 v3.0.0 Release 重新下载 Windows ZIP 后，发现四条教程正文正确，但标题中的中文被 Windows PowerShell 5.1 以错误代码页解析后写成乱码。

## 修复

- 从 UTF-8 教程源文件保留标题，只在 PowerShell 中追加版本号
- ZIP 冒烟检查兼容 Windows 反斜杠条目
- 对标题中文与当前 pubspec 版本做精确断言
- 发布版本更新为 3.0.1+301；不移动已经发布的 v3.0.0 标签

## 验证

- 公开 v3.0.0 ZIP 可稳定复现标题断言失败
- 版本、教程、密钥扫描与本地 DMG 冒烟通过
- 必须由 Windows CI 重新打包并让增强后的 ZIP 冒烟转绿后才能合并。