### PR TITLE
fix(android): prefer official Flutter Maven repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 修复
 
 - Windows TUN 清理持久化本次连接新建网卡的稳定 `InterfaceGuid`，不再把通用的 `Meta` 名称、相同地址、其他 VPN 的路由或可能被 Windows 复用的数字索引当作 SSRVPN 所有权；旧版纯索引状态升级后会被安全忽略。
+- Android 构建显式优先使用 Flutter 官方 Maven 仓库，再把阿里云仓库作为后备，避免镜像临时返回 5xx 时阻断 Flutter embedding 解析。
 
 ### 安全
 

--- a/SSRVPN_Android/android/build.gradle.kts
+++ b/SSRVPN_Android/android/build.gradle.kts
@@ -2,6 +2,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://storage.googleapis.com/download.flutter.io") }
         maven { url = uri("https://maven.aliyun.com/repository/google") }
         maven { url = uri("https://maven.aliyun.com/repository/central") }
         maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") }

--- a/scripts/check-android-built-in-kotlin.sh
+++ b/scripts/check-android-built-in-kotlin.sh
@@ -9,6 +9,7 @@ from pathlib import Path
 import re
 
 settings = Path("SSRVPN_Android/android/settings.gradle.kts").read_text(encoding="utf-8")
+root_build = Path("SSRVPN_Android/android/build.gradle.kts").read_text(encoding="utf-8")
 app = Path("SSRVPN_Android/android/app/build.gradle.kts").read_text(encoding="utf-8")
 properties = Path("SSRVPN_Android/android/gradle.properties").read_text(encoding="utf-8")
 wrapper = Path(
@@ -45,5 +46,15 @@ if "android:extractNativeLibs" in manifest:
 if "useLegacyPackaging = true" not in app:
     raise SystemExit("native core extraction must use the AGP 9 packaging DSL")
 
-print("Android built-in Kotlin migration guard passed.")
+flutter_repository = "https://storage.googleapis.com/download.flutter.io"
+aliyun_repository = "https://maven.aliyun.com/repository/"
+if flutter_repository not in root_build:
+    raise SystemExit("the official Flutter Maven repository must be explicit")
+if (
+    aliyun_repository in root_build
+    and root_build.index(flutter_repository) > root_build.index(aliyun_repository)
+):
+    raise SystemExit("the official Flutter Maven repository must precede mirrors")
+
+print("Android build configuration guard passed.")
 PY


### PR DESCRIPTION
## Summary
- make the official Flutter Maven repository explicit before optional Aliyun mirrors
- keep the mirrors as fallback for users who need them
- add a repository-order regression guard

## Root cause
The post-merge main run reached an Aliyun mirror before Flutter's repository. A transient HTTP 502 stopped Gradle before it could resolve flutter_embedding_debug from the official repository.

## Verification
- official Flutter embedding POM returned HTTP 200
- Android native build and unit tests passed
- make verify passed completely

No version bump, tag, or release is included.