### PR TITLE
fix: recover interrupted GitHub release drafts

### DIFF
--- a/scripts/reuse-github-release-assets.sh
+++ b/scripts/reuse-github-release-assets.sh
@@ -14,21 +14,101 @@ fi
 work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT
 release_json="$work_dir/release.json"
+release_pages_json="$work_dir/release-pages.json"
 api_error="$work_dir/api-error.log"
+asset_map="$work_dir/assets.tsv"
 
-if ! gh api "repos/$repo/releases/tags/$tag" >"$release_json" 2>"$api_error"; then
-  if grep -Eq 'HTTP 404|Not Found.*404|404.*Not Found' "$api_error"; then
-    echo "exists=false" >>"$output_file"
-    exit 0
+github_api_retry() {
+  local stdout_file="$1"
+  local stderr_file="$2"
+  shift 2
+  local max_attempts="${GITHUB_API_RETRY_ATTEMPTS:-4}"
+  local base_delay="${GITHUB_API_RETRY_BASE_SECONDS:-1}"
+  local attempt=1
+  local delay
+
+  if [[ ! "$max_attempts" =~ ^[1-9][0-9]*$ ]] || [ "$max_attempts" -gt 10 ]; then
+    echo "GITHUB_API_RETRY_ATTEMPTS must be between 1 and 10" >&2
+    return 2
   fi
-  cat "$api_error" >&2
-  echo "Unable to inspect an existing GitHub release for $tag" >&2
-  exit 1
-fi
+  if [[ ! "$base_delay" =~ ^[0-9]+$ ]] || [ "$base_delay" -gt 30 ]; then
+    echo "GITHUB_API_RETRY_BASE_SECONDS must be between 0 and 30" >&2
+    return 2
+  fi
 
-inspection="$(python3 - "$release_json" <<'PY'
+  while true; do
+    : >"$stdout_file"
+    : >"$stderr_file"
+    if gh api "$@" >"$stdout_file" 2>"$stderr_file"; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$max_attempts" ] ||
+      ! grep -Eqi \
+        'HTTP (408|429|500|502|503|504)|rate.?limit|timed? ?out|timeout|connection (reset|refused)|temporar(il)?y unavailable|TLS handshake|unexpected EOF' \
+        "$stderr_file"; then
+      return 1
+    fi
+    delay=$((base_delay * (1 << (attempt - 1))))
+    [ "$delay" -le 30 ] || delay=30
+    echo "Transient GitHub API failure (attempt $attempt/$max_attempts); retrying in ${delay}s" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+}
+
+if ! github_api_retry "$release_json" "$api_error" \
+  "repos/$repo/releases/tags/$tag"; then
+  if grep -Eq 'HTTP 404|Not Found.*404|404.*Not Found' "$api_error"; then
+    if ! github_api_retry "$release_pages_json" "$api_error" \
+      --paginate --slurp "repos/$repo/releases?per_page=100"; then
+      cat "$api_error" >&2
+      echo "Unable to inspect GitHub release drafts for $tag" >&2
+      exit 1
+    fi
+    selection="$(python3 - "$release_pages_json" "$release_json" "$tag" <<'PY'
 import json
 import sys
+from pathlib import Path
+
+pages_path = Path(sys.argv[1])
+release_path = Path(sys.argv[2])
+expected_tag = sys.argv[3]
+payload = json.loads(pages_path.read_text(encoding="utf-8"))
+if not isinstance(payload, list):
+    raise SystemExit("GitHub release listing is not a JSON array")
+if any(not isinstance(page, list) for page in payload):
+    raise SystemExit("GitHub paginated release response is invalid")
+releases = [release for page in payload for release in page]
+matches = [
+    release
+    for release in releases
+    if isinstance(release, dict) and release.get("tag_name") == expected_tag
+]
+if not matches:
+    print("missing")
+elif len(matches) == 1:
+    release_path.write_text(json.dumps(matches[0]), encoding="utf-8")
+    print("found")
+else:
+    raise SystemExit(f"Multiple GitHub releases use tag {expected_tag}")
+PY
+)"
+    if [ "$selection" = missing ]; then
+      echo "exists=false" >>"$output_file"
+      exit 0
+    fi
+  else
+    cat "$api_error" >&2
+    echo "Unable to inspect an existing GitHub release for $tag" >&2
+    exit 1
+  fi
+fi
+
+inspection="$(python3 - "$release_json" "$tag" "$asset_map" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
 
 required = {
     "SSRVPN.apk",
@@ -48,37 +128,87 @@ limits = {
     for name in required
 }
 release = json.load(open(sys.argv[1], encoding="utf-8"))
-assets = {
-    asset.get("name"): asset
-    for asset in release.get("assets", [])
-    if isinstance(asset, dict) and isinstance(asset.get("name"), str)
-}
+expected_tag = sys.argv[2]
+asset_map_path = Path(sys.argv[3])
+if not isinstance(release, dict):
+    raise SystemExit("GitHub release response is not a JSON object")
+if release.get("tag_name") != expected_tag:
+    raise SystemExit("GitHub release tag does not match the requested tag")
+release_id = release.get("id")
+if isinstance(release_id, bool) or not isinstance(release_id, int) or release_id <= 0:
+    raise SystemExit("GitHub release ID is invalid")
+raw_assets = release.get("assets")
+if not isinstance(raw_assets, list):
+    raise SystemExit("GitHub release asset list is invalid")
+assets = {}
+duplicate_names = set()
+invalid_entries = False
+for asset in raw_assets:
+    if not isinstance(asset, dict) or not isinstance(asset.get("name"), str):
+        invalid_entries = True
+        continue
+    name = asset["name"]
+    if name in assets:
+        duplicate_names.add(name)
+    assets[name] = asset
 missing = sorted(required - set(assets))
 unexpected = sorted(set(assets) - required)
-empty = sorted(
-    name for name in required if name in assets and int(assets[name].get("size") or 0) <= 0
-)
-oversized = sorted(
-    name
-    for name in required
-    if name in assets and int(assets[name].get("size") or 0) > limits[name]
-)
-draft = release.get("draft") is True
-prerelease = release.get("prerelease") is True
-visibility = "draft" if draft else ("prerelease" if prerelease else "public")
+empty = []
+oversized = []
+unfinished = []
+invalid_metadata = bool(duplicate_names or invalid_entries)
+asset_ids = set()
+digest_pattern = re.compile(r"sha256:[0-9a-f]{64}\Z")
+for name in required & set(assets):
+    asset = assets[name]
+    size = asset.get("size")
+    asset_id = asset.get("id")
+    digest = asset.get("digest")
+    if asset.get("state") != "uploaded":
+        unfinished.append(name)
+        continue
+    if isinstance(size, bool) or not isinstance(size, int):
+        invalid_metadata = True
+    elif size <= 0:
+        empty.append(name)
+    elif size > limits[name]:
+        oversized.append(name)
+    if (
+        isinstance(asset_id, bool)
+        or not isinstance(asset_id, int)
+        or asset_id <= 0
+        or asset_id in asset_ids
+    ):
+        invalid_metadata = True
+    else:
+        asset_ids.add(asset_id)
+    if not isinstance(digest, str) or digest_pattern.fullmatch(digest) is None:
+        invalid_metadata = True
+if not isinstance(release.get("draft"), bool) or not isinstance(
+    release.get("prerelease"), bool
+):
+    raise SystemExit("GitHub release visibility metadata is invalid")
+draft = release["draft"]
+prerelease = release["prerelease"]
+visibility = "prerelease" if prerelease else ("draft" if draft else "public")
 if oversized:
-    print("invalid\t" + visibility)
-elif missing or unexpected or empty:
-    print("incomplete\t" + visibility)
+    print(f"invalid\t{visibility}\t{release_id}\toversized asset")
+elif invalid_metadata and not (missing or unexpected or empty or unfinished):
+    print(f"invalid\t{visibility}\t{release_id}\tinvalid asset metadata")
+elif missing or unexpected or empty or unfinished:
+    print(f"incomplete\t{visibility}\t{release_id}\tincomplete asset set")
 else:
-    print("complete\t" + visibility)
+    asset_map_path.write_text(
+        "".join(f"{name}\t{assets[name]['id']}\n" for name in sorted(required)),
+        encoding="utf-8",
+    )
+    print(f"complete\t{visibility}\t{release_id}\tverified asset metadata")
 PY
 )"
-state="${inspection%%$'\t'*}"
-visibility="${inspection#*$'\t'}"
+IFS=$'\t' read -r state visibility release_id inspection_reason <<<"$inspection"
 
 if [ "$state" = invalid ]; then
-  echo "GitHub release $tag contains an oversized asset; refusing to download it" >&2
+  echo "GitHub release $tag has $inspection_reason; refusing to download it" >&2
   exit 1
 fi
 if [ "$visibility" = prerelease ]; then
@@ -89,7 +219,13 @@ if [ "$state" != complete ]; then
   if [ "$visibility" = draft ]; then
     # A failed first upload may leave a partial draft. It has never been public,
     # so delete only the draft release and keep the immutable Git tag.
-    gh release delete "$tag" --repo "$repo" --yes
+    delete_response="$work_dir/delete-response.json"
+    if ! github_api_retry "$delete_response" "$api_error" \
+      --method DELETE "repos/$repo/releases/$release_id"; then
+      cat "$api_error" >&2
+      echo "Unable to delete incomplete GitHub release draft $release_id" >&2
+      exit 1
+    fi
     echo "exists=false" >>"$output_file"
     exit 0
   fi
@@ -99,11 +235,23 @@ fi
 
 download_dir="$work_dir/download"
 mkdir -p "$download_dir"
-gh release download "$tag" --repo "$repo" --dir "$download_dir" \
-  --pattern 'SSRVPN.apk' --pattern 'SSRVPN.apk.sha256' \
-  --pattern 'SSRVPN.dmg' --pattern 'SSRVPN.dmg.sha256' \
-  --pattern 'SSRVPN_Setup.exe' --pattern 'SSRVPN_Setup.exe.sha256' \
-  --pattern 'SSRVPN-release-provenance.json'
+while IFS=$'\t' read -r asset_name asset_id; do
+  case "$asset_name" in
+    SSRVPN.apk | SSRVPN.apk.sha256 | SSRVPN.dmg | SSRVPN.dmg.sha256 | \
+      SSRVPN_Setup.exe | SSRVPN_Setup.exe.sha256 | SSRVPN-release-provenance.json) ;;
+    *)
+      echo "Refusing to download unexpected GitHub asset: $asset_name" >&2
+      exit 1
+      ;;
+  esac
+  if ! github_api_retry "$download_dir/$asset_name" "$api_error" \
+    -H "Accept: application/octet-stream" \
+    "repos/$repo/releases/assets/$asset_id"; then
+    cat "$api_error" >&2
+    echo "Unable to download GitHub release asset $asset_name" >&2
+    exit 1
+  fi
+done <"$asset_map"
 
 python3 - "$release_json" "$download_dir" "$tag" "${GITHUB_SHA:?GITHUB_SHA is required}" <<'PY'
 import hashlib
@@ -126,15 +274,19 @@ def sha256(path: Path) -> str:
             digest.update(chunk)
     return digest.hexdigest()
 
+for name, asset in assets.items():
+    downloaded = download_path / name
+    if not downloaded.is_file():
+        raise SystemExit(f"Downloaded release is missing {name}")
+    if asset["digest"] != f"sha256:{sha256(downloaded)}":
+        raise SystemExit(f"GitHub digest mismatch for {name}")
+
 for name in ("SSRVPN.apk", "SSRVPN.dmg", "SSRVPN_Setup.exe"):
     artifact = download_path / name
     checksum_file = download_path / f"{name}.sha256"
     if not artifact.is_file() or not checksum_file.is_file():
         raise SystemExit(f"Downloaded release is missing {name} or its checksum")
     actual = sha256(artifact)
-    api_digest = str(assets[name].get("digest") or "")
-    if api_digest != f"sha256:{actual}":
-        raise SystemExit(f"GitHub digest mismatch for {name}")
     match = sha_re.search(checksum_file.read_text(encoding="ascii"))
     if match is None or match.group(1).lower() != actual:
         raise SystemExit(f"Checksum mismatch for {name}")
@@ -182,7 +334,9 @@ install -m 0644 "$download_dir/SSRVPN.dmg.sha256" "$artifact_root/macos/SSRVPN.d
 install -m 0644 "$download_dir/SSRVPN_Setup.exe" "$artifact_root/windows/SSRVPN_Setup.exe"
 install -m 0644 "$download_dir/SSRVPN_Setup.exe.sha256" "$artifact_root/windows/SSRVPN_Setup.exe.sha256"
 
-echo "exists=true" >>"$output_file"
-echo "draft=$([ "$visibility" = draft ] && echo true || echo false)" >>"$output_file"
-echo "prerelease=false" >>"$output_file"
+{
+  echo "exists=true"
+  echo "draft=$([ "$visibility" = draft ] && echo true || echo false)"
+  echo "prerelease=false"
+} >>"$output_file"
 echo "Reused verified canonical assets from GitHub release $tag ($visibility)."

--- a/scripts/test_reuse_github_release_assets.py
+++ b/scripts/test_reuse_github_release_assets.py
@@ -25,11 +25,13 @@ class ReuseGithubReleaseAssetsTest(unittest.TestCase):
         self.temp = tempfile.TemporaryDirectory()
         self.root = Path(self.temp.name)
         self.assets = self.root / "release-assets"
+        self.asset_ids = self.root / "release-asset-ids"
         self.artifacts = self.root / "artifacts"
         self.bin_dir = self.root / "bin"
         self.android_home = self.root / "android-sdk"
         for directory in (
             self.assets,
+            self.asset_ids,
             self.artifacts / "android",
             self.artifacts / "macos",
             self.artifacts / "windows",
@@ -64,21 +66,77 @@ class ReuseGithubReleaseAssetsTest(unittest.TestCase):
         gh.write_text(
             """#!/usr/bin/env bash
 set -euo pipefail
+printf '%s\\n' "$*" >>"$FAKE_GH_LOG"
 if [ "$1" = api ]; then
+  if [[ "$*" == *'--method DELETE'* ]]; then
+    if [ "$FAKE_API_MODE" = delete-transient ]; then
+      attempts=0
+      if [ -f "$FAKE_DELETE_ATTEMPTS" ]; then attempts="$(cat "$FAKE_DELETE_ATTEMPTS")"; fi
+      attempts=$((attempts + 1))
+      printf '%s' "$attempts" >"$FAKE_DELETE_ATTEMPTS"
+      if [ "$attempts" -lt 3 ]; then
+        echo 'gh: Service Unavailable (HTTP 503)' >&2
+        exit 1
+      fi
+    fi
+    touch "$FAKE_DELETE_MARKER"
+    exit 0
+  fi
+  if [[ "$*" == *'/releases/assets/'* ]]; then
+    attempts=0
+    if [ -f "$FAKE_ASSET_ATTEMPTS" ]; then attempts="$(cat "$FAKE_ASSET_ATTEMPTS")"; fi
+    attempts=$((attempts + 1))
+    printf '%s' "$attempts" >"$FAKE_ASSET_ATTEMPTS"
+    if [ "$FAKE_API_MODE" = asset-transient ] && [ "$attempts" -lt 3 ]; then
+      echo 'gh: Service Unavailable (HTTP 503)' >&2
+      exit 1
+    fi
+    endpoint="${!#}"
+    cat "$FAKE_RELEASE_ASSET_IDS/${endpoint##*/}"
+    exit 0
+  fi
   case "$FAKE_API_MODE" in
-    found) cat "$FAKE_RELEASE_JSON" ;;
-    missing) echo 'gh: Not Found (HTTP 404)' >&2; exit 1 ;;
+    found | asset-transient | delete-transient) cat "$FAKE_RELEASE_JSON" ;;
+    transient-found)
+      attempts=0
+      if [ -f "$FAKE_API_ATTEMPTS" ]; then attempts="$(cat "$FAKE_API_ATTEMPTS")"; fi
+      attempts=$((attempts + 1))
+      printf '%s' "$attempts" >"$FAKE_API_ATTEMPTS"
+      if [ "$attempts" -lt 3 ]; then
+        echo 'gh: Service Unavailable (HTTP 503)' >&2
+        exit 1
+      fi
+      cat "$FAKE_RELEASE_JSON"
+      ;;
+    hidden-draft)
+      if [[ "$*" == *'/releases/tags/'* ]]; then
+        echo 'gh: Not Found (HTTP 404)' >&2
+        exit 1
+      fi
+      printf '[['
+      cat "$FAKE_RELEASE_JSON"
+      printf ']]\\n'
+      ;;
+    duplicate-drafts)
+      if [[ "$*" == *'/releases/tags/'* ]]; then
+        echo 'gh: Not Found (HTTP 404)' >&2
+        exit 1
+      fi
+      printf '[['
+      cat "$FAKE_RELEASE_JSON"
+      printf ','
+      cat "$FAKE_RELEASE_JSON"
+      printf ']]\\n'
+      ;;
+    missing)
+      if [[ "$*" == *'/releases/tags/'* ]]; then
+        echo 'gh: Not Found (HTTP 404)' >&2
+        exit 1
+      fi
+      echo '[[]]'
+      ;;
     *) echo 'gh: connection reset' >&2; exit 1 ;;
   esac
-elif [ "$1" = release ] && [ "$2" = delete ]; then
-  touch "$FAKE_DELETE_MARKER"
-elif [ "$1" = release ] && [ "$2" = download ]; then
-  shift 2
-  destination=''
-  while [ "$#" -gt 0 ]; do
-    if [ "$1" = --dir ]; then destination="$2"; shift 2; else shift; fi
-  done
-  cp "$FAKE_RELEASE_ASSETS"/* "$destination/"
 else
   echo "unexpected gh command: $*" >&2
   exit 2
@@ -98,6 +156,10 @@ fi
         self.release_json = self.root / "release.json"
         self.output = self.root / "output"
         self.delete_marker = self.root / "deleted"
+        self.gh_log = self.root / "gh.log"
+        self.api_attempts = self.root / "api-attempts"
+        self.asset_attempts = self.root / "asset-attempts"
+        self.delete_attempts = self.root / "delete-attempts"
 
     def tearDown(self) -> None:
         self.temp.cleanup()
@@ -114,16 +176,26 @@ fi
             if path.name == missing:
                 continue
             digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            asset_id = len(assets) + 100
+            (self.asset_ids / str(asset_id)).write_bytes(path.read_bytes())
             assets.append(
                 {
+                    "id": asset_id,
                     "name": path.name,
                     "size": path.stat().st_size,
                     "digest": f"sha256:{digest}",
+                    "state": "uploaded",
                 }
             )
         self.release_json.write_text(
             json.dumps(
-                {"draft": draft, "prerelease": prerelease, "assets": assets}
+                {
+                    "id": 42,
+                    "tag_name": "v3.2.0",
+                    "draft": draft,
+                    "prerelease": prerelease,
+                    "assets": assets,
+                }
             ),
             encoding="utf-8",
         )
@@ -135,8 +207,13 @@ fi
                 "PATH": f"{self.bin_dir}:{env['PATH']}",
                 "FAKE_API_MODE": mode,
                 "FAKE_RELEASE_JSON": str(self.release_json),
-                "FAKE_RELEASE_ASSETS": str(self.assets),
+                "FAKE_RELEASE_ASSET_IDS": str(self.asset_ids),
                 "FAKE_DELETE_MARKER": str(self.delete_marker),
+                "FAKE_GH_LOG": str(self.gh_log),
+                "FAKE_API_ATTEMPTS": str(self.api_attempts),
+                "FAKE_ASSET_ATTEMPTS": str(self.asset_attempts),
+                "FAKE_DELETE_ATTEMPTS": str(self.delete_attempts),
+                "GITHUB_API_RETRY_BASE_SECONDS": "0",
                 "GITHUB_REF_NAME": "v3.2.0",
                 "GITHUB_SHA": COMMIT,
                 "GITHUB_REPOSITORY": "Elegying/SSRVPN",
@@ -175,9 +252,66 @@ fi
                 (self.assets / name).read_bytes(),
             )
 
+    def test_hidden_complete_draft_downloads_assets_by_validated_asset_id(self) -> None:
+        self._write_release(draft=True)
+
+        result = self._run("hidden-draft")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.gh_log.read_text(encoding="utf-8")
+        self.assertNotIn("release download", calls)
+        self.assertEqual(calls.count("/releases/assets/"), 7)
+        self.assertIn("exists=true", self.output.read_text(encoding="utf-8"))
+
     def test_partial_draft_is_deleted_without_deleting_the_tag(self) -> None:
         self._write_release(draft=True, missing="SSRVPN.dmg")
         result = self._run("found")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(self.delete_marker.is_file())
+        self.assertEqual(self.output.read_text(), "exists=false\n")
+
+    def test_hidden_partial_draft_is_discovered_and_deleted_by_release_id(self) -> None:
+        self._write_release(draft=True, missing="SSRVPN.dmg")
+
+        result = self._run("hidden-draft")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.gh_log.read_text(encoding="utf-8")
+        self.assertIn("repos/Elegying/SSRVPN/releases?per_page=100", calls)
+        self.assertIn(
+            "--method DELETE repos/Elegying/SSRVPN/releases/42",
+            calls,
+        )
+        self.assertNotIn("release delete", calls)
+        self.assertEqual(self.output.read_text(), "exists=false\n")
+
+    def test_ambiguous_hidden_drafts_fail_closed(self) -> None:
+        self._write_release(draft=True, missing="SSRVPN.dmg")
+
+        result = self._run("duplicate-drafts")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Multiple GitHub releases", result.stderr)
+        self.assertFalse(self.delete_marker.exists())
+
+    def test_partial_draft_delete_retries_transient_api_failure(self) -> None:
+        self._write_release(draft=True, missing="SSRVPN.dmg")
+
+        result = self._run("delete-transient")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.delete_attempts.read_text(encoding="ascii"), "3")
+        self.assertTrue(self.delete_marker.is_file())
+
+    def test_draft_with_an_unfinished_upload_is_deleted_for_retry(self) -> None:
+        self._write_release(draft=True)
+        release = json.loads(self.release_json.read_text(encoding="utf-8"))
+        release["assets"][0]["state"] = "starter"
+        release["assets"][0]["digest"] = None
+        self.release_json.write_text(json.dumps(release), encoding="utf-8")
+
+        result = self._run("found")
+
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertTrue(self.delete_marker.is_file())
         self.assertEqual(self.output.read_text(), "exists=false\n")
@@ -203,9 +337,39 @@ fi
         result = self._run("network")
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("Unable to inspect", result.stderr)
+        calls = self.gh_log.read_text(encoding="utf-8")
+        self.assertEqual(calls.count("/releases/tags/v3.2.0"), 4)
+
+    def test_transient_github_api_failure_is_retried_with_a_bound(self) -> None:
+        self._write_release(draft=False)
+
+        result = self._run("transient-found")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.api_attempts.read_text(encoding="ascii"), "3")
+        self.assertIn("exists=true", self.output.read_text(encoding="utf-8"))
+
+    def test_transient_asset_download_failure_is_retried(self) -> None:
+        self._write_release(draft=True)
+
+        result = self._run("asset-transient")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.asset_attempts.read_text(encoding="ascii"), "9")
+        self.assertIn("exists=true", self.output.read_text(encoding="utf-8"))
 
     def test_prerelease_is_never_reused_or_promoted(self) -> None:
         self._write_release(draft=False, prerelease=True)
+
+        result = self._run("found")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is a prerelease", result.stderr)
+        self.assertFalse(self.delete_marker.exists())
+        self.assertFalse(self.output.exists())
+
+    def test_draft_prerelease_is_never_reused_or_deleted(self) -> None:
+        self._write_release(draft=True, prerelease=True)
 
         result = self._run("found")
 
@@ -246,6 +410,18 @@ fi
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("oversized asset", result.stderr)
         self.assertFalse(self.delete_marker.exists())
+
+    def test_complete_release_with_invalid_asset_id_fails_closed(self) -> None:
+        self._write_release(draft=True)
+        release = json.loads(self.release_json.read_text(encoding="utf-8"))
+        release["assets"][0]["id"] = None
+        self.release_json.write_text(json.dumps(release), encoding="utf-8")
+
+        result = self._run("found")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid asset metadata", result.stderr)
+        self.assertFalse(self.asset_attempts.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

- Discover same-tag draft Releases through the authenticated paginated API when GitHub's tag endpoint returns 404.
- Reuse complete drafts by validated Asset ID, or delete only an incomplete draft by its exact Release ID while preserving the Git tag.
- Treat unfinished `starter` uploads as recoverable partial drafts.
- Retry transient GitHub API failures with a bounded 4-attempt exponential backoff; fail closed for public, prerelease, ambiguous, oversized, or malformed states.
- Add regression coverage for hidden drafts, interrupted uploads, API 503s during lookup/delete/download, retry exhaustion, and invalid metadata.

## Why

The v3.4.7 outage exposed a recovery gap: GitHub's release-by-tag endpoint hides draft Releases. After a failed upload left a partial draft, the retry script interpreted the 404 as "no release" and could not safely clean up or reuse that draft.

## Impact

Release tooling only. This PR does not change application code, version 3.4.7, the existing v3.4.7 Release, the OSS public channel, portable-package policy, or HTTP subscription behavior.

## Checks

- `python3 -m unittest scripts.test_reuse_github_release_assets` — 18 passed
- `bash scripts/test-release-tooling.sh` — 199 passed
- `bash -n scripts/reuse-github-release-assets.sh`
- `shellcheck scripts/reuse-github-release-assets.sh`
- `git diff --check`
- Read-only validation against the live v3.4.7 Release confirmed the expected `id`, `state=uploaded`, `digest`, paginated response shape, and Asset-ID download behavior.
- `make verify` passed release tooling, analysis, shared tests, Android tests/coverage, and macOS Flutter tests. The local Xcode `RunnerTests` launcher then waited 398 seconds for a test worker without starting one and was interrupted; this pre-existing host/Xcode startup issue is unrelated to the two changed scripts, so isolated PR CI is required for the final platform result.