### PR TITLE
chore(assets): refresh GeoIP to latest

### DIFF
--- a/docs/GEOIP_SOURCE.txt
+++ b/docs/GEOIP_SOURCE.txt
@@ -1,12 +1,12 @@
 Repo: MetaCubeX/meta-rules-dat
-Release ID: 355962252
+Release ID: 356481033
 Release tag: latest
-Release name: Release 2026-07-18 07:14
-Asset ID: 480917611
-Asset URL: https://api.github.com/repos/MetaCubeX/meta-rules-dat/releases/assets/480917611
-Upstream SHA256: 7cf5ed69574a73021735c6cba9891509aaa205dd3854db049571664b476df1f4
-Bundled gzip SHA256: 073889534886f211285398d5622922e540e3fb052d18e649e07351dc73323c9a
+Release name: Release 2026-07-20 10:57
+Asset ID: 482977723
+Asset URL: https://api.github.com/repos/MetaCubeX/meta-rules-dat/releases/assets/482977723
+Upstream SHA256: 0f904f0eafb9a43bebd309c0d193166454d1f28844f7426d8b9083dfe36528ae
+Bundled gzip SHA256: b4bc0c14c9c6ad47756b6dc6955f67b78ec7a5a4e9ca086bef0709a595d0cd91
 Mirror repo: Elegying/SSRVPN
 Mirror release tag: core-assets-v1
-Mirror asset name: geoip.metadb-073889534886f211285398d5622922e540e3fb052d18e649e07351dc73323c9a.gz
-Mirror URL: https://github.com/Elegying/SSRVPN/releases/download/core-assets-v1/geoip.metadb-073889534886f211285398d5622922e540e3fb052d18e649e07351dc73323c9a.gz
+Mirror asset name: geoip.metadb-b4bc0c14c9c6ad47756b6dc6955f67b78ec7a5a4e9ca086bef0709a595d0cd91.gz
+Mirror URL: https://github.com/Elegying/SSRVPN/releases/download/core-assets-v1/geoip.metadb-b4bc0c14c9c6ad47756b6dc6955f67b78ec7a5a4e9ca086bef0709a595d0cd91.gz


### PR DESCRIPTION
Automated verified GeoIP snapshot refresh. Upstream provenance, the raw and deterministic gzip SHA-256 values, and the immutable SSRVPN mirror URL are pinned in docs/GEOIP_SOURCE.txt.