### PR TITLE
fix: use OSS as the primary update source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.11] - 2026-07-22
+
+### 修复
+
+- Android、macOS 与 Windows 的启动更新检查统一以阿里云 OSS `latest.json` 为主更新源：有效清单会直接决定是否提醒和下载，不再要求 GitHub 提供同版本、同摘要的二次确认。
+- 只有 OSS 清单不可访问、格式或版本无效，或者缺少当前平台的规范安装包时才回退到 GitHub；有效但没有新版本的 OSS 清单不会产生额外 GitHub 请求。
+- 保留 HTTPS、OSS 域名、版本目录、标准文件名和 SHA-256 校验，并修正备用请求完成前网络客户端可能提前关闭的资源释放顺序。
+
+### 测试
+
+- 新增 OSS 主源直返、GitHub 不参与有效清单、OSS 无效时回退 GitHub 及三端规范安装包选择回归；共享层完整门禁通过。
+
+### 兼容性边界
+
+- 本版本没有修改 HTTP 订阅的兼容与安全策略；既有 HTTP/HTTPS 订阅处理保持不变。
+
 ## [3.4.10] - 2026-07-21
 
 ### 修复

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.4.10+3410
+version: 3.4.11+3411
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.4.10+3410
+version: 3.4.11+3411
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/test/clash_service_test.dart
+++ b/SSRVPN_MacOS/test/clash_service_test.dart
@@ -509,8 +509,10 @@ void main() {
       final tempDir = await Directory.systemTemp.createTemp(
         'ssrvpn_macos_native_pid_cleanup_',
       );
+      final service = ClashService();
       addTearDown(() async {
         messenger.setMockMethodCallHandler(channel, null);
+        await service.flushLogs();
         if (await tempDir.exists()) await tempDir.delete(recursive: true);
       });
       final pidFile = File('${tempDir.path}/AtlasCore.pid');
@@ -527,7 +529,7 @@ void main() {
         return true;
       });
 
-      await ClashService().init(AppSettings(), dataDir: tempDir.path);
+      await service.init(AppSettings(), dataDir: tempDir.path);
 
       expect(await pidFile.exists(), isFalse);
     });

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 3.4.10+3410
+version: 3.4.11+3411
 resolution: workspace
 
 environment:

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.4.10';
+  static const String appVersion = '3.4.11';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/packages/ssrvpn_shared/lib/services/update_checker.dart
+++ b/packages/ssrvpn_shared/lib/services/update_checker.dart
@@ -58,31 +58,23 @@ class UpdateChecker {
     final ownsClient = client == null;
     final httpClient = client ?? http.Client();
     try {
-      AppUpdateInfo? primary;
       try {
-        primary = await _checkPrimaryManifest(
+        return await _checkPrimaryManifest(
           currentVersion: currentVersion,
           assetExtension: assetExtension,
           client: httpClient,
           timeout: timeout,
         );
       } catch (_) {
-        // GitHub is the independent fallback and authority for release
-        // metadata. A primary failure must not suppress that attempt.
+        // GitHub is used only when the OSS manifest cannot be fetched or
+        // validated. A primary failure must not suppress that fallback.
       }
-      // Desktop installers are opened outside the app. Do not trust the OSS
-      // manifest alone; GitHub must independently publish the same digest.
-      if (primary != null && !_isDesktopAsset(assetExtension)) return primary;
-
-      final github = await _checkGitHub(
+      return await _checkGitHub(
         currentVersion: currentVersion,
         assetExtension: assetExtension,
         client: httpClient,
         timeout: timeout,
       );
-      if (primary == null) return github;
-      if (_sameReleaseDigest(primary, github)) return primary;
-      return github;
     } finally {
       if (ownsClient) httpClient.close();
     }
@@ -112,14 +104,16 @@ class UpdateChecker {
     }
 
     final data = jsonDecode(response.body);
-    if (data is! Map<String, dynamic>) return null;
+    if (data is! Map<String, dynamic>) {
+      throw const FormatException('OSS update metadata is not an object');
+    }
 
     final version = (data['version']?.toString() ?? '')
         .trim()
         .replaceFirst(RegExp(r'^v'), '');
-    if (!_isValidVersion(version)) return null;
-    // A stale pointer can remain when GitHub publishing succeeds but the OSS
-    // upload fails. Let GitHub act as the backup detector in that case.
+    if (!_isValidVersion(version)) {
+      throw const FormatException('OSS release version is invalid');
+    }
     if (compareVersions(version, currentVersion) <= 0) return null;
 
     final asset = _manifestAssetFor(
@@ -127,7 +121,12 @@ class UpdateChecker {
       assetExtension,
       version,
     );
-    if (asset == null) return null;
+    if (asset == null) {
+      throw FormatException(
+        'OSS manifest has no valid ${_assetNameForExtension(assetExtension)} '
+        'asset for v$version',
+      );
+    }
     final sourceHost = Uri.parse(asset.downloadUrl).host;
     final fallbackUrl = Uri.https(
       'github.com',
@@ -222,20 +221,6 @@ class UpdateChecker {
 
   static bool _isValidVersion(String version) =>
       RegExp(r'^\d+(?:\.\d+){1,3}$').hasMatch(version);
-
-  static bool _isDesktopAsset(String assetExtension) =>
-      const {'.dmg', '.exe', '.zip'}.contains(
-        assetExtension.trim().toLowerCase(),
-      );
-
-  static bool _sameReleaseDigest(
-    AppUpdateInfo primary,
-    AppUpdateInfo? github,
-  ) =>
-      github != null &&
-      primary.version == github.version &&
-      primary.sha256 != null &&
-      primary.sha256 == github.sha256;
 
   static _ReleaseAsset? _manifestAssetFor(
     Object? assets,

--- a/packages/ssrvpn_shared/test/update_checker_test.dart
+++ b/packages/ssrvpn_shared/test/update_checker_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -42,7 +41,8 @@ void main() {
     expect(UpdateChecker.compareVersions('2.0.0', '2.1.0'), -1);
   });
 
-  test('checkLatest prefers OSS after GitHub digest corroboration', () async {
+  test('checkLatest returns a valid OSS update without contacting GitHub',
+      () async {
     final requestedHosts = <String>[];
     final client = MockClient((request) async {
       requestedHosts.add(request.url.host);
@@ -64,7 +64,7 @@ void main() {
 }
 ''', 200);
       }
-      return githubReleaseResponse(request, assetName: 'SSRVPN_Setup.exe');
+      fail('GitHub must not be contacted when the OSS manifest is valid');
     });
 
     final update = await UpdateChecker.checkLatest(
@@ -88,14 +88,11 @@ void main() {
       update.fallbackDownloadUrl,
       'https://github.com/Elegying/SSRVPN/releases/download/v3.1.0/SSRVPN_Setup.exe',
     );
-    expect(requestedHosts, [
-      'nikuaimobi.oss-cn-qingdao.aliyuncs.com',
-      'api.github.com',
-      'github.com',
-    ]);
+    expect(requestedHosts, ['nikuaimobi.oss-cn-qingdao.aliyuncs.com']);
   });
 
-  test('checkLatest exposes a GitHub outage so desktop can retry', () async {
+  test('checkLatest does not let a GitHub outage block an OSS update',
+      () async {
     final requestedHosts = <String>[];
     final client = MockClient((request) async {
       requestedHosts.add(request.url.host);
@@ -113,22 +110,18 @@ void main() {
 }
 ''', 200);
       }
-      return http.Response('GitHub unavailable', 503);
+      fail('GitHub must not be contacted when the OSS manifest is valid');
     });
 
-    await expectLater(
-      UpdateChecker.checkLatest(
-        currentVersion: '3.0.0',
-        assetExtension: '.exe',
-        client: client,
-      ),
-      throwsA(isA<HttpException>()),
+    final update = await UpdateChecker.checkLatest(
+      currentVersion: '3.0.0',
+      assetExtension: '.exe',
+      client: client,
     );
 
-    expect(requestedHosts, [
-      'nikuaimobi.oss-cn-qingdao.aliyuncs.com',
-      'api.github.com',
-    ]);
+    expect(update, isNotNull);
+    expect(update!.sourceHost, 'nikuaimobi.oss-cn-qingdao.aliyuncs.com');
+    expect(requestedHosts, ['nikuaimobi.oss-cn-qingdao.aliyuncs.com']);
   });
 
   test('metadata timeout cancels the stalled response stream', () async {
@@ -160,8 +153,11 @@ void main() {
     await streamCancelled.future.timeout(const Duration(seconds: 1));
   });
 
-  test('checkLatest uses GitHub when the desktop OSS digest differs', () async {
+  test('checkLatest treats the OSS digest as authoritative for desktop',
+      () async {
+    final requestedHosts = <String>[];
     final client = MockClient((request) async {
+      requestedHosts.add(request.url.host);
       if (request.url.host == 'nikuaimobi.oss-cn-qingdao.aliyuncs.com') {
         return http.Response('''
 {
@@ -176,11 +172,7 @@ void main() {
 }
 ''', 200);
       }
-      return githubReleaseResponse(
-        request,
-        assetName: 'SSRVPN_Setup.exe',
-        digest: _digestB,
-      );
+      fail('GitHub must not corroborate a valid OSS digest');
     });
 
     final update = await UpdateChecker.checkLatest(
@@ -190,8 +182,9 @@ void main() {
     );
 
     expect(update, isNotNull);
-    expect(update!.sourceHost, 'github.com');
-    expect(update.sha256, _digestB);
+    expect(update!.sourceHost, 'nikuaimobi.oss-cn-qingdao.aliyuncs.com');
+    expect(update.sha256, _digestA);
+    expect(requestedHosts, ['nikuaimobi.oss-cn-qingdao.aliyuncs.com']);
   });
 
   test('checkLatest selects the canonical Windows installer', () async {
@@ -227,7 +220,7 @@ void main() {
     expect(update!.downloadUrl, endsWith('/v3.1.0/SSRVPN_Setup.exe'));
   });
 
-  test('checkLatest checks GitHub when the OSS pointer has no newer release',
+  test('checkLatest accepts a valid OSS pointer with no newer release',
       () async {
     final requestedHosts = <String>[];
     final client = MockClient((request) async {
@@ -247,14 +240,7 @@ void main() {
 }
 ''', 200);
       }
-      expect(request.url.host, 'api.github.com');
-      return http.Response('''
-{
-  "tag_name": "v3.0.0",
-  "body": "current",
-  "assets": []
-}
-''', 200);
+      fail('GitHub must not be contacted when the OSS manifest is current');
     });
 
     final update = await UpdateChecker.checkLatest(
@@ -264,10 +250,7 @@ void main() {
     );
 
     expect(update, isNull);
-    expect(requestedHosts, [
-      'nikuaimobi.oss-cn-qingdao.aliyuncs.com',
-      'api.github.com',
-    ]);
+    expect(requestedHosts, ['nikuaimobi.oss-cn-qingdao.aliyuncs.com']);
   });
 
   test('checkLatest rejects off-bucket OSS assets and falls back to GitHub',
@@ -371,6 +354,33 @@ void main() {
   ]
 }
 ''', 200);
+    });
+
+    final update = await UpdateChecker.checkLatest(
+      currentVersion: '3.0.0',
+      assetExtension: '.dmg',
+      client: client,
+    );
+
+    expect(update, isNotNull);
+    expect(update!.version, '3.1.0');
+    expect(update.sourceHost, 'github.com');
+    expect(requestedHosts, [
+      'nikuaimobi.oss-cn-qingdao.aliyuncs.com',
+      'api.github.com',
+      'github.com',
+    ]);
+  });
+
+  test('checkLatest falls back to GitHub when the OSS manifest is invalid',
+      () async {
+    final requestedHosts = <String>[];
+    final client = MockClient((request) async {
+      requestedHosts.add(request.url.host);
+      if (request.url.host == 'nikuaimobi.oss-cn-qingdao.aliyuncs.com') {
+        return http.Response('{"version":"not-a-version","assets":[]}', 200);
+      }
+      return githubReleaseResponse(request, assetName: 'SSRVPN.dmg');
     });
 
     final update = await UpdateChecker.checkLatest(


### PR DESCRIPTION
## 变更

- Android、macOS、Windows 共用的更新检查器改为阿里云 OSS `latest.json` 主源
- 有效 OSS 清单直接决定更新提醒与下载，不再依赖 GitHub 同版本、同摘要确认
- OSS 不可用、无效或缺少当前平台规范资产时才回退 GitHub
- 保留 HTTPS、域名、版本目录、规范文件名与 SHA-256 校验
- 版本同步升级为 `3.4.11+3411`，补充用户可见更新说明

## 根因

旧逻辑即使 OSS 清单有效，也要求 GitHub 提供相同版本和摘要才能提醒；GitHub 状态、摘要或发布信息异常会阻断本应由 OSS 提供的更新。

## 验证

- `make verify` 完整通过
- 更新检查器测试 22/22 通过
- Shared `flutter analyze` 无问题
- 发布工具回归 223/223 通过
- 三端版本同步、文档一致性、版本递增检查通过

## 兼容性

- HTTP 订阅策略未修改
- Windows 仍只发布未签名 `SSRVPN_Setup.exe` 安装版
