### PR TITLE
fix(windows): stop installer auto-launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.16] - 2026-07-23
+
+### 修复
+
+- Windows 安装器移除完成页的“运行 SSRVPN”复选框，不再在安装结束时自动启动需要管理员权限的客户端，避免安装器低权限上下文触发管理员启动错误；用户可在安装完成后从桌面或开始菜单自行打开并确认 UAC。
+
 ## [3.4.15] - 2026-07-23
 
 ### 修复

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.4.15+3415
+version: 3.4.16+3416
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.4.15+3415
+version: 3.4.16+3416
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/README.md
+++ b/SSRVPN_Windows/README.md
@@ -4,7 +4,8 @@
 
 SSRVPN Windows 客户端支持系统代理、TUN、系统托盘与在线更新。安装后的客户端默认请求
 Windows 管理员权限，因此每次启动都会显示 UAC；授权后系统代理与 TUN 均在同一管理员
-实例中运行。Windows 对外只发布每用户安装器 `SSRVPN_Setup.exe`；不再构建或发布便携 ZIP。
+实例中运行。安装完成后不会自动启动客户端，用户需从桌面或开始菜单自行打开并确认 UAC。
+Windows 对外只发布每用户安装器 `SSRVPN_Setup.exe`；不再构建或发布便携 ZIP。
 
 ## 构建要求
 

--- a/SSRVPN_Windows/USER_GUIDE.md
+++ b/SSRVPN_Windows/USER_GUIDE.md
@@ -9,6 +9,8 @@ Windows 只发布 `SSRVPN_Setup.exe`。安装器按当前用户安装到
 `%LOCALAPPDATA%\Programs\SSRVPN`，创建桌面和开始菜单入口，不需要管理员权限。
 请只从正式 Release 或官网固定地址下载安装器，并按发布页校验 SHA256。当前安装器没有
 Authenticode 签名；只有在来源和哈希都确认无误时才继续处理 SmartScreen 提示。
+安装完成后安装器不会自动运行 SSRVPN，也不会显示“运行 SSRVPN”复选框；请关闭安装器后
+从桌面或开始菜单手动打开，并在 Windows UAC 中确认管理员授权。
 
 覆盖运行新版安装器只替换已知程序文件，并保留：
 

--- a/SSRVPN_Windows/installer/SSRVPN.iss
+++ b/SSRVPN_Windows/installer/SSRVPN.iss
@@ -77,9 +77,6 @@ Source: "{#ProjectDir}\installer\program_files_transaction.ps1"; DestDir: "{app}
 Name: "{autoprograms}\SSRVPN"; Filename: "{app}\ssrvpn_windows.exe"; WorkingDir: "{app}"
 Name: "{autodesktop}\SSRVPN"; Filename: "{app}\ssrvpn_windows.exe"; WorkingDir: "{app}"
 
-[Run]
-Filename: "{app}\ssrvpn_windows.exe"; Description: "{cm:LaunchProgram,SSRVPN}"; WorkingDir: "{app}"; Flags: nowait postinstall skipifsilent
-
 [Code]
 const
   AppInstanceMutexName = 'Local\SSRVPN_Windows_SingleInstance';

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 3.4.15+3415
+version: 3.4.16+3416
 resolution: workspace
 
 environment:

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.4.15';
+  static const String appVersion = '3.4.16';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/scripts/test_windows_installer_config.py
+++ b/scripts/test_windows_installer_config.py
@@ -84,12 +84,9 @@ class WindowsInstallerConfigTest(unittest.TestCase):
         self.assertIn("ssrvpn_windows_app.exe", script)
         self.assertIn("ssrvpn_windows.exe", script)
         self.assertNotRegex(script, r"taskkill[^\n]+mihomo\.exe")
-        run_entry = next(
-            line for line in script.splitlines() if line.startswith('Filename: "{app}')
-        )
-        self.assertIn('Description: "{cm:LaunchProgram,SSRVPN}"', run_entry)
-        self.assertIn("postinstall", run_entry)
-        self.assertIn("skipifsilent", run_entry)
+        self.assertNotIn("[Run]", script)
+        self.assertNotIn("{cm:LaunchProgram,SSRVPN}", script)
+        self.assertNotIn("postinstall", script)
 
     def test_installer_ignores_portable_data_and_blocks_before_destructive_copy(
         self,
@@ -219,7 +216,7 @@ class WindowsInstallerConfigTest(unittest.TestCase):
             "procedure DeinitializeUninstall;\nbegin\n  ReleaseInstallGates;",
             installer,
         )
-        self.assertIn("nowait postinstall skipifsilent", installer)
+        self.assertNotIn("nowait postinstall skipifsilent", installer)
 
     def test_verified_update_handoff_waits_for_elevated_launcher_exit(self) -> None:
         installer = (


### PR DESCRIPTION
## 变更内容

- 删除 Windows Inno Setup 安装器的 `[Run]` 段。
- 安装完成页不再显示“运行 SSRVPN”复选框，安装结束后不再自动启动客户端。
- 用户可从桌面或开始菜单自行打开 SSRVPN，并在独立启动流程中确认 UAC。
- 更新安装器发布守卫，明确禁止 `postinstall` 和 `LaunchProgram` 回归。
- 版本升级为 `3.4.16+3416`，同步用户指南、README 和变更日志。

## 根因与用户影响

安装器本身以当前用户权限运行，而 SSRVPN 客户端现在要求管理员权限。完成页自动启动会把应用拉起和安装事务绑定在一起，导致安装后请求管理员权限时报错。移除完成页启动项后，安装事务会正常结束，用户再通过桌面或开始菜单独立启动客户端并确认 UAC。

## 验证

- Windows 安装器配置测试：29/29 通过
- 版本同步：`3.4.16+3416`
- `verify-release-transition.py`：通过
- 发布说明与发布入口测试：5/5 通过
- `git diff --check`：通过
- 全仓确认安装器无 `[Run]`、`LaunchProgram` 或 `postinstall`

依赖 Bash 的发布脚本单测由 GitHub Actions Linux runner 完整执行。
