### PR TITLE
fix(android): improve IPv6 direct fallback and safe disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.3] - 2026-07-25
+
+### 修复
+
+- 三端 Mihomo 配置启用双栈 TCP 并发连接：国内 `DIRECT` 域名同时解析出 IPv4 与 IPv6 时采用最先成功的地址，底层 Wi-Fi 缺少可用 IPv6 出口时能够自动回退 IPv4，不改变“用户强制代理优先、国内直连、国外代理”的规则顺序。
+- Android 断开连接为内嵌核心 API 端口提供 5 秒释放宽限期，避免 `Bridge.stop()` 已返回但端口仍在短暂收尾时错误终止前台进程；待启动任务无法停止、Bridge 停止无法验证或端口超过完整宽限期仍监听时，继续保留进程级安全兜底。
+
+### 测试
+
+- 新增双栈竞速与强制代理优先级、Android 停止决策、端口旧阈值回归测试，并更新 Android 原生发布守卫。
+
+### 兼容性边界
+
+- 裸 IPv6 地址和仅支持 IPv6 的目标仍需要底层网络提供真实 IPv6 出口；客户端的双栈 IPv4 回退不能替代路由器或 AP 的 IPv6 RA 转发修复。
+- 本版本没有修改 HTTP 订阅的兼容与安全策略；Windows 继续只发布未签名的 `SSRVPN_Setup.exe` 安装版，不提供便携 ZIP。
+
 ## [3.5.2] - 2026-07-25
 
 ### 修复

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CorePortReleaseVerifier.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CorePortReleaseVerifier.kt
@@ -4,10 +4,15 @@ import java.net.InetSocketAddress
 import java.net.Socket
 
 internal object CorePortReleaseVerifier {
+    // Bridge.stop can return before its listener closes. Allow five seconds
+    // before treating the detached TUN/core shutdown as genuinely stuck.
+    private const val DEFAULT_RELEASE_ATTEMPTS = 51
+    private const val DEFAULT_RETRY_DELAY_MILLIS = 100L
+
     fun waitUntilReleased(
         port: Int,
-        attempts: Int = 6,
-        retryDelayMillis: Long = 100,
+        attempts: Int = DEFAULT_RELEASE_ATTEMPTS,
+        retryDelayMillis: Long = DEFAULT_RETRY_DELAY_MILLIS,
         canConnect: (Int) -> Boolean = ::canConnect,
     ): Boolean {
         if (port !in 1..65535) return true

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreStopDecision.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreStopDecision.kt
@@ -1,0 +1,41 @@
+package com.ssrvpn.android
+
+internal data class CoreStopDecision(
+    val terminateProcess: Boolean,
+    val clearRunningSession: Boolean,
+    val apiPortLingering: Boolean
+) {
+    fun terminationMessage(apiPort: Int): String = if (apiPortLingering) {
+        "Bridge stopped but API port $apiPort still listens after the release grace period"
+    } else {
+        "Bridge shutdown could not be verified"
+    }
+
+    companion object {
+        fun afterBridgeCheck(
+            pendingStartStopped: Boolean,
+            bridgeStopped: Boolean,
+            apiPort: Int,
+            waitUntilPortReleased: (Int) -> Boolean =
+                CorePortReleaseVerifier::waitUntilReleased
+        ): CoreStopDecision = evaluate(
+            pendingStartStopped = pendingStartStopped,
+            bridgeStopped = bridgeStopped,
+            apiPortReleased = bridgeStopped && waitUntilPortReleased(apiPort)
+        )
+
+        fun evaluate(
+            pendingStartStopped: Boolean,
+            bridgeStopped: Boolean,
+            apiPortReleased: Boolean
+        ): CoreStopDecision {
+            val bridgeShutdownVerified = pendingStartStopped && bridgeStopped
+            val shutdownCompleted = bridgeShutdownVerified && apiPortReleased
+            return CoreStopDecision(
+                terminateProcess = !shutdownCompleted,
+                clearRunningSession = shutdownCompleted,
+                apiPortLingering = bridgeShutdownVerified && !apiPortReleased
+            )
+        }
+    }
+}

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
@@ -802,10 +802,8 @@ class SsrvpnVpnService : VpnService() {
                 stopOperation.complete()
             }
             if (terminateProcess) {
-                Log.e(
-                    TAG,
-                    "Bridge.stop failed or timed out; terminating process to release the detached TUN fd"
-                )
+                Log.e(TAG,
+                    "Core shutdown incomplete; terminating process to release the detached TUN fd")
                 notificationHandler.postDelayed({
                     android.os.Process.killProcess(android.os.Process.myPid())
                 }, 750L)
@@ -822,14 +820,17 @@ class SsrvpnVpnService : VpnService() {
         protectThread?.interrupt()
         protectThread = null
         val pendingStartStopped = waitForPendingStart()
-        val bridgeStopped = pendingStartStopped && stopBridgeWithTimeout() &&
-            CorePortReleaseVerifier.waitUntilReleased(currentApiPort)
+        val bridgeStopped = pendingStartStopped && stopBridgeWithTimeout()
+        val stopDecision = CoreStopDecision.afterBridgeCheck(
+            pendingStartStopped, bridgeStopped, currentApiPort
+        )
+        if (stopDecision.terminateProcess) Log.e(TAG, stopDecision.terminationMessage(currentApiPort))
         try {
             vpnFd?.close()
         } catch (_: Exception) {}
         vpnFd = null
         isRunning = false
-        if (bridgeStopped) NativeConnectionSession.clearRunning()
+        if (stopDecision.clearRunningSession) NativeConnectionSession.clearRunning()
         broadcastState(this)
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -842,7 +843,7 @@ class SsrvpnVpnService : VpnService() {
             Log.w(TAG, "stopForeground failed: ${e.message}")
         }
         Log.d(TAG, "Stopped")
-        return !bridgeStopped
+        return stopDecision.terminateProcess
     }
 
     private fun waitForPendingStart(): Boolean {

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/CorePortReleaseVerifierTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/CorePortReleaseVerifierTest.kt
@@ -35,6 +35,20 @@ class CorePortReleaseVerifierTest {
     }
 
     @Test
+    fun `default grace period tolerates release after the former six checks`() {
+        var checks = 0
+
+        val released = CorePortReleaseVerifier.waitUntilReleased(
+            port = 9090,
+            retryDelayMillis = 0,
+            canConnect = { ++checks <= 8 },
+        )
+
+        assertTrue(released)
+        assertTrue(checks > 6)
+    }
+
+    @Test
     fun `isPortListening returns true when port is open`() {
         val server = ServerSocket(0, 1, InetAddress.getLoopbackAddress())
         val port = server.localPort

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/CoreStopDecisionTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/CoreStopDecisionTest.kt
@@ -1,0 +1,60 @@
+package com.ssrvpn.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CoreStopDecisionTest {
+    @Test
+    fun `terminates only after bridge stopped but API port exceeded its grace period`() {
+        val decision = CoreStopDecision.afterBridgeCheck(
+            pendingStartStopped = true,
+            bridgeStopped = true,
+            apiPort = 9090,
+            waitUntilPortReleased = { false }
+        )
+
+        assertTrue(decision.terminateProcess)
+        assertFalse(decision.clearRunningSession)
+        assertTrue(decision.apiPortLingering)
+        assertTrue(decision.terminationMessage(9090).contains("API port 9090"))
+    }
+
+    @Test
+    fun `completes normally after bridge and API port both stop`() {
+        val decision = CoreStopDecision.afterBridgeCheck(
+            pendingStartStopped = true,
+            bridgeStopped = true,
+            apiPort = 9090,
+            waitUntilPortReleased = { true }
+        )
+
+        assertFalse(decision.terminateProcess)
+        assertTrue(decision.clearRunningSession)
+        assertFalse(decision.apiPortLingering)
+    }
+
+    @Test
+    fun `terminates app when bridge stop cannot be verified`() {
+        val decision = CoreStopDecision.evaluate(
+            pendingStartStopped = true,
+            bridgeStopped = false,
+            apiPortReleased = false
+        )
+
+        assertTrue(decision.terminateProcess)
+        assertFalse(decision.clearRunningSession)
+    }
+
+    @Test
+    fun `terminates app when a pending start cannot be cancelled`() {
+        val decision = CoreStopDecision.evaluate(
+            pendingStartStopped = false,
+            bridgeStopped = true,
+            apiPortReleased = true
+        )
+
+        assertTrue(decision.terminateProcess)
+        assertFalse(decision.clearRunningSession)
+    }
+}

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.5.2+3502
+version: 3.5.3+3503
 resolution: workspace
 
 environment:

--- a/SSRVPN_Android/test/clash_service_test.dart
+++ b/SSRVPN_Android/test/clash_service_test.dart
@@ -386,6 +386,7 @@ void main() {
       expect(parsed['socks-port'], isA<int>());
       expect(parsed['allow-lan'], isFalse);
       expect(parsed['ipv6'], isTrue);
+      expect(parsed['tcp-concurrent'], isTrue);
       expect(parsed['dns']['ipv6'], isTrue);
       expect(parsed['dns']['fake-ip-range6'], isNotEmpty);
       expect(parsed['tun']['inet6-address'], isNotEmpty);

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.5.2+3502
+version: 3.5.3+3503
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 3.5.2+3502
+version: 3.5.3+3503
 resolution: workspace
 
 environment:

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.5.2';
+  static const String appVersion = '3.5.3';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/packages/ssrvpn_shared/lib/services/clash_config_generator.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_config_generator.dart
@@ -114,6 +114,9 @@ class ClashConfigGenerator {
     result.writeln("external-controller: '127.0.0.1:${settings.apiPort}'");
     result.writeln('# SSRVPN IPv4 / IPv6 双栈配置');
     result.writeln('ipv6: true');
+    // Race every resolved address so a broken IPv6 underlay cannot turn a
+    // dual-stack DIRECT destination into a black hole.
+    result.writeln('tcp-concurrent: true');
     result.writeln('etag-support: true');
     final apiSecret =
         RuntimeConfigNamePolicy.canonicalApiSecret(settings.apiSecret);

--- a/packages/ssrvpn_shared/test/clash_config_generator_test.dart
+++ b/packages/ssrvpn_shared/test/clash_config_generator_test.dart
@@ -183,6 +183,34 @@ proxies:
       expect(config, contains('Test Node'));
     });
 
+    test('dual-stack direct traffic races every resolved address', () {
+      const yaml = '''
+proxies:
+  - name: "Test Node"
+    type: ss
+    server: example.com
+    port: 443
+    cipher: aes-256-gcm
+    password: "test123"
+''';
+
+      final parsed = loadYaml(
+        ClashConfigGenerator.generateConfig(yaml, AppSettings()),
+      ) as YamlMap;
+      final rules = (parsed['rules'] as YamlList).cast<String>();
+
+      expect(parsed['ipv6'], isTrue);
+      expect(parsed['tcp-concurrent'], isTrue);
+      expect(rules, contains('RULE-SET,ssrvpn-geosite-cn,DIRECT'));
+      expect(rules, contains('GEOIP,CN,DIRECT'));
+      expect(
+        rules.indexOf('DOMAIN-SUFFIX,openai.com,PROXY'),
+        lessThan(
+          rules.indexOf('RULE-SET,ssrvpn-geosite-cn,DIRECT'),
+        ),
+      );
+    });
+
     test('generateConfig enables bounded HTTP TLS and QUIC domain sniffing',
         () {
       const yaml = '''

--- a/scripts/check-android-native-bridge-guards.sh
+++ b/scripts/check-android-native-bridge-guards.sh
@@ -19,6 +19,8 @@ VPN_ROUTE_INSTALLER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn
 NOTIFICATION_SUPPORT="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnNotificationSupport.kt"
 NOTIFICATION_GATE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NotificationGenerationGate.kt"
 CORE_LIVENESS_MONITOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreLivenessMonitor.kt"
+CORE_PORT_RELEASE_VERIFIER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CorePortReleaseVerifier.kt"
+CORE_STOP_DECISION="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreStopDecision.kt"
 NATIVE_SNAPSHOT_STORE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSnapshotStore.kt"
 NATIVE_CONNECTION_SESSION="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSession.kt"
 NATIVE_SESSION_COORDINATOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeVpnSessionCoordinator.kt"
@@ -121,7 +123,7 @@ grep -Fq "fun connectionState(): Map<String, Any?>" "$NATIVE_SESSION_COORDINATOR
 require_text "NativeConnectionSession.publishRunning(configPath)"
 require_text "NativeVpnSessionCoordinator.reserveRecovery(request.configPath)"
 require_text "NativeConnectionSession.clearRunning()"
-require_text "if (bridgeStopped) NativeConnectionSession.clearRunning()"
+require_text "if (stopDecision.clearRunningSession)"
 require_text "NativeConnectionSession.clearRecovery()"
 require_text "CoreRecoveryPolicy.nextAttempt(request.attempt)"
 require_text "stopForRecovery"
@@ -218,7 +220,17 @@ require_text "BRIDGE_IS_RUNNING_TIMEOUT_MS"
 require_text "startBridgeWithTimeout"
 require_text "stopBridgeWithTimeout"
 require_text "isBridgeRunningWithTimeout"
-require_text "CorePortReleaseVerifier.waitUntilReleased(currentApiPort)"
+grep -Fq "CorePortReleaseVerifier::waitUntilReleased" "$CORE_STOP_DECISION" || {
+  echo "Android stop decision no longer verifies API port release" >&2
+  exit 1
+}
+grep -Fq "DEFAULT_RELEASE_ATTEMPTS = 51" "$CORE_PORT_RELEASE_VERIFIER" || {
+  echo "Android core port release grace period regressed below five seconds" >&2
+  exit 1
+}
+require_text "CoreStopDecision.afterBridgeCheck("
+require_text "stopDecision.terminationMessage(currentApiPort)"
+require_text "return stopDecision.terminateProcess"
 require_text "SSRVPN-bridge-start"
 require_text "SSRVPN-bridge-stop"
 require_text "SSRVPN-bridge-is-running"
@@ -326,7 +338,7 @@ PY
 require_text "Bridge.isRunning already in progress; deferring verdict"
 require_text "Bridge.isRunning timed out after"
 require_text "treating stop as unverified"
-require_text "Bridge.stop failed or timed out; terminating process to release the detached TUN fd"
+require_text "Core shutdown incomplete; terminating process to release the detached TUN fd"
 require_text "android.os.Process.killProcess(android.os.Process.myPid())"
 require_text "VpnRouteInstaller.configure(builder)"
 require_route_text "PublicIpv4Routes.routes"


### PR DESCRIPTION
## Summary

- race dual-stack TCP destinations so domestic DIRECT traffic can fall back to IPv4 when the network lacks a usable IPv6 path
- preserve user force-proxy priority, domestic DIRECT rules, and foreign MATCH/PROXY fallback
- allow the Android core API port up to five seconds to close before the existing process-termination safety fallback
- bump all clients to 3.5.3+3503 and add release notes

## Verification

- full make verify passed locally
- release tooling: 230 tests
- Shared: 452 tests, 82.16% coverage
- Android: 212 Flutter tests, native Gradle/JUnit successful, 63.37% coverage
- macOS: 220 Flutter tests plus XCTest, 64.78% coverage
- Windows: 191 tests passed with 8 platform-conditioned skips, 47.29% coverage
- workspace analyze, secret scan, release guards, and version transition checks passed

## Risk

- tcp-concurrent may create parallel connection attempts for multiple resolved addresses; Mihomo keeps the first successful connection
- raw IPv6 and IPv6-only targets still require a working underlay IPv6 route
- process termination remains only when pending startup or Bridge shutdown cannot be verified, or the API port still listens after the full grace period