### PR TITLE
fix(windows): retry transient TUN baseline probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.4] - 2026-07-25
+
+### 修复
+
+- 三端 Mihomo 配置启用双栈 TCP 并发连接：国内 `DIRECT` 域名同时解析出 IPv4 与 IPv6 时采用最先成功的地址，底层 Wi-Fi 缺少可用 IPv6 出口时能够自动回退 IPv4，不改变“用户强制代理优先、国内直连、国外代理”的规则顺序。
+- Android 断开连接为内嵌核心 API 端口提供 5 秒释放宽限期，避免 `Bridge.stop()` 已返回但端口仍在短暂收尾时错误终止前台进程；待启动任务无法停止、Bridge 停止无法验证或端口超过完整宽限期仍监听时，继续保留进程级安全兜底。
+- Windows TUN 启动前网卡基线探测遇到一次 PowerShell 冷启动超时或瞬时空结果时会自动重试，避免把正常机器上的临时探测失败误判为无法安全建立 TUN。
+
+### 测试
+
+- 新增双栈竞速与强制代理优先级、Android 停止决策、端口旧阈值和 Windows 网卡基线瞬时失败重试回归测试，并更新 Android 原生发布守卫。
+
+### 兼容性边界
+
+- 裸 IPv6 地址和仅支持 IPv6 的目标仍需要底层网络提供真实 IPv6 出口；客户端的双栈 IPv4 回退不能替代路由器或 AP 的 IPv6 RA 转发修复。
+- 本版本没有修改 HTTP 订阅的兼容与安全策略；Windows 继续只发布未签名的 `SSRVPN_Setup.exe` 安装版，不提供便携 ZIP。
+
 ## [3.5.3] - 2026-07-25
 
 ### 修复

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.5.3+3503
+version: 3.5.4+3504
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.5.3+3503
+version: 3.5.4+3504
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/lib/services/windows_tun_runtime_probe.dart
+++ b/SSRVPN_Windows/lib/services/windows_tun_runtime_probe.dart
@@ -209,9 +209,37 @@ if ($identities.Count -eq 0) {
   }
 }
 
+Future<Set<WindowsTunInterfaceIdentity>>
+    retryWindowsNetworkInterfaceIdentityProbe({
+  required WindowsNetworkInterfaceIdentityProbe probe,
+  int maxAttempts = 2,
+}) async {
+  if (maxAttempts < 1) {
+    throw ArgumentError.value(maxAttempts, 'maxAttempts', 'must be positive');
+  }
+  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+    final identities = await probe();
+    if (identities.isNotEmpty) return identities;
+  }
+  return const <WindowsTunInterfaceIdentity>{};
+}
+
 Future<Set<WindowsTunInterfaceIdentity>> probeWindowsNetworkInterfaceIdentities(
-    {Future<void>? cancellation}) async {
-  if (!Platform.isWindows) return const <WindowsTunInterfaceIdentity>{};
+    {Future<void>? cancellation}) {
+  if (!Platform.isWindows) {
+    return Future.value(const <WindowsTunInterfaceIdentity>{});
+  }
+  return retryWindowsNetworkInterfaceIdentityProbe(
+    probe: () => _probeWindowsNetworkInterfaceIdentitiesOnce(
+      cancellation: cancellation,
+    ),
+  );
+}
+
+Future<Set<WindowsTunInterfaceIdentity>>
+    _probeWindowsNetworkInterfaceIdentitiesOnce({
+  Future<void>? cancellation,
+}) async {
   try {
     const script = r'''
 $ErrorActionPreference = 'Stop'

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 3.5.3+3503
+version: 3.5.4+3504
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart
+++ b/SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart
@@ -21,6 +21,23 @@ void main() {
   ]) =>
       (status: status, interfaces: interfaces);
 
+  test('network interface baseline retries one transient empty probe',
+      () async {
+    var calls = 0;
+
+    final baseline = await retryWindowsNetworkInterfaceIdentityProbe(
+      probe: () async {
+        calls++;
+        return calls == 1
+            ? const <WindowsTunInterfaceIdentity>{}
+            : const {identity7};
+      },
+    );
+
+    expect(baseline, const {identity7});
+    expect(calls, 2);
+  });
+
   test('TUN teardown waits until the residual probe reports gone', () async {
     final statuses = <WindowsTunResidualProbeResult>[
       residual(WindowsTunResidualStatus.present, const {identity7}),

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.5.3';
+  static const String appVersion = '3.5.4';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 


### PR DESCRIPTION
## Summary
- retry the Windows network-interface baseline once after a transient empty PowerShell result
- keep the existing fail-closed TUN ownership and teardown checks unchanged
- prepare v3.5.4 because the existing v3.5.3 tag had a failed Windows release job

## Root cause
The v3.5.3 release run passed shared, Android, and macOS jobs but the Windows integration test spent 24.04 seconds and failed without reporting any residual TUN artifact. The same test passed on the identical commit in PR CI in 5.04 seconds and main CI in 6.02 seconds. A 6-second cold baseline timeout returns an empty set; that makes the following 15-second teardown check fail closed by construction.

## Verification
- RED: targeted Windows probe test failed because the retry policy did not exist
- GREEN: targeted Windows probe suite passed after the bounded retry
- make verify passed locally
  - release tooling: 230 tests
  - shared: 452 tests, 82.19% coverage
  - Android: 212 Flutter tests plus native unit tests, 63.37% coverage
  - macOS: 220 Flutter tests plus XCTest, 64.78% coverage
  - Windows: 192 tests passed with 8 platform-only skips, 47.29% coverage
  - workspace analyze: 0 issues

## Release history
- failed v3.5.3 run: https://github.com/Elegying/SSRVPN/actions/runs/30163666814
- the v3.5.3 tag is not moved or deleted