### PR TITLE
fix(android): preserve UI during fail-safe disconnect

### DIFF
--- a/SSRVPN_Android/android/app/src/main/AndroidManifest.xml
+++ b/SSRVPN_Android/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,15 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".DisconnectRecoveryActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:finishOnTaskLaunch="true"
+            android:process=":disconnect_recovery"
+            android:taskAffinity="${applicationId}.disconnect_recovery"
+            android:theme="@style/LaunchTheme" />
         
         <meta-data
             android:name="io.flutter.embedding.android.EnableImpeller"

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/DisconnectRecoveryActivity.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/DisconnectRecoveryActivity.kt
@@ -1,0 +1,54 @@
+package com.ssrvpn.android
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+class DisconnectRecoveryActivity : Activity() {
+    private val handler = Handler(Looper.getMainLooper())
+    private val relaunch = Runnable {
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+            ?: Intent(this, MainActivity::class.java)
+        launchIntent.addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                Intent.FLAG_ACTIVITY_NO_ANIMATION
+        )
+        startActivity(launchIntent)
+        finishAndRemoveTask()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        handler.postDelayed(relaunch, RELAUNCH_DELAY_MS)
+    }
+
+    override fun onDestroy() {
+        handler.removeCallbacks(relaunch)
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val TAG = "DisconnectRecovery"
+        private const val RELAUNCH_DELAY_MS = 1_500L
+
+        fun handoff(context: Context) {
+            try {
+                context.startActivity(
+                    Intent(context, DisconnectRecoveryActivity::class.java).addFlags(
+                        Intent.FLAG_ACTIVITY_NEW_TASK or
+                            Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS or
+                            Intent.FLAG_ACTIVITY_NO_ANIMATION
+                    )
+                )
+            } catch (error: Exception) {
+                Log.e(TAG, "Unable to preserve foreground UI during core reset", error)
+            }
+        }
+    }
+}

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/DisconnectRecoveryCoordinator.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/DisconnectRecoveryCoordinator.kt
@@ -1,0 +1,20 @@
+package com.ssrvpn.android
+
+import android.content.Context
+
+internal object DisconnectRecoveryCoordinator {
+    fun shouldHandoff(
+        foregroundUiRequested: Boolean,
+        processTerminationRequired: Boolean
+    ): Boolean = foregroundUiRequested && processTerminationRequired
+
+    fun handoffIfNeeded(context: Context, preserveForegroundUi: Boolean) {
+        if (shouldHandoff(
+                preserveForegroundUi,
+                processTerminationRequired = true
+            )
+        ) {
+            DisconnectRecoveryActivity.handoff(context)
+        }
+    }
+}

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt
@@ -321,7 +321,9 @@ class MainActivity : FlutterActivity() {
                 stopService(Intent(this, SsrvpnVpnService::class.java))
                 result.success(true)
             } else {
-                service.stopAll { runOnUiThread { result.success(true) } }
+                service.stopAll(preserveForegroundUi = true) {
+                    runOnUiThread { result.success(true) }
+                }
             }
         } catch (error: Exception) {
             result.error("STOP_FAILED", error.message, null)

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
@@ -758,18 +758,16 @@ class SsrvpnVpnService : VpnService() {
 
     private fun applyProxySelection(apiPort: Int, apiSecret: String, nodeName: String?) =
         MihomoProxySelection.apply(apiPort, apiSecret, nodeName)
-
-    fun stopAll(onComplete: (() -> Unit)? = null) {
+    fun stopAll(preserveForegroundUi: Boolean = false, onComplete: (() -> Unit)? = null) {
         manualStopRequested.set(true)
         recoveryGeneration.incrementAndGet()
-        stopInternal(stopServiceWhenDone = true, onComplete = onComplete)
+        stopInternal(true, preserveForegroundUi, onComplete)
     }
-
     private fun stopForRecovery(onComplete: () -> Unit) =
-        stopInternal(stopServiceWhenDone = false, onComplete = onComplete)
+        stopInternal(false, false, onComplete)
 
     private fun stopInternal(
-        stopServiceWhenDone: Boolean,
+        stopServiceWhenDone: Boolean, preserveForegroundUi: Boolean,
         onComplete: (() -> Unit)?
     ) {
         notificationGeneration.invalidate()
@@ -798,12 +796,14 @@ class SsrvpnVpnService : VpnService() {
             try {
                 terminateProcess = stopAllOnWorker()
             } finally {
-                if (terminateProcess) processTerminationPending.set(true)
+                if (terminateProcess) {
+                    processTerminationPending.set(true)
+                    DisconnectRecoveryCoordinator.handoffIfNeeded(this, preserveForegroundUi)
+                }
                 stopOperation.complete()
             }
             if (terminateProcess) {
-                Log.e(TAG,
-                    "Core shutdown incomplete; terminating process to release the detached TUN fd")
+                Log.e(TAG, "Core shutdown incomplete; terminating process to release the detached TUN fd")
                 notificationHandler.postDelayed({
                     android.os.Process.killProcess(android.os.Process.myPid())
                 }, 750L)
@@ -907,7 +907,7 @@ class SsrvpnVpnService : VpnService() {
         super.onDestroy()
         try { unregisterReceiver(disconnectReceiver) } catch (_: Exception) {}
         try { unregisterReceiver(screenStateReceiver) } catch (_: Exception) {}
-        stopAll()
+        if (!processTerminationPending.get()) stopAll()
         instance = null
     }
 

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/DisconnectRecoveryCoordinatorTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/DisconnectRecoveryCoordinatorTest.kt
@@ -1,0 +1,33 @@
+package com.ssrvpn.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DisconnectRecoveryCoordinatorTest {
+    @Test
+    fun `hands off foreground UI before a required process reset`() {
+        assertTrue(
+            DisconnectRecoveryCoordinator.shouldHandoff(
+                foregroundUiRequested = true,
+                processTerminationRequired = true
+            )
+        )
+    }
+
+    @Test
+    fun `does not open UI for background disconnects or clean shutdowns`() {
+        assertFalse(
+            DisconnectRecoveryCoordinator.shouldHandoff(
+                foregroundUiRequested = false,
+                processTerminationRequired = true
+            )
+        )
+        assertFalse(
+            DisconnectRecoveryCoordinator.shouldHandoff(
+                foregroundUiRequested = true,
+                processTerminationRequired = false
+            )
+        )
+    }
+}

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.5.4+3504
+version: 3.5.5+3505
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.5.4+3504
+version: 3.5.5+3505
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 3.5.4+3504
+version: 3.5.5+3505
 resolution: workspace
 
 environment:

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.5.4';
+  static const String appVersion = '3.5.5';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/scripts/check-android-native-bridge-guards.sh
+++ b/scripts/check-android-native-bridge-guards.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SERVICE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt"
 MAIN_ACTIVITY="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt"
+DISCONNECT_RECOVERY_ACTIVITY="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/DisconnectRecoveryActivity.kt"
+DISCONNECT_RECOVERY_COORDINATOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/DisconnectRecoveryCoordinator.kt"
 TILE_SERVICE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTileService.kt"
 BUILD_GRADLE="$ROOT/SSRVPN_Android/android/app/build.gradle.kts"
 MANIFEST="$ROOT/SSRVPN_Android/android/app/src/main/AndroidManifest.xml"
@@ -340,6 +342,33 @@ require_text "Bridge.isRunning timed out after"
 require_text "treating stop as unverified"
 require_text "Core shutdown incomplete; terminating process to release the detached TUN fd"
 require_text "android.os.Process.killProcess(android.os.Process.myPid())"
+require_text "DisconnectRecoveryCoordinator.handoffIfNeeded(this, preserveForegroundUi)"
+require_text "if (!processTerminationPending.get()) stopAll()"
+require_activity_text "service.stopAll(preserveForegroundUi = true)"
+for needle in \
+  'android:name=".DisconnectRecoveryActivity"' \
+  'android:exported="false"' \
+  'android:process=":disconnect_recovery"' \
+  'android:taskAffinity="${applicationId}.disconnect_recovery"'; do
+  require_manifest_text "$needle"
+done
+for needle in \
+  "foregroundUiRequested && processTerminationRequired" \
+  "DisconnectRecoveryActivity.handoff(context)"; do
+  grep -Fq "$needle" "$DISCONNECT_RECOVERY_COORDINATOR" || {
+    echo "Android disconnect recovery policy guard failed: missing '$needle'" >&2
+    exit 1
+  }
+done
+for needle in \
+  "RELAUNCH_DELAY_MS = 1_500L" \
+  "Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS" \
+  "Intent.FLAG_ACTIVITY_NO_ANIMATION"; do
+  grep -Fq "$needle" "$DISCONNECT_RECOVERY_ACTIVITY" || {
+    echo "Android disconnect recovery activity guard failed: missing '$needle'" >&2
+    exit 1
+  }
+done
 require_text "VpnRouteInstaller.configure(builder)"
 require_route_text "PublicIpv4Routes.routes"
 require_route_text "configure(builder::addAddress, builder::addRoute)"


### PR DESCRIPTION
## Summary

- keep the Android disconnect screen visible while the fail-safe process reset releases a lingering native TUN/core
- restrict the recovery activity to a non-exported isolated app process and avoid foreground UI handoff for background shutdowns
- suppress duplicate service teardown during the pending process reset
- bump the application version to 3.5.5+3505

## Verification

- real Android 16 device: three VPN disconnect cycles released proxy/API ports and returned to the SSRVPN disconnected screen
- make verify
- Android recovery policy unit tests and manifest/static guards
- version transition 3.5.4/3504 to 3.5.5/3505