### PR TITLE
fix(release): prepare v3.5.6 with changelog guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.6] - 2026-07-26
+
+### 修复
+
+- Android 在用户主动断开且进程级安全兜底被触发时，通过独立、不可导出的前台恢复 Activity 接管任务栈，避免 VPN 服务进程收尾导致当前界面随之消失；后台断开、服务销毁和错误恢复仍沿用原有清理策略。
+
+### 测试
+
+- 新增 Android 前台恢复 Activity、任务栈交接参数、服务销毁保护和仅限前台主动断开的原生发布守卫，并完成真实 Xiaomi 设备断开复测。
+- 版本同步门禁现在同时要求 `CHANGELOG.md` 包含当前版本章节，避免云端构建全部完成后才在发布说明阶段失败。
+
+### 兼容性边界
+
+- 本版本没有修改 HTTP 订阅的兼容与安全策略；Windows 继续只发布未签名的 `SSRVPN_Setup.exe` 安装版，不提供便携 ZIP。
+
 ## [3.5.4] - 2026-07-25
 
 ### 修复

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.5.5+3505
+version: 3.5.6+3506
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.5.5+3505
+version: 3.5.6+3506
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 3.5.5+3505
+version: 3.5.6+3506
 resolution: workspace
 
 environment:

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.5.5';
+  static const String appVersion = '3.5.6';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -48,4 +48,10 @@ if [ "$base_version" != "$constant_version" ]; then
   exit 1
 fi
 
+version_pattern="${base_version//./\\.}"
+if ! grep -Eq "^## \\[$version_pattern\\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHANGELOG.md; then
+  echo "version check failed: CHANGELOG.md has no [$base_version] section" >&2
+  exit 1
+fi
+
 echo "Version sync check passed: $workspace_version"


### PR DESCRIPTION
## Summary
- publish the Android disconnect recovery fix as v3.5.6 without moving the already-pushed v3.5.5 tag
- add the missing current-version CHANGELOG section
- fail version-sync checks early when the CHANGELOG entry is absent

## Verification
- version sync and 3.5.5 -> 3.5.6 transition checks
- release notes generated successfully for v3.5.6
- 230 release-tooling tests passed
- bash syntax and git diff checks passed

## Release context
The v3.5.5 Release workflow built all three platforms successfully but stopped before publication because CHANGELOG.md had no [3.5.5] section. No public v3.5.5 GitHub Release was created; this PR preserves tag immutability and prepares v3.5.6.