### PR TITLE
fix(android): show safe disconnect transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
 
   flutter-app:
     name: ${{ matrix.name }}
-    needs: [shared, core-assets]
+    needs: [core-assets, secret-scan]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -130,6 +130,13 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
+
+      - name: Cache Gradle dependencies
+        if: matrix.directory == 'SSRVPN_Android'
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+          cache-read-only: ${{ github.ref_name != github.event.repository.default_branch }}
 
       - run: bash scripts/verify-core-assets.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
   # ── Android ──
   build-android:
     name: Android APK
-    needs: [shared-test, prepare-geoip]
+    needs: [validate-source, prepare-geoip]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -187,6 +187,12 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
+
+      - name: Cache Gradle dependencies
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+          cache-read-only: ${{ github.ref_name != github.event.repository.default_branch }}
 
       - name: Install dependencies
         run: |
@@ -282,7 +288,7 @@ jobs:
   # ── macOS ──
   build-macos:
     name: macOS DMG
-    needs: [shared-test, prepare-geoip]
+    needs: [validate-source, prepare-geoip]
     runs-on: macos-15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -366,7 +372,7 @@ jobs:
   # ── Windows ──
   build-windows:
     name: Windows installer
-    needs: [shared-test, prepare-geoip]
+    needs: [validate-source, prepare-geoip]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -450,7 +456,7 @@ jobs:
   publish:
     name: Publish Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-android, build-macos, build-windows]
+    needs: [shared-test, build-android, build-macos, build-windows]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -668,6 +674,7 @@ jobs:
           cp artifacts/macos/SSRVPN.dmg* "$public_assets/"
           cp artifacts/windows/SSRVPN_Setup.exe* "$public_assets/"
           OSS_BACKUP_DIR="$backup_dir" OSS_PRESERVE_BACKUP=1 \
+            OSS_VERSIONED_SOURCE_PREFIX="$OSS_PREFIX/releases/$tag" \
             bash scripts/promote-oss-public-channel.sh \
             "$public_assets" artifacts/oss/latest.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] - 2026-07-26
+
+### 修复
+
+- Android 在主动断开触发进程级安全复位时立即显示专用过渡页，使用与窗口一致的深蓝背景、SSRVPN 图标、状态文案和进度指示，消除原先约 1～2 秒的黑屏；既有 TUN 文件描述符释放、独立恢复进程和 1.5 秒安全窗口保持不变。
+
+### 改进
+
+- PR 与 main CI 的共享检查和三端验证改为并行，Release 的共享门禁与三端构建也改为并行；最终发布仍必须等待所有门禁成功。
+- Android CI 增加只允许 main 写入的 Gradle 依赖缓存；OSS 固定下载通道从同一 Bucket 的已验证版本化对象服务端复制，避免跨网重复上传，同时保留公开回读、SHA-256 校验、整通道备份和失败回滚。
+
+### 测试
+
+- 新增 Android 断开恢复主题、布局、首帧渲染顺序和原安全边界守卫，并在真实 Xiaomi 设备上确认过渡页约 332 毫秒完成首帧、1.5 秒后返回主界面且无 FATAL。
+- 新增 CI/Release 并行依赖、Gradle 缓存只读边界、OSS 服务端晋升、非法来源拒绝以及版本化对象不一致时完整回滚的发布工具回归测试。
+
+### 兼容性边界
+
+- 本版本没有修改 HTTP 订阅、国内应用直连名单或三端 IPv4-only 策略；Windows 继续只发布未签名的 `SSRVPN_Setup.exe` 安装版，不提供便携 ZIP。
+
 ## [3.6.0] - 2026-07-26
 
 ### 新增

--- a/SSRVPN_Android/android/app/src/main/AndroidManifest.xml
+++ b/SSRVPN_Android/android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
             android:finishOnTaskLaunch="true"
             android:process=":disconnect_recovery"
             android:taskAffinity="${applicationId}.disconnect_recovery"
-            android:theme="@style/LaunchTheme" />
+            android:theme="@style/DisconnectRecoveryTheme" />
         
         <meta-data
             android:name="io.flutter.embedding.android.EnableImpeller"

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/DisconnectRecoveryActivity.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/DisconnectRecoveryActivity.kt
@@ -25,6 +25,7 @@ class DisconnectRecoveryActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_disconnect_recovery)
         handler.postDelayed(relaunch, RELAUNCH_DELAY_MS)
     }
 

--- a/SSRVPN_Android/android/app/src/main/res/drawable/disconnect_recovery_background.xml
+++ b/SSRVPN_Android/android/app/src/main/res/drawable/disconnect_recovery_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="270"
+        android:centerColor="@color/disconnect_recovery_background_glow"
+        android:endColor="@color/disconnect_recovery_background"
+        android:startColor="@color/disconnect_recovery_background"
+        android:type="linear" />
+</shape>

--- a/SSRVPN_Android/android/app/src/main/res/layout/activity_disconnect_recovery.xml
+++ b/SSRVPN_Android/android/app/src/main/res/layout/activity_disconnect_recovery.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/disconnect_recovery_background"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:paddingStart="32dp"
+    android:paddingEnd="32dp">
+
+    <ImageView
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:contentDescription="@null"
+        android:src="@mipmap/ic_launcher" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:fontFamily="sans-serif-medium"
+        android:text="@string/disconnect_recovery_title"
+        android:textColor="@color/disconnect_recovery_text_primary"
+        android:textSize="22sp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:fontFamily="sans-serif"
+        android:text="@string/disconnect_recovery_status"
+        android:textColor="@color/disconnect_recovery_text_primary"
+        android:textSize="16sp" />
+
+    <ProgressBar
+        style="?android:attr/progressBarStyleSmall"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginTop="18dp"
+        android:contentDescription="@string/disconnect_recovery_progress"
+        android:indeterminate="true"
+        android:indeterminateTint="@color/disconnect_recovery_accent" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:fontFamily="sans-serif"
+        android:text="@string/disconnect_recovery_wait"
+        android:textColor="@color/disconnect_recovery_text_secondary"
+        android:textSize="13sp" />
+
+</LinearLayout>

--- a/SSRVPN_Android/android/app/src/main/res/values-night/styles.xml
+++ b/SSRVPN_Android/android/app/src/main/res/values-night/styles.xml
@@ -15,4 +15,15 @@
     <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
+
+    <!-- Keep the disconnect handoff identical in light and dark system modes. -->
+    <style name="DisconnectRecoveryTheme" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowActionModeOverlay">true</item>
+        <item name="android:windowBackground">@drawable/disconnect_recovery_background</item>
+        <item name="android:colorAccent">@color/disconnect_recovery_accent</item>
+        <item name="android:statusBarColor">@color/disconnect_recovery_background</item>
+        <item name="android:navigationBarColor">@color/disconnect_recovery_background</item>
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
 </resources>

--- a/SSRVPN_Android/android/app/src/main/res/values/colors.xml
+++ b/SSRVPN_Android/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="disconnect_recovery_background">#0B0D14</color>
+    <color name="disconnect_recovery_background_glow">#132044</color>
+    <color name="disconnect_recovery_accent">#2F6BFF</color>
+    <color name="disconnect_recovery_text_primary">#F4F6F8</color>
+    <color name="disconnect_recovery_text_secondary">#A4ACB8</color>
+</resources>

--- a/SSRVPN_Android/android/app/src/main/res/values/strings.xml
+++ b/SSRVPN_Android/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="disconnect_recovery_title">SSRVPN</string>
+    <string name="disconnect_recovery_status">正在安全断开…</string>
+    <string name="disconnect_recovery_wait">请稍候</string>
+    <string name="disconnect_recovery_progress">正在完成断开连接</string>
+</resources>

--- a/SSRVPN_Android/android/app/src/main/res/values/styles.xml
+++ b/SSRVPN_Android/android/app/src/main/res/values/styles.xml
@@ -15,4 +15,15 @@
     <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
+
+    <!-- Native handoff shown while a forced core reset releases the detached TUN fd. -->
+    <style name="DisconnectRecoveryTheme" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowActionModeOverlay">true</item>
+        <item name="android:windowBackground">@drawable/disconnect_recovery_background</item>
+        <item name="android:colorAccent">@color/disconnect_recovery_accent</item>
+        <item name="android:statusBarColor">@color/disconnect_recovery_background</item>
+        <item name="android:navigationBarColor">@color/disconnect_recovery_background</item>
+        <item name="android:windowLightStatusBar">false</item>
+    </style>
 </resources>

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.6.0+3600
+version: 3.6.1+3601
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.6.0+3600
+version: 3.6.1+3601
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 3.6.0+3600
+version: 3.6.1+3601
 resolution: workspace
 
 environment:

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.6.0';
+  static const String appVersion = '3.6.1';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/scripts/check-android-native-bridge-guards.sh
+++ b/scripts/check-android-native-bridge-guards.sh
@@ -9,6 +9,11 @@ DISCONNECT_RECOVERY_COORDINATOR="$ROOT/SSRVPN_Android/android/app/src/main/kotli
 TILE_SERVICE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTileService.kt"
 BUILD_GRADLE="$ROOT/SSRVPN_Android/android/app/build.gradle.kts"
 MANIFEST="$ROOT/SSRVPN_Android/android/app/src/main/AndroidManifest.xml"
+DISCONNECT_RECOVERY_LAYOUT="$ROOT/SSRVPN_Android/android/app/src/main/res/layout/activity_disconnect_recovery.xml"
+DISCONNECT_RECOVERY_BACKGROUND="$ROOT/SSRVPN_Android/android/app/src/main/res/drawable/disconnect_recovery_background.xml"
+ANDROID_STYLES="$ROOT/SSRVPN_Android/android/app/src/main/res/values/styles.xml"
+ANDROID_NIGHT_STYLES="$ROOT/SSRVPN_Android/android/app/src/main/res/values-night/styles.xml"
+ANDROID_STRINGS="$ROOT/SSRVPN_Android/android/app/src/main/res/values/strings.xml"
 HOME_DART="$ROOT/SSRVPN_Android/lib/screens/home_screen.dart"
 HOME_PARTS=(
   "$ROOT/SSRVPN_Android/lib/screens/home_connection_actions_part.dart"
@@ -349,7 +354,8 @@ for needle in \
   'android:name=".DisconnectRecoveryActivity"' \
   'android:exported="false"' \
   'android:process=":disconnect_recovery"' \
-  'android:taskAffinity="${applicationId}.disconnect_recovery"'; do
+  'android:taskAffinity="${applicationId}.disconnect_recovery"' \
+  'android:theme="@style/DisconnectRecoveryTheme"'; do
   require_manifest_text "$needle"
 done
 for needle in \
@@ -369,6 +375,45 @@ for needle in \
     exit 1
   }
 done
+python3 - "$DISCONNECT_RECOVERY_ACTIVITY" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+content = source.index("setContentView(R.layout.activity_disconnect_recovery)")
+relaunch = source.index("handler.postDelayed(relaunch, RELAUNCH_DELAY_MS)")
+if content >= relaunch:
+    raise SystemExit(
+        "Android disconnect recovery activity does not render before relaunch scheduling"
+    )
+PY
+for needle in \
+  '@mipmap/ic_launcher' \
+  '@string/disconnect_recovery_status' \
+  '<ProgressBar'; do
+  grep -Fq "$needle" "$DISCONNECT_RECOVERY_LAYOUT" || {
+    echo "Android disconnect recovery layout guard failed: missing '$needle'" >&2
+    exit 1
+  }
+done
+for styles in "$ANDROID_STYLES" "$ANDROID_NIGHT_STYLES"; do
+  for needle in \
+    'style name="DisconnectRecoveryTheme"' \
+    '<item name="android:windowBackground">@drawable/disconnect_recovery_background</item>'; do
+    grep -Fq "$needle" "$styles" || {
+      echo "Android disconnect recovery theme guard failed in $styles: missing '$needle'" >&2
+      exit 1
+    }
+  done
+done
+grep -Fq '@color/disconnect_recovery_background' "$DISCONNECT_RECOVERY_BACKGROUND" || {
+  echo "Android disconnect recovery window lost its branded background" >&2
+  exit 1
+}
+grep -Fq '<string name="disconnect_recovery_status">' "$ANDROID_STRINGS" || {
+  echo "Android disconnect recovery status string is missing" >&2
+  exit 1
+}
 require_text "VpnRouteInstaller.configure(builder)"
 require_route_text "PublicIpv4Routes.routes"
 require_route_text "configure(builder::addAddress, builder::addRoute)"

--- a/scripts/promote-oss-public-channel.sh
+++ b/scripts/promote-oss-public-channel.sh
@@ -79,6 +79,23 @@ fi
 
 public_base="https://$OSS_BUCKET.$OSS_ENDPOINT"
 stable_prefix="$OSS_PREFIX/downloads"
+versioned_source_prefix="${OSS_VERSIONED_SOURCE_PREFIX:-}"
+if [ -n "$versioned_source_prefix" ]; then
+  versioned_source_prefix="${versioned_source_prefix%/}"
+  case "$versioned_source_prefix" in
+    "$OSS_PREFIX"/releases/v*) ;;
+    *)
+      echo "Invalid OSS versioned source prefix: $versioned_source_prefix" >&2
+      exit 2
+      ;;
+  esac
+  case "$versioned_source_prefix" in
+    *..*|*//*|*[[:space:]]*)
+      echo "Unsafe OSS versioned source prefix: $versioned_source_prefix" >&2
+      exit 2
+      ;;
+  esac
+fi
 committed=0
 
 object_key() {
@@ -500,8 +517,12 @@ trap restore_previous_channel EXIT
 
 for name in "${publish_files[@]}"; do
   source="$source_dir/$name"
+  upload_source="$source"
+  if [ -n "$versioned_source_prefix" ]; then
+    upload_source="oss://$OSS_BUCKET/$versioned_source_prefix/$name"
+  fi
   key="$(object_key "$name")"
-  "$ossutil_bin" cp "$source" "oss://$OSS_BUCKET/$key" \
+  "$ossutil_bin" cp "$upload_source" "oss://$OSS_BUCKET/$key" \
     --force --cache-control "no-cache"
   downloaded="$backup_dir/verify-$name"
   status="$(fetch_object "$name" "$downloaded")"

--- a/scripts/test_generate_oss_release_manifest.py
+++ b/scripts/test_generate_oss_release_manifest.py
@@ -65,7 +65,15 @@ class GenerateOssReleaseManifestTest(unittest.TestCase):
         ).read_text(encoding="utf-8")
 
         self.assertIn("scripts/promote-oss-public-channel.sh", workflow)
+        self.assertIn(
+            'OSS_VERSIONED_SOURCE_PREFIX="$OSS_PREFIX/releases/$tag"',
+            workflow,
+        )
         self.assertIn('stable_prefix="$OSS_PREFIX/downloads"', promoter)
+        self.assertIn(
+            'upload_source="oss://$OSS_BUCKET/$versioned_source_prefix/$name"',
+            promoter,
+        )
         self.assertIn('--cache-control "no-cache"', promoter)
         self.assertIn('cmp "$source" "$downloaded"', promoter)
         for name in (

--- a/scripts/test_promote_oss_public_channel.py
+++ b/scripts/test_promote_oss_public_channel.py
@@ -108,7 +108,7 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
         before = self._snapshot_public_channel()
 
         result = self._run(
-            versioned_source_prefix="ssrvpn/releases/../../other",
+            versioned_source_prefix="ssrvpn/releases/v9.9.9/../../other",
         )
 
         self.assertEqual(result.returncode, 2)

--- a/scripts/test_promote_oss_public_channel.py
+++ b/scripts/test_promote_oss_public_channel.py
@@ -43,6 +43,11 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
         self._write_fake_tools()
         self.old = self._write_channel(self.objects / "ssrvpn", b"old")
         self.new = self._write_channel(self.source, b"new")
+        self.versioned_prefix = "ssrvpn/releases/v9.9.9"
+        versioned = self.objects / self.versioned_prefix
+        versioned.mkdir(parents=True)
+        for name in PUBLISHED_FILES:
+            (versioned / name).write_bytes((self.source / name).read_bytes())
         self.manifest = self.source / "latest.json"
         self.manifest.write_text(
             json.dumps(
@@ -85,6 +90,44 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
             (self.objects / "ssrvpn" / "latest.json").read_bytes(),
             self.manifest.read_bytes(),
         )
+
+    def test_success_uses_versioned_oss_objects_for_stable_assets(self) -> None:
+        result = self._run(
+            versioned_source_prefix=self.versioned_prefix,
+            require_server_side_source=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for name in PUBLISHED_FILES:
+            self.assertEqual(
+                (self.objects / "ssrvpn" / "downloads" / name).read_bytes(),
+                (self.source / name).read_bytes(),
+            )
+
+    def test_rejects_unsafe_versioned_source_prefix_before_mutation(self) -> None:
+        before = self._snapshot_public_channel()
+
+        result = self._run(
+            versioned_source_prefix="ssrvpn/releases/../../other",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Unsafe OSS versioned source prefix", result.stderr)
+        self.assertEqual(self._snapshot_public_channel(), before)
+
+    def test_versioned_source_mismatch_restores_previous_channel(self) -> None:
+        before = self._snapshot_public_channel()
+        (
+            self.objects / self.versioned_prefix / "SSRVPN.dmg"
+        ).write_bytes(b"unexpected-versioned-object")
+
+        result = self._run(
+            versioned_source_prefix=self.versioned_prefix,
+            require_server_side_source=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self._snapshot_public_channel(), before)
 
     def test_success_tolerates_already_absent_retired_aliases(self) -> None:
         for name in RETIRED_FILES:
@@ -400,6 +443,8 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
         stale_backup_root: Optional[Path] = None,
         require_no_cache: bool = False,
         public_missing_on: str = "",
+        versioned_source_prefix: str = "",
+        require_server_side_source: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -418,10 +463,15 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                 "FAKE_STALE_BACKUP_ROOT": str(stale_backup_root or ""),
                 "FAKE_REQUIRE_NO_CACHE": "1" if require_no_cache else "0",
                 "FAKE_PUBLIC_MISSING_ON": public_missing_on,
+                "FAKE_REQUIRE_SERVER_SIDE_SOURCE": (
+                    "1" if require_server_side_source else "0"
+                ),
                 "RUNNER_TEMP": str(self.root),
                 "OSS_PRESERVE_BACKUP": "1" if preserve_backup else "0",
             }
         )
+        if versioned_source_prefix:
+            env["OSS_VERSIONED_SOURCE_PREFIX"] = versioned_source_prefix
         if backup is not None:
             env["OSS_BACKUP_DIR"] = str(backup)
         return subprocess.run(
@@ -546,10 +596,23 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                                 else:
                                     remaining.unlink()
                                 raise SystemExit(13)
-                        target = pathlib.Path(destination)
+                        target = (
+                            object_path(destination)
+                            if destination.startswith('oss://')
+                            else pathlib.Path(destination)
+                        )
                         target.parent.mkdir(parents=True, exist_ok=True)
                         shutil.copyfile(remote, target)
                         raise SystemExit(0)
+                    if (os.environ.get('FAKE_REQUIRE_SERVER_SIDE_SOURCE') == '1'
+                            and destination.startswith('oss://')
+                            and pathlib.Path(destination).name in {
+                                'SSRVPN.apk', 'SSRVPN.apk.sha256',
+                                'SSRVPN.dmg', 'SSRVPN.dmg.sha256',
+                                'SSRVPN_Setup.exe', 'SSRVPN_Setup.exe.sha256'}
+                            and source.startswith(
+                                os.environ.get('FAKE_NEW_SOURCE', '') + os.sep)):
+                        raise SystemExit(15)
                     if (os.environ.get('FAKE_FAIL_ON') == pathlib.Path(destination).name
                             and source.startswith(os.environ.get('FAKE_NEW_SOURCE', '') + os.sep)):
                         raise SystemExit(9)

--- a/scripts/test_release_tooling_entrypoint.py
+++ b/scripts/test_release_tooling_entrypoint.py
@@ -97,6 +97,62 @@ python3 -m unittest \\
             publish.index("    steps:\n"),
         )
 
+    def test_ci_platform_jobs_run_in_parallel_with_workspace_checks(self) -> None:
+        workflow = (
+            ROOT / ".github" / "workflows" / "ci.yml"
+        ).read_text(encoding="utf-8")
+        platform_job = workflow[workflow.index("  flutter-app:\n") :]
+        platform_header = platform_job[: platform_job.index("    steps:\n")]
+
+        self.assertIn(
+            "    needs: [core-assets, secret-scan]\n",
+            platform_header,
+        )
+        self.assertNotIn("shared", platform_header)
+
+    def test_release_builds_run_in_parallel_with_shared_gate(self) -> None:
+        workflow = (
+            ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text(encoding="utf-8")
+        for job_name in ("build-android", "build-macos", "build-windows"):
+            job = workflow[workflow.index(f"  {job_name}:\n") :]
+            header = job[: job.index("    steps:\n")]
+            with self.subTest(job=job_name):
+                self.assertIn(
+                    "    needs: [validate-source, prepare-geoip]\n",
+                    header,
+                )
+                self.assertNotIn("shared-test", header)
+
+        publish = workflow[workflow.index("  publish:\n") :]
+        publish_header = publish[: publish.index("    steps:\n")]
+        self.assertIn(
+            "    needs: [shared-test, build-android, build-macos, build-windows]\n",
+            publish_header,
+        )
+
+    def test_android_jobs_cache_gradle_dependencies_read_only_off_main(self) -> None:
+        expected_action = (
+            "gradle/actions/setup-gradle@"
+            "3f131e8634966bd73d06cc69884922b02e6faf92"
+        )
+        ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        release = (
+            ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(expected_action, ci)
+        self.assertIn("if: matrix.directory == 'SSRVPN_Android'", ci)
+        self.assertIn(expected_action, release)
+        for workflow in (ci, release):
+            self.assertIn("cache-provider: basic", workflow)
+            self.assertIn(
+                "cache-read-only: ${{ github.ref_name != github.event.repository.default_branch }}",
+                workflow,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- replace the Android disconnect recovery black frame with a dedicated native progress screen
- preserve the existing fail-safe VPN teardown and delayed process relaunch behavior
- shorten verified CI/release latency by running independent platform jobs in parallel, caching Gradle safely, and promoting OSS stable aliases server-side
- prepare release v3.6.1

## Verification

- `make verify`
- Android real-device recovery first frame observed in about 332 ms with no fatal crash
- release workflow and OSS rollback/validation tests

## Release boundaries

- HTTP subscription behavior is unchanged
- domestic app exclusions and IPv4-only policy are unchanged
- Windows remains installer-only (no portable ZIP)