### PR TITLE
fix: harden Android native starts and runtime diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.2] - 2026-07-27
+
+### 安全
+
+- Android 外部链接入口现在只接受带有效主机名、且不含用户凭据的 HTTP/HTTPS 绝对地址，拒绝 `file:`、`content:`、`intent:`、`javascript:` 和相对路径。
+- Android 前台 VPN 启动 Intent 不再携带配置路径、API 端口、API 凭据或节点名；应用内首次启动通过一次性随机句柄消费内存快照，磁贴与自动恢复继续使用 Android Keystore 加密的原子快照。
+- Android 原生连接快照在写入、读取和首次启动前都会解析真实路径，只允许应用私有数据目录内的普通配置文件，拒绝目录穿越、相邻前缀和符号链接逃逸。
+
+### 修复
+
+- Android 原生连接会话的复合状态与通知流量采样改为原子读写，避免并发启动、停止、恢复或通知刷新观察到撕裂状态。
+- Android TUN 文件描述符在转交给 Mihomo 后立即清除 Java 包装器所有权；停止时先关闭 Bridge，再限时等待 socket 保护线程退出，无法验证回收时继续使用既有进程级安全兜底。
+- 共享健康监控为控制面检查增加 10 秒上限，异常与超时统一计入连续失败并进入既有串行恢复；默认恢复前复核也受同一上限保护。
+- 数据通道观察增加 30 秒上限，异常或超时会发布不改变连接生命周期的降级提示；诊断页对核心、配置、运行时和平台检查分别限时并记录脱敏错误，同时明确显示健康数据通道。
+
+### 测试
+
+- 新增 Android URL 策略、私有路径、一次性启动句柄、流量快照并发和原生所有权守卫，以及共享健康检查、数据通道与诊断挂起回归测试。
+- 保留三端现有健康恢复、连接意图、快照代际、系统代理、TUN/DNS、发布资产和覆盖率门禁。
+
+### 兼容性边界
+
+- 本版本没有修改 HTTP 订阅、国内应用直连名单、三端 IPv4-only 策略或桌面系统代理恢复顺序；Windows 继续只发布未签名的 `SSRVPN_Setup.exe` 安装版，不提供便携 ZIP。
+
 ## [3.6.1] - 2026-07-26
 
 ### 修复

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/ExternalUrlPolicy.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/ExternalUrlPolicy.kt
@@ -1,0 +1,19 @@
+package com.ssrvpn.android
+
+import java.net.URI
+
+/** Restricts MethodChannel-driven external navigation to ordinary web links. */
+internal object ExternalUrlPolicy {
+    fun normalizedHttpUrl(rawUrl: String?): String? {
+        val candidate = rawUrl?.trim()?.takeIf(String::isNotEmpty) ?: return null
+        val uri = try {
+            URI(candidate)
+        } catch (_: Exception) {
+            return null
+        }
+        val scheme = uri.scheme?.lowercase() ?: return null
+        if (scheme != "http" && scheme != "https") return null
+        if (uri.host.isNullOrBlank() || uri.rawUserInfo != null) return null
+        return uri.toASCIIString()
+    }
+}

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt
@@ -42,6 +42,8 @@ class MainActivity : FlutterActivity() {
     private var myStartRequestId: String? = null
     @Volatile
     private var myStartClaimId: String? = null
+    @Volatile
+    private var myStartPayloadId: String? = null
     private var methodChannel: MethodChannel? = null
     // 监听 VPN 状态广播（磁贴断开/连接），实时推送给 Flutter 更新 UI
     private var vpnStateReceiver: BroadcastReceiver? = null
@@ -258,6 +260,8 @@ class MainActivity : FlutterActivity() {
             myStartRequestId = null
             NativeVpnSessionCoordinator.releasePendingStart(myStartClaimId)
             myStartClaimId = null
+            NativeStartPayloadRegistry.discard(myStartPayloadId)
+            myStartPayloadId = null
             VpnStartResultRegistry.clear(requestId)
             try {
                 SsrvpnVpnService.instance?.stopAll()
@@ -276,6 +280,8 @@ class MainActivity : FlutterActivity() {
             VpnStartResultRegistry.clear(requestId)
             NativeVpnSessionCoordinator.releasePendingStart(myStartClaimId)
             myStartClaimId = null
+            NativeStartPayloadRegistry.discard(myStartPayloadId)
+            myStartPayloadId = null
             myResultCallback = null
             myStartRequestId = null
             runOnUiThread {
@@ -290,14 +296,29 @@ class MainActivity : FlutterActivity() {
         myResultCallback = callback
         requestId = VpnStartResultRegistry.register(callback)
         myStartRequestId = requestId
+        val startPayload = try {
+            NativeConnectionPathPolicy.requireTrusted(
+                applicationInfo.dataDir,
+                NativeConnectionSnapshot(
+                    configDir = configDir,
+                    configPath = configPath,
+                    apiPort = apiPort,
+                    apiSecret = apiSecret,
+                    selectedNodeName = nodeName
+                )
+            )
+        } catch (error: Exception) {
+            VpnStartResultRegistry.clear(requestId)
+            myResultCallback = null
+            myStartRequestId = null
+            result.error("INVALID_CONFIG_PATH", "VPN 配置路径不安全或不可用", null)
+            return
+        }
+        myStartPayloadId = NativeStartPayloadRegistry.register(startPayload)
         pendingVpnServiceIntent = SsrvpnVpnService.createStartIntent(
             this,
-            configDir,
-            configPath,
-            apiPort,
-            apiSecret,
-            nodeName,
-            requestId
+            requestId = requestId,
+            startPayloadId = myStartPayloadId
         )
         startTimeoutRunnable = timeoutRunnable
 
@@ -357,9 +378,11 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun handleOpenUrl(call: MethodCall, result: MethodChannel.Result) {
-        val url = call.argument<String>("url")
+        val url = ExternalUrlPolicy.normalizedHttpUrl(
+            call.argument<String>("url")
+        )
         if (url == null) {
-            result.error("INVALID_ARGS", "URL is required", null)
+            result.error("INVALID_URL", "Only HTTP and HTTPS URLs are allowed", null)
             return
         }
         try {
@@ -526,6 +549,8 @@ class MainActivity : FlutterActivity() {
         pendingVpnServiceIntent = null
         NativeVpnSessionCoordinator.releasePendingStart(myStartClaimId)
         myStartClaimId = null
+        NativeStartPayloadRegistry.discard(myStartPayloadId)
+        myStartPayloadId = null
         myResultCallback?.invoke(false, message, null)
     }
 
@@ -571,6 +596,8 @@ class MainActivity : FlutterActivity() {
         pendingVpnServiceIntent = null
         NativeVpnSessionCoordinator.releasePendingStart(myStartClaimId)
         myStartClaimId = null
+        NativeStartPayloadRegistry.discard(myStartPayloadId)
+        myStartPayloadId = null
         // 只清理本 Activity 注册的回调，避免静态引用泄漏 Activity；
         // 不影响磁贴等其他来源设置的回调
         VpnStartResultRegistry.clear(myStartRequestId)

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionPathPolicy.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionPathPolicy.kt
@@ -1,0 +1,34 @@
+package com.ssrvpn.android
+
+import java.io.File
+
+/** Confines native runtime snapshots to regular files in app-private storage. */
+internal object NativeConnectionPathPolicy {
+    fun requireTrusted(
+        appDataDir: String,
+        snapshot: NativeConnectionSnapshot
+    ): NativeConnectionSnapshot {
+        val privateRoot = File(appDataDir).canonicalFile
+        require(privateRoot.isDirectory) { "Private app directory is unavailable" }
+
+        val configDir = File(snapshot.configDir).canonicalFile
+        val configPath = File(snapshot.configPath).canonicalFile
+        require(configDir.isDirectory && isWithin(privateRoot, configDir)) {
+            "Config directory is outside private app storage"
+        }
+        require(configPath.isFile && isWithin(configDir, configPath)) {
+            "Config path is not a regular file inside the config directory"
+        }
+        return snapshot.copy(
+            configDir = configDir.path,
+            configPath = configPath.path
+        )
+    }
+
+    private fun isWithin(parent: File, child: File): Boolean {
+        val parentPath = parent.path
+        val childPath = child.path
+        return childPath == parentPath ||
+            childPath.startsWith(parentPath + File.separator)
+    }
+}

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSession.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSession.kt
@@ -36,6 +36,7 @@ internal object NativeConnectionSession {
     @Volatile
     private var stopping = false
 
+    @Synchronized
     fun beginStarting(claimId: String?): Boolean {
         val pendingClaimId = pendingStartClaimId
         if (pendingClaimId != null && pendingClaimId != claimId) return false
@@ -47,10 +48,12 @@ internal object NativeConnectionSession {
         return true
     }
 
+    @Synchronized
     fun reserveStarting(configPath: String) {
         startingConfigPath = configPath
     }
 
+    @Synchronized
     fun publishRunning(configPath: String) {
         runningConfigPath = configPath
         recoveryConfigPath = null
@@ -61,23 +64,28 @@ internal object NativeConnectionSession {
         stopping = false
     }
 
+    @Synchronized
     fun reserveRecovery(configPath: String) {
         recoveryConfigPath = configPath
     }
 
+    @Synchronized
     fun clearRunning() {
         runningConfigPath = null
         stopping = false
     }
 
+    @Synchronized
     fun beginStopping() {
         stopping = true
     }
 
+    @Synchronized
     fun clearRecovery() {
         recoveryConfigPath = null
     }
 
+    @Synchronized
     fun clearStarting() {
         startingConfigPath = null
         pendingStartClaimId = null
@@ -90,12 +98,14 @@ internal object NativeConnectionSession {
         gate: StartGenerationGate,
         running: () -> Boolean
     ): String? = gate.withCurrent {
-        if (running() || isTransitioning() || !File(configPath).isFile) {
-            return@withCurrent null
-        }
-        UUID.randomUUID().toString().also { claimId ->
-            pendingStartClaimId = claimId
-            pendingStartConfigPath = File(configPath).absolutePath
+        synchronized(this) {
+            if (running() || isTransitioning() || !File(configPath).isFile) {
+                return@withCurrent null
+            }
+            UUID.randomUUID().toString().also { claimId ->
+                pendingStartClaimId = claimId
+                pendingStartConfigPath = File(configPath).absolutePath
+            }
         }
     }
 
@@ -104,22 +114,26 @@ internal object NativeConnectionSession {
         gate: StartGenerationGate,
         running: () -> Boolean
     ): NativeStartClaim? = gate.withCurrent {
-        if (running() || isTransitioning()) return@withCurrent null
-        val snapshot = NativeConnectionSnapshotStore.read(context)
-            ?: return@withCurrent null
-        if (!File(snapshot.configPath).isFile) return@withCurrent null
-        val claimId = UUID.randomUUID().toString()
-        pendingStartClaimId = claimId
-        pendingStartConfigPath = File(snapshot.configPath).absolutePath
-        NativeStartClaim(claimId, snapshot)
+        synchronized(this) {
+            if (running() || isTransitioning()) return@withCurrent null
+            val snapshot = NativeConnectionSnapshotStore.read(context)
+                ?: return@withCurrent null
+            if (!File(snapshot.configPath).isFile) return@withCurrent null
+            val claimId = UUID.randomUUID().toString()
+            pendingStartClaimId = claimId
+            pendingStartConfigPath = File(snapshot.configPath).absolutePath
+            NativeStartClaim(claimId, snapshot)
+        }
     }
 
     fun releasePendingStart(claimId: String?, gate: StartGenerationGate) {
         if (claimId == null) return
         gate.withCurrent {
-            if (pendingStartClaimId == claimId) {
-                pendingStartClaimId = null
-                pendingStartConfigPath = null
+            synchronized(this) {
+                if (pendingStartClaimId == claimId) {
+                    pendingStartClaimId = null
+                    pendingStartConfigPath = null
+                }
             }
         }
     }
@@ -129,13 +143,15 @@ internal object NativeConnectionSession {
         running: () -> Boolean,
         clearSnapshot: () -> Unit
     ): Boolean = gate.withCurrent {
-        if (running() || starting || stopping || recoveryConfigPath != null) {
-            return@withCurrent false
+        synchronized(this) {
+            if (running() || starting || stopping || recoveryConfigPath != null) {
+                return@withCurrent false
+            }
+            clearSnapshot()
+            pendingStartClaimId = null
+            pendingStartConfigPath = null
+            true
         }
-        clearSnapshot()
-        pendingStartClaimId = null
-        pendingStartConfigPath = null
-        true
     }
 
     fun clearIdleSnapshot(
@@ -144,12 +160,18 @@ internal object NativeConnectionSession {
         running: () -> Boolean,
         expectedGeneration: String?
     ): Boolean = gate.withCurrent {
-        check(!running() && !isTransitioning()) {
-            "Native VPN start or recovery is in progress"
+        synchronized(this) {
+            check(!running() && !isTransitioning()) {
+                "Native VPN start or recovery is in progress"
+            }
+            NativeConnectionSnapshotStore.clearIfGeneration(
+                context,
+                expectedGeneration
+            )
         }
-        NativeConnectionSnapshotStore.clearIfGeneration(context, expectedGeneration)
     }
 
+    @Synchronized
     fun protectedConfigPath(running: Boolean): String? =
         if (running) {
             runningConfigPath
@@ -160,9 +182,11 @@ internal object NativeConnectionSession {
                 runningConfigPath.takeIf { stopping }
         }
 
+    @Synchronized
     fun isTransitioning(): Boolean =
         starting || stopping || recoveryConfigPath != null || pendingStartClaimId != null
 
+    @Synchronized
     fun snapshot(running: Boolean, sessionGeneration: Long): Map<String, Any?> =
         mapOf(
             "running" to running,
@@ -178,7 +202,12 @@ internal object NativeConnectionSession {
         while (true) {
             val token = gate.current()
             var state: Map<String, Any?>? = null
-            if (gate.runIfCurrent(token) { state = snapshot(running(), token) }) {
+            if (gate.runIfCurrent(token) {
+                    synchronized(this) {
+                        state = snapshot(running(), token)
+                    }
+                }
+            ) {
                 return checkNotNull(state)
             }
         }
@@ -193,8 +222,16 @@ internal object NativeConnectionSession {
         val token = gate.current()
         var generation: String? = null
         gate.runIfCurrent(token) {
-            if (!running() && !isTransitioning() && protectedConfigPath(false) == null) {
-                generation = NativeConnectionSnapshotStore.write(context, snapshot)
+            synchronized(this) {
+                if (!running() &&
+                    !isTransitioning() &&
+                    protectedConfigPath(false) == null
+                ) {
+                    generation = NativeConnectionSnapshotStore.write(
+                        context,
+                        snapshot
+                    )
+                }
             }
         }
         return generation

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSnapshotStore.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSnapshotStore.kt
@@ -41,12 +41,14 @@ internal object NativeConnectionSnapshotStore {
         snapshot: NativeConnectionSnapshot,
         generation: String
     ) {
-        require(snapshot.configDir.isNotBlank()) { "Missing config directory" }
-        require(snapshot.configPath.isNotBlank()) { "Missing config path" }
-        require(snapshot.apiPort in 1..65535) { "Invalid API port" }
-        require(snapshot.apiSecret.isNotBlank()) { "Missing API credential" }
+        val trustedSnapshot = NativeConnectionPathPolicy.requireTrusted(
+            context.applicationInfo.dataDir,
+            snapshot
+        )
+        require(trustedSnapshot.apiPort in 1..65535) { "Invalid API port" }
+        require(trustedSnapshot.apiSecret.isNotBlank()) { "Missing API credential" }
 
-        val plaintext = NativeConnectionSnapshotCodec.encode(snapshot)
+        val plaintext = NativeConnectionSnapshotCodec.encode(trustedSnapshot)
         val encrypted = try {
             encrypt(plaintext, getOrCreateKey())
         } catch (_: KeyPermanentlyInvalidatedException) {
@@ -79,8 +81,12 @@ internal object NativeConnectionSnapshotStore {
                     Base64.decode(ivValue, Base64.NO_WRAP)
                 )
             )
-            NativeConnectionSnapshotCodec.decode(
+            val decoded = NativeConnectionSnapshotCodec.decode(
                 cipher.doFinal(Base64.decode(ciphertextValue, Base64.NO_WRAP))
+            ) ?: return null
+            NativeConnectionPathPolicy.requireTrusted(
+                context.applicationInfo.dataDir,
+                decoded
             )
         } catch (error: Exception) {
             // Preserve the ciphertext: transient Keystore failures must not

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeStartPayloadRegistry.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeStartPayloadRegistry.kt
@@ -1,0 +1,25 @@
+package com.ssrvpn.android
+
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Keeps one foreground-start payload in process memory while the Intent carries
+ * only an opaque identifier. Payloads are consumed at most once.
+ */
+internal object NativeStartPayloadRegistry {
+    private val payloads = ConcurrentHashMap<String, NativeConnectionSnapshot>()
+
+    fun register(snapshot: NativeConnectionSnapshot): String =
+        UUID.randomUUID().toString().also { payloads[it] = snapshot }
+
+    fun peek(id: String?): NativeConnectionSnapshot? =
+        id?.let(payloads::get)
+
+    fun consume(id: String?): NativeConnectionSnapshot? =
+        id?.let(payloads::remove)
+
+    fun discard(id: String?) {
+        if (id != null) payloads.remove(id)
+    }
+}

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeVpnSessionCoordinator.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeVpnSessionCoordinator.kt
@@ -36,10 +36,11 @@ internal object NativeVpnSessionCoordinator {
         )
 
     fun claimPendingStart(intent: Intent): String? {
-        val configPath = intent.getStringExtra(SsrvpnVpnService.EXTRA_CONFIG_PATH)
-            ?: return null
+        val payload = NativeStartPayloadRegistry.peek(
+            intent.getStringExtra(SsrvpnVpnService.EXTRA_START_PAYLOAD_ID)
+        ) ?: return null
         val claimId = NativeConnectionSession.claimPendingStart(
-            configPath,
+            payload.configPath,
             SsrvpnVpnService.startGeneration,
             { SsrvpnVpnService.isRunning }
         )

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
@@ -32,12 +32,8 @@ class SsrvpnVpnService : VpnService() {
 
         const val ACTION_DISCONNECT = "com.ssrvpn.ACTION_DISCONNECT"
         const val ACTION_CONNECT = "com.ssrvpn.ACTION_CONNECT"
-        private const val EXTRA_CONFIG_DIR = "com.ssrvpn.extra.CONFIG_DIR"
-        internal const val EXTRA_CONFIG_PATH = "com.ssrvpn.extra.CONFIG_PATH"
-        private const val EXTRA_API_PORT = "com.ssrvpn.extra.API_PORT"
-        private const val EXTRA_API_SECRET = "com.ssrvpn.extra.API_SECRET"
-        private const val EXTRA_NODE_NAME = "com.ssrvpn.extra.NODE_NAME"
         private const val EXTRA_REQUEST_ID = "com.ssrvpn.extra.REQUEST_ID"
+        internal const val EXTRA_START_PAYLOAD_ID = "com.ssrvpn.extra.START_PAYLOAD_ID"
         internal const val EXTRA_START_CLAIM_ID = "com.ssrvpn.extra.START_CLAIM_ID"
         private const val EXTRA_RECOVERY_ATTEMPT = "com.ssrvpn.extra.RECOVERY_ATTEMPT"
         private const val EXTRA_RECOVERY_TOKEN = "com.ssrvpn.extra.RECOVERY_TOKEN"
@@ -50,22 +46,14 @@ class SsrvpnVpnService : VpnService() {
             private set
         fun createStartIntent(
             context: Context,
-            configDir: String,
-            configPath: String,
-            apiPort: Int,
-            apiSecret: String,
-            nodeName: String?,
             requestId: String? = null,
+            startPayloadId: String? = null,
             startClaimId: String? = null,
             recoveryAttempt: Int = 0,
             recoveryToken: Long? = null
         ): Intent = Intent(context, SsrvpnVpnService::class.java).apply {
-            putExtra(EXTRA_CONFIG_DIR, configDir)
-            putExtra(EXTRA_CONFIG_PATH, configPath)
-            putExtra(EXTRA_API_PORT, apiPort)
-            putExtra(EXTRA_API_SECRET, apiSecret)
-            putExtra(EXTRA_NODE_NAME, nodeName)
             putExtra(EXTRA_REQUEST_ID, requestId)
+            startPayloadId?.let { putExtra(EXTRA_START_PAYLOAD_ID, it) }
             startClaimId?.let { putExtra(EXTRA_START_CLAIM_ID, it) }
             putExtra(EXTRA_RECOVERY_ATTEMPT, recoveryAttempt)
             recoveryToken?.let { putExtra(EXTRA_RECOVERY_TOKEN, it) }
@@ -93,6 +81,7 @@ class SsrvpnVpnService : VpnService() {
         private const val API_HEALTH_POLL_INTERVAL_MS = 250L
         private const val BRIDGE_STOP_TIMEOUT_MS = 5_000L
         private const val BRIDGE_IS_RUNNING_TIMEOUT_MS = 2_000L
+        private const val PROTECT_MONITOR_STOP_TIMEOUT_MS = 1_000L
         private val stopOperation = CoalescedOperation()
         private val serviceStartInProgress = AtomicBoolean(false)
         private val bridgeStartInProgress = AtomicBoolean(false)
@@ -212,6 +201,8 @@ class SsrvpnVpnService : VpnService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "VPN Service starting...")
         val requestId = intent?.getStringExtra(EXTRA_REQUEST_ID)
+        val startPayloadId = intent?.getStringExtra(EXTRA_START_PAYLOAD_ID)
+        val startPayload = NativeStartPayloadRegistry.consume(startPayloadId)
         val startClaimId = intent?.getStringExtra(EXTRA_START_CLAIM_ID)
         val recoveryAttempt = intent?.getIntExtra(EXTRA_RECOVERY_ATTEMPT, 0) ?: 0
         val recoveryToken = if (intent?.hasExtra(EXTRA_RECOVERY_TOKEN) == true) {
@@ -261,34 +252,19 @@ class SsrvpnVpnService : VpnService() {
             return finishRejectedServiceStart(startId, isRunning, false)
         }
 
-        val explicitConfigDir = intent?.getStringExtra(EXTRA_CONFIG_DIR)
-        val explicitConfigPath = intent?.getStringExtra(EXTRA_CONFIG_PATH)
-        val hasExplicitApiPort = intent?.hasExtra(EXTRA_API_PORT) == true
-        val explicitApiSecret = intent?.getStringExtra(EXTRA_API_SECRET)
-        val needsSnapshot = explicitConfigDir == null ||
-            explicitConfigPath == null ||
-            !hasExplicitApiPort ||
-            explicitApiSecret.isNullOrBlank()
-        val snapshot = if (needsSnapshot) {
+        val snapshot = if (startPayloadId == null) {
             NativeConnectionSnapshotStore.read(this)
         } else {
-            null
+            startPayload
         }
-        val configDir = explicitConfigDir ?: snapshot?.configDir
-        val configPath = explicitConfigPath ?: snapshot?.configPath
-        val apiPort = if (hasExplicitApiPort) {
-            intent.getIntExtra(EXTRA_API_PORT, 9090)
-        } else {
-            snapshot?.apiPort ?: 9090
-        }
-        val apiSecret = NativeApiSecretResolver.resolve(explicitApiSecret) {
-            snapshot?.apiSecret
-        }
+        val configDir = snapshot?.configDir
+        val configPath = snapshot?.configPath
+        val apiPort = snapshot?.apiPort ?: 9090
+        val apiSecret = snapshot?.apiSecret.orEmpty()
         currentApiPort = apiPort
         configPath?.let(NativeConnectionSession::reserveStarting)
 
-        currentNodeName = intent?.getStringExtra(EXTRA_NODE_NAME)
-            ?: snapshot?.selectedNodeName
+        currentNodeName = snapshot?.selectedNodeName
             ?: "SSRVPN"
         connectionStartedAt = System.currentTimeMillis()
         notificationConnected = false
@@ -485,7 +461,13 @@ class SsrvpnVpnService : VpnService() {
             }
 
             ensureStartCurrent(startToken)
-            val tunFd = vpnFd!!.detachFd().toLong()
+            val descriptor = checkNotNull(vpnFd)
+            vpnFd = null
+            val tunFd = try {
+                descriptor.detachFd().toLong()
+            } finally {
+                descriptor.close()
+            }
             Log.d(TAG, "VPN established! fd=$tunFd")
 
             if (tunFd <= 0) {
@@ -689,11 +671,6 @@ class SsrvpnVpnService : VpnService() {
             try {
                 val restartIntent = createStartIntent(
                     this,
-                    request.configDir,
-                    request.configPath,
-                    request.apiPort,
-                    request.apiSecret,
-                    currentNodeName,
                     recoveryAttempt = nextAttempt,
                     recoveryToken = recoveryToken
                 )
@@ -815,12 +792,16 @@ class SsrvpnVpnService : VpnService() {
     private fun stopAllOnWorker(): Boolean {
         Log.d(TAG, "Stopping...")
         stopNotificationUpdates()
-        protectThread?.interrupt()
+        val protectMonitor = protectThread
+        protectMonitor?.interrupt()
         protectThread = null
         val pendingStartStopped = waitForPendingStart()
         val bridgeStopped = pendingStartStopped && stopBridgeWithTimeout()
+        val protectMonitorStopped = waitForProtectMonitor(protectMonitor)
         val stopDecision = CoreStopDecision.afterBridgeCheck(
-            pendingStartStopped, bridgeStopped, currentApiPort
+            pendingStartStopped,
+            bridgeStopped && protectMonitorStopped,
+            currentApiPort
         )
         if (stopDecision.terminateProcess) Log.e(TAG, stopDecision.terminationMessage(currentApiPort))
         try {
@@ -842,6 +823,24 @@ class SsrvpnVpnService : VpnService() {
         }
         Log.d(TAG, "Stopped")
         return stopDecision.terminateProcess
+    }
+
+    private fun waitForProtectMonitor(thread: Thread?): Boolean {
+        if (thread == null || !thread.isAlive) return true
+        try {
+            thread.join(PROTECT_MONITOR_STOP_TIMEOUT_MS)
+        } catch (error: InterruptedException) {
+            Thread.currentThread().interrupt()
+            Log.e(TAG, "Interrupted while waiting for protect monitor", error)
+            return false
+        }
+        if (!thread.isAlive) return true
+        Log.e(
+            TAG,
+            "Protect monitor did not stop within " +
+                "${PROTECT_MONITOR_STOP_TIMEOUT_MS}ms"
+        )
+        return false
     }
 
     private fun waitForPendingStart(): Boolean {

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTileService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTileService.kt
@@ -107,8 +107,6 @@ class VpnTileService : TileService() {
             launchApp()
             return
         }
-        val snapshot = claim.snapshot
-
         // 已有权限，直接启动
         Log.d(TAG, "Starting VPN directly from tile")
         val consumed = AtomicBoolean(false)
@@ -125,13 +123,8 @@ class VpnTileService : TileService() {
         val requestId = VpnStartResultRegistry.register(callback)
         val intent = SsrvpnVpnService.createStartIntent(
             this,
-            snapshot.configDir,
-            snapshot.configPath,
-            snapshot.apiPort,
-            snapshot.apiSecret,
-            snapshot.selectedNodeName,
-            requestId,
-            claim.id
+            requestId = requestId,
+            startClaimId = claim.id
         )
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTrafficTracker.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTrafficTracker.kt
@@ -20,6 +20,7 @@ internal class VpnTrafficTracker(
     private var uploadRate = 0L
     private var downloadRate = 0L
 
+    @Synchronized
     fun reset() {
         val tx = readTransmittedBytes().coerceAtLeast(0L)
         val rx = readReceivedBytes().coerceAtLeast(0L)
@@ -28,11 +29,13 @@ internal class VpnTrafficTracker(
         resetSample(tx, rx)
     }
 
+    @Synchronized
     fun resetSample() = resetSample(
         readTransmittedBytes().coerceAtLeast(0L),
         readReceivedBytes().coerceAtLeast(0L)
     )
 
+    @Synchronized
     fun update(bytesPerSecond: (Long, Long) -> Long) {
         val now = elapsedRealtime()
         val tx = readTransmittedBytes().coerceAtLeast(0L)
@@ -45,6 +48,7 @@ internal class VpnTrafficTracker(
         lastSampleAt = now
     }
 
+    @Synchronized
     fun snapshot() = VpnTrafficSnapshot(
         uploadRate = uploadRate,
         downloadRate = downloadRate,

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/ExternalUrlPolicyTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/ExternalUrlPolicyTest.kt
@@ -1,0 +1,33 @@
+package com.ssrvpn.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ExternalUrlPolicyTest {
+    @Test
+    fun `only absolute HTTP and HTTPS links may leave the app`() {
+        assertEquals(
+            "https://example.com/releases/latest",
+            ExternalUrlPolicy.normalizedHttpUrl(
+                " https://example.com/releases/latest "
+            )
+        )
+        assertEquals(
+            "http://example.com/help",
+            ExternalUrlPolicy.normalizedHttpUrl("http://example.com/help")
+        )
+
+        for (url in listOf(
+            "file:///data/user/0/com.ssrvpn/files/private",
+            "content://com.ssrvpn.private/state",
+            "intent://example.com/#Intent;scheme=https;end",
+            "javascript:alert(1)",
+            "https://user:password@example.com/",
+            "/relative/path",
+            "https:///missing-host"
+        )) {
+            assertNull(url, ExternalUrlPolicy.normalizedHttpUrl(url))
+        }
+    }
+}

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeConnectionPathPolicyTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeConnectionPathPolicyTest.kt
@@ -1,0 +1,95 @@
+package com.ssrvpn.android
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class NativeConnectionPathPolicyTest {
+    @Test
+    fun `snapshot paths must resolve inside the private app directory`() {
+        val root = Files.createTempDirectory("ssrvpn-private-root").toFile()
+        try {
+            val configDir = File(root, "app_flutter/runtime").apply { mkdirs() }
+            val config = File(configDir, "config.yaml").apply {
+                writeText("mixed-port: 7890")
+            }
+            val trusted = NativeConnectionPathPolicy.requireTrusted(
+                root.path,
+                snapshot(configDir, config)
+            )
+
+            assertEquals(configDir.canonicalPath, trusted.configDir)
+            assertEquals(config.canonicalPath, trusted.configPath)
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `sibling prefix traversal and symlink escapes are rejected`() {
+        val parent = Files.createTempDirectory("ssrvpn-path-policy").toFile()
+        try {
+            val root = File(parent, "app-data").apply { mkdirs() }
+            val sibling = File(parent, "app-data-evil").apply { mkdirs() }
+            val siblingConfig = File(sibling, "config.yaml").apply {
+                writeText("mixed-port: 7890")
+            }
+            assertThrows(IllegalArgumentException::class.java) {
+                NativeConnectionPathPolicy.requireTrusted(
+                    root.path,
+                    snapshot(sibling, siblingConfig)
+                )
+            }
+
+            val link = File(root, "escaped")
+            Files.createSymbolicLink(link.toPath(), sibling.toPath())
+            assertThrows(IllegalArgumentException::class.java) {
+                NativeConnectionPathPolicy.requireTrusted(
+                    root.path,
+                    snapshot(link, File(link, "config.yaml"))
+                )
+            }
+        } finally {
+            parent.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `config must be a regular file inside the declared config directory`() {
+        val root = Files.createTempDirectory("ssrvpn-config-policy").toFile()
+        try {
+            val firstDir = File(root, "first").apply { mkdirs() }
+            val secondDir = File(root, "second").apply { mkdirs() }
+            val outsideDeclaredDir = File(secondDir, "config.yaml").apply {
+                writeText("mixed-port: 7890")
+            }
+            assertThrows(IllegalArgumentException::class.java) {
+                NativeConnectionPathPolicy.requireTrusted(
+                    root.path,
+                    snapshot(firstDir, outsideDeclaredDir)
+                )
+            }
+            assertThrows(IllegalArgumentException::class.java) {
+                NativeConnectionPathPolicy.requireTrusted(
+                    root.path,
+                    snapshot(firstDir, File(firstDir, "missing.yaml"))
+                )
+            }
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    private fun snapshot(
+        configDir: File,
+        configPath: File
+    ) = NativeConnectionSnapshot(
+        configDir = configDir.path,
+        configPath = configPath.path,
+        apiPort = 9090,
+        apiSecret = "test-secret",
+        selectedNodeName = "Node A"
+    )
+}

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeStartPayloadRegistryTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeStartPayloadRegistryTest.kt
@@ -1,0 +1,28 @@
+package com.ssrvpn.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NativeStartPayloadRegistryTest {
+    @Test
+    fun `runtime payload is addressed by an opaque one-time identifier`() {
+        val snapshot = NativeConnectionSnapshot(
+            configDir = "/private/runtime",
+            configPath = "/private/runtime/config.yaml",
+            apiPort = 9090,
+            apiSecret = "secret-not-for-intent",
+            selectedNodeName = "Node A"
+        )
+
+        val id = NativeStartPayloadRegistry.register(snapshot)
+
+        assertNotEquals(snapshot.configPath, id)
+        assertNotEquals(snapshot.apiSecret, id)
+        assertEquals(snapshot, NativeStartPayloadRegistry.peek(id))
+        assertEquals(snapshot, NativeStartPayloadRegistry.consume(id))
+        assertNull(NativeStartPayloadRegistry.peek(id))
+        assertNull(NativeStartPayloadRegistry.consume(id))
+    }
+}

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnTrafficTrackerTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnTrafficTrackerTest.kt
@@ -1,6 +1,11 @@
 package com.ssrvpn.android
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VpnTrafficTrackerTest {
@@ -26,5 +31,62 @@ class VpnTrafficTrackerTest {
             ),
             tracker.snapshot()
         )
+    }
+
+    @Test
+    fun `snapshot cannot observe a partially updated traffic sample`() {
+        var tx = 100L
+        var rx = 200L
+        var now = 1_000L
+        val tracker = VpnTrafficTracker({ tx }, { rx }, { now })
+        tracker.reset()
+        tx = 2_100L
+        rx = 4_200L
+        now = 3_000L
+
+        val firstRateCalculated = CountDownLatch(1)
+        val allowUpdateToFinish = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            var calculation = 0
+            val update = executor.submit {
+                tracker.update { delta, elapsed ->
+                    calculation++
+                    if (calculation == 1) {
+                        firstRateCalculated.countDown()
+                        allowUpdateToFinish.await(1, TimeUnit.SECONDS)
+                    }
+                    delta * 1_000L / elapsed
+                }
+            }
+            assertTrue(firstRateCalculated.await(1, TimeUnit.SECONDS))
+
+            val snapshotAttempted = CountDownLatch(1)
+            val snapshot = executor.submit<VpnTrafficSnapshot> {
+                snapshotAttempted.countDown()
+                tracker.snapshot()
+            }
+            assertTrue(snapshotAttempted.await(1, TimeUnit.SECONDS))
+            Thread.sleep(25L)
+            assertFalse(
+                "snapshot returned while update held a partial sample",
+                snapshot.isDone
+            )
+
+            allowUpdateToFinish.countDown()
+            update.get(1, TimeUnit.SECONDS)
+            assertEquals(
+                VpnTrafficSnapshot(
+                    uploadRate = 1_000L,
+                    downloadRate = 2_000L,
+                    sessionUpload = 2_000L,
+                    sessionDownload = 4_000L
+                ),
+                snapshot.get(1, TimeUnit.SECONDS)
+            )
+        } finally {
+            allowUpdateToFinish.countDown()
+            executor.shutdownNow()
+        }
     }
 }

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.6.1+3601
+version: 3.6.2+3602
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 3.6.1+3601
+version: 3.6.2+3602
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 3.6.1+3601
+version: 3.6.2+3602
 resolution: workspace
 
 environment:

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '3.6.1';
+  static const String appVersion = '3.6.2';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/packages/ssrvpn_shared/lib/services/clash_service_base.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_base.dart
@@ -89,6 +89,17 @@ abstract class ClashServiceBase
   Duration get statusMonitorInterval => const Duration(seconds: 5);
 
   @protected
+  Duration get healthCheckTimeout => const Duration(seconds: 10);
+
+  @protected
+  @override
+  Duration get dataPlaneObservationTimeout => const Duration(seconds: 30);
+
+  @protected
+  @override
+  Duration get diagnosticCheckTimeout => const Duration(seconds: 10);
+
+  @protected
   int get maxConsecutiveHealthCheckFailures => 3;
 
   @protected
@@ -107,6 +118,21 @@ abstract class ClashServiceBase
   @protected
   void setLastHealthCheckError(String? value) {
     _lastHealthCheckError = value;
+  }
+
+  @protected
+  Future<bool> boundedHealthCheck() async {
+    try {
+      return await healthCheck().timeout(healthCheckTimeout);
+    } on TimeoutException {
+      _lastHealthCheckError = '健康检查超时';
+      log('Mihomo 健康检查超时 (${healthCheckTimeout.inSeconds}s)');
+      return false;
+    } catch (error) {
+      _lastHealthCheckError = '健康检查异常';
+      log('Mihomo 健康检查异常: $error');
+      return false;
+    }
   }
 
   @override
@@ -661,7 +687,7 @@ abstract class ClashServiceBase
   /// recovery only if the platform deliberately left itself running.
   @protected
   Future<bool> recoverAfterHealthCheckFailure(int connectionGeneration) async {
-    if (await healthCheck()) {
+    if (await boundedHealthCheck()) {
       setRunning(true);
       return isConnectionIntentCurrent(connectionGeneration, connected: true);
     }

--- a/packages/ssrvpn_shared/lib/services/clash_service_base.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_base.dart
@@ -41,7 +41,8 @@ abstract class ClashServiceBase
         _ClashConfigSupport,
         _ClashRuntimeSupport,
         _ClashDataPlaneSupport,
-        _ClashDiagnosticsSupport {
+        _ClashDiagnosticsSupport,
+        _ClashHealthSupport {
   // ── 状态 ──
   bool _isRunning = false;
   bool _healthCheckInProgress = false;
@@ -89,17 +90,6 @@ abstract class ClashServiceBase
   Duration get statusMonitorInterval => const Duration(seconds: 5);
 
   @protected
-  Duration get healthCheckTimeout => const Duration(seconds: 10);
-
-  @protected
-  @override
-  Duration get dataPlaneObservationTimeout => const Duration(seconds: 30);
-
-  @protected
-  @override
-  Duration get diagnosticCheckTimeout => const Duration(seconds: 10);
-
-  @protected
   int get maxConsecutiveHealthCheckFailures => 3;
 
   @protected
@@ -116,23 +106,9 @@ abstract class ClashServiceBase
   String? get lastHealthCheckError => _lastHealthCheckError;
 
   @protected
+  @override
   void setLastHealthCheckError(String? value) {
     _lastHealthCheckError = value;
-  }
-
-  @protected
-  Future<bool> boundedHealthCheck() async {
-    try {
-      return await healthCheck().timeout(healthCheckTimeout);
-    } on TimeoutException {
-      _lastHealthCheckError = '健康检查超时';
-      log('Mihomo 健康检查超时 (${healthCheckTimeout.inSeconds}s)');
-      return false;
-    } catch (error) {
-      _lastHealthCheckError = '健康检查异常';
-      log('Mihomo 健康检查异常: $error');
-      return false;
-    }
   }
 
   @override
@@ -173,8 +149,7 @@ abstract class ClashServiceBase
     required Future<String> Function(
       AppSettings runtimeSettings,
       String? preferredNodeName,
-    )
-    generateConfig,
+    ) generateConfig,
     required bool Function() isRevisionCurrent,
     String? preferredNodeName,
   }) {
@@ -225,8 +200,7 @@ abstract class ClashServiceBase
     }
     try {
       final result = await plan.recover(connectionGeneration);
-      final connected =
-          result.connected &&
+      final connected = result.connected &&
           isRunning &&
           isConnectionIntentCurrent(connectionGeneration, connected: true);
       if (!connected && result.failureReason != null) {

--- a/packages/ssrvpn_shared/lib/services/clash_service_data_plane_support.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_data_plane_support.dart
@@ -36,15 +36,26 @@ mixin _ClashDataPlaneSupport {
   void scheduleDataPlaneObservation() {
     if (_dataPlaneObservationInProgress || !isRunning) return;
     _dataPlaneObservationInProgress = true;
+    final observation = Future<void>.sync(observeDataPlaneHealth);
+    // Future.timeout does not cancel its source. Keep the ownership flag until
+    // the real probe settles so a timed-out probe cannot overlap later probes.
     unawaited(
-      observeDataPlaneHealth()
+      observation.then<void>(
+        (_) => _dataPlaneObservationInProgress = false,
+        onError: (Object _, StackTrace __) {
+          _dataPlaneObservationInProgress = false;
+        },
+      ),
+    );
+    unawaited(
+      observation
           .timeout(dataPlaneObservationTimeout)
           .catchError((Object error, StackTrace stack) {
         log('数据通道观察失败，不影响核心生命周期: $error');
         if (isRunning) {
           setConnectivityWarning('数据通道检查未能完成，请稍后重试或切换节点');
         }
-      }).whenComplete(() => _dataPlaneObservationInProgress = false),
+      }),
     );
   }
 

--- a/packages/ssrvpn_shared/lib/services/clash_service_data_plane_support.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_data_plane_support.dart
@@ -12,7 +12,8 @@ mixin _ClashDataPlaneSupport {
   void notifyStatusChanged();
   String _localHttpProxyConfig();
   String userConnectivityProxyConfig();
-  Duration get dataPlaneObservationTimeout;
+  @protected
+  Duration get dataPlaneObservationTimeout => const Duration(seconds: 30);
 
   String? get connectivityWarning => _connectivityWarning;
 

--- a/packages/ssrvpn_shared/lib/services/clash_service_data_plane_support.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_data_plane_support.dart
@@ -12,6 +12,7 @@ mixin _ClashDataPlaneSupport {
   void notifyStatusChanged();
   String _localHttpProxyConfig();
   String userConnectivityProxyConfig();
+  Duration get dataPlaneObservationTimeout;
 
   String? get connectivityWarning => _connectivityWarning;
 
@@ -35,8 +36,13 @@ mixin _ClashDataPlaneSupport {
     if (_dataPlaneObservationInProgress || !isRunning) return;
     _dataPlaneObservationInProgress = true;
     unawaited(
-      observeDataPlaneHealth().catchError((Object error, StackTrace stack) {
+      observeDataPlaneHealth()
+          .timeout(dataPlaneObservationTimeout)
+          .catchError((Object error, StackTrace stack) {
         log('数据通道观察失败，不影响核心生命周期: $error');
+        if (isRunning) {
+          setConnectivityWarning('数据通道检查未能完成，请稍后重试或切换节点');
+        }
       }).whenComplete(() => _dataPlaneObservationInProgress = false),
     );
   }

--- a/packages/ssrvpn_shared/lib/services/clash_service_diagnostics.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_diagnostics.dart
@@ -8,6 +8,8 @@ mixin _ClashDiagnosticsSupport {
   String? get connectivityWarning;
   String get recentLogs;
   String get configPath;
+  Duration get diagnosticCheckTimeout;
+  void log(String message);
 
   Future<bool> healthCheck();
 
@@ -30,15 +32,28 @@ mixin _ClashDiagnosticsSupport {
   @protected
   Future<List<AppDiagnosticCheck>> platformDiagnosticChecks() async => const [];
 
+  Future<T?> _runDiagnosticCheck<T>(
+    String id,
+    Future<T> Function() operation,
+  ) async {
+    try {
+      return await operation().timeout(diagnosticCheckTimeout);
+    } on TimeoutException {
+      log('诊断检查 $id 超时');
+      return null;
+    } catch (error) {
+      log('诊断检查 $id 失败: $error');
+      return null;
+    }
+  }
+
   Future<AppDiagnosticReport> runDiagnostics({
     DateTime Function()? clock,
   }) async {
     final checks = <AppDiagnosticCheck>[];
 
-    var coreAvailable = false;
-    try {
-      coreAvailable = await diagnosticCoreAvailable();
-    } catch (_) {}
+    final coreAvailable =
+        await _runDiagnosticCheck('core', diagnosticCoreAvailable) ?? false;
     checks.add(
       AppDiagnosticCheck(
         id: 'core',
@@ -71,12 +86,11 @@ mixin _ClashDiagnosticsSupport {
         ),
       );
     } else {
-      var configAvailable = false;
-      try {
-        configAvailable =
-            await FileSystemEntity.type(configuredPath, followLinks: false) ==
-                FileSystemEntityType.file;
-      } catch (_) {}
+      final configType = await _runDiagnosticCheck(
+        'config',
+        () => FileSystemEntity.type(configuredPath, followLinks: false),
+      );
+      final configAvailable = configType == FileSystemEntityType.file;
       checks.add(
         AppDiagnosticCheck(
           id: 'config',
@@ -100,10 +114,8 @@ mixin _ClashDiagnosticsSupport {
         ),
       );
     } else {
-      var healthy = false;
-      try {
-        healthy = await healthCheck();
-      } catch (_) {}
+      final healthy =
+          await _runDiagnosticCheck('runtime', healthCheck) ?? false;
       checks.add(
         AppDiagnosticCheck(
           id: 'runtime',
@@ -125,6 +137,15 @@ mixin _ClashDiagnosticsSupport {
           status: AppDiagnosticStatus.warning,
           summary: '数据通道处于降级恢复状态；核心、系统服务和运行配置仍保持连接',
           errorCode: AppErrorCode.dataPlaneDegraded,
+        ),
+      );
+    } else if (isRunning) {
+      checks.add(
+        const AppDiagnosticCheck(
+          id: 'data_plane',
+          title: '节点与外部网络',
+          status: AppDiagnosticStatus.passed,
+          summary: '当前没有检测到数据通道降级',
         ),
       );
     }
@@ -156,9 +177,11 @@ mixin _ClashDiagnosticsSupport {
       );
     }
 
-    try {
-      checks.addAll(await platformDiagnosticChecks());
-    } catch (_) {
+    final platformChecks = await _runDiagnosticCheck(
+      'platform',
+      platformDiagnosticChecks,
+    );
+    if (platformChecks == null) {
       checks.add(
         const AppDiagnosticCheck(
           id: 'platform',
@@ -168,6 +191,8 @@ mixin _ClashDiagnosticsSupport {
           errorCode: AppErrorCode.unknown,
         ),
       );
+    } else {
+      checks.addAll(platformChecks);
     }
 
     return AppDiagnosticReport(

--- a/packages/ssrvpn_shared/lib/services/clash_service_diagnostics.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_diagnostics.dart
@@ -8,7 +8,8 @@ mixin _ClashDiagnosticsSupport {
   String? get connectivityWarning;
   String get recentLogs;
   String get configPath;
-  Duration get diagnosticCheckTimeout;
+  @protected
+  Duration get diagnosticCheckTimeout => const Duration(seconds: 10);
   void log(String message);
 
   Future<bool> healthCheck();

--- a/packages/ssrvpn_shared/lib/services/clash_service_health_monitor.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_health_monitor.dart
@@ -12,7 +12,7 @@ extension ClashServiceHealthMonitor on ClashServiceBase {
       if (!_isRunning || _healthCheckInProgress) return;
       _healthCheckInProgress = true;
       try {
-        final healthy = await healthCheck();
+        final healthy = await boundedHealthCheck();
         if (healthy) {
           _consecutiveHealthCheckFailures = 0;
           scheduleDataPlaneObservation();

--- a/packages/ssrvpn_shared/lib/services/clash_service_health_monitor.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_health_monitor.dart
@@ -1,5 +1,29 @@
 part of 'clash_service_base.dart';
 
+mixin _ClashHealthSupport {
+  Future<bool> healthCheck();
+  void log(String message);
+  void setLastHealthCheckError(String? value);
+
+  @protected
+  Duration get healthCheckTimeout => const Duration(seconds: 10);
+
+  @protected
+  Future<bool> boundedHealthCheck() async {
+    try {
+      return await healthCheck().timeout(healthCheckTimeout);
+    } on TimeoutException {
+      setLastHealthCheckError('健康检查超时');
+      log('Mihomo 健康检查超时 (${healthCheckTimeout.inSeconds}s)');
+      return false;
+    } catch (error) {
+      setLastHealthCheckError('健康检查异常');
+      log('Mihomo 健康检查异常: $error');
+      return false;
+    }
+  }
+}
+
 extension ClashServiceHealthMonitor on ClashServiceBase {
   void startStatusMonitor() {
     _statusTimer?.cancel();

--- a/packages/ssrvpn_shared/test/clash_service_base_test.dart
+++ b/packages/ssrvpn_shared/test/clash_service_base_test.dart
@@ -749,6 +749,35 @@ proxies:
     expect(service.stopCalls, 0);
   });
 
+  test('status monitor bounds a health check that never completes', () async {
+    final service = _HangingHealthClashService();
+    addTearDown(service.dispose);
+    service.requestConnectionIntent(true);
+    service.setRunning(true);
+
+    service.startStatusMonitor();
+    await service.stopped.future.timeout(const Duration(seconds: 1));
+
+    expect(service.healthCalls, greaterThanOrEqualTo(2));
+    expect(service.isRunning, isFalse);
+    expect(service.recentLogs, contains('健康检查超时'));
+  });
+
+  test('data-plane observation timeout becomes an advisory warning', () async {
+    final service = _HangingDataPlaneClashService();
+    addTearDown(service.dispose);
+    service.requestConnectionIntent(true);
+    service.setRunning(true);
+
+    service.startStatusMonitor();
+    await service.warningPublished.future.timeout(const Duration(seconds: 1));
+    service.stopStatusMonitor();
+
+    expect(service.isRunning, isTrue);
+    expect(service.connectionDesired, isTrue);
+    expect(service.connectivityWarning, contains('未能完成'));
+  });
+
   group('ClashServiceBase diagnostics', () {
     test('reports missing core and config with stable error codes', () async {
       final tempDir =
@@ -812,6 +841,45 @@ proxies:
       expect(runtime.status, AppDiagnosticStatus.passed);
       expect(dataPlane.status, AppDiagnosticStatus.warning);
       expect(dataPlane.summary, contains('核心、系统服务和运行配置仍保持连接'));
+    });
+
+    test('reports a healthy data plane instead of omitting the check',
+        () async {
+      final service = _DiagnosticClashService();
+      addTearDown(service.dispose);
+      service.setRunning(true);
+
+      final report = await service.runDiagnostics();
+      final dataPlane =
+          report.checks.singleWhere((check) => check.id == 'data_plane');
+
+      expect(dataPlane.status, AppDiagnosticStatus.passed);
+      expect(dataPlane.errorCode, isNull);
+    });
+
+    test('bounds and logs diagnostic check failures', () async {
+      final service = _HangingDiagnosticClashService();
+      addTearDown(service.dispose);
+      service.setRunning(true);
+
+      final report =
+          await service.runDiagnostics().timeout(const Duration(seconds: 1));
+
+      expect(
+        report.checks.singleWhere((check) => check.id == 'core').status,
+        AppDiagnosticStatus.failed,
+      );
+      expect(
+        report.checks.singleWhere((check) => check.id == 'runtime').status,
+        AppDiagnosticStatus.failed,
+      );
+      expect(
+        report.checks.singleWhere((check) => check.id == 'platform').status,
+        AppDiagnosticStatus.warning,
+      );
+      expect(service.recentLogs, contains('诊断检查 core 超时'));
+      expect(service.recentLogs, contains('诊断检查 runtime 超时'));
+      expect(service.recentLogs, contains('诊断检查 platform 超时'));
     });
 
     test('checks the platform active config instead of a stale base path',
@@ -1245,4 +1313,69 @@ class _AdvisoryDataPlaneClashService extends _TestClashService {
   Future<void> onStopRequired() async {
     stopCalls++;
   }
+}
+
+class _HangingHealthClashService extends ClashServiceBase {
+  final Completer<void> stopped = Completer<void>();
+  int healthCalls = 0;
+
+  @override
+  Duration get statusMonitorInterval => const Duration(milliseconds: 1);
+
+  @override
+  Duration get healthCheckTimeout => const Duration(milliseconds: 10);
+
+  @override
+  int get maxConsecutiveHealthCheckFailures => 1;
+
+  @override
+  Future<bool> healthCheck() {
+    healthCalls++;
+    return Completer<bool>().future;
+  }
+
+  @override
+  Future<void> onStopRequired() async {
+    setRunning(false);
+    if (!stopped.isCompleted) stopped.complete();
+  }
+}
+
+class _HangingDataPlaneClashService extends _TestClashService {
+  final Completer<void> warningPublished = Completer<void>();
+
+  @override
+  Duration get statusMonitorInterval => const Duration(milliseconds: 1);
+
+  @override
+  Duration get dataPlaneObservationTimeout => const Duration(milliseconds: 10);
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
+  Future<void> observeDataPlaneHealth() => Completer<void>().future;
+
+  @override
+  void notifyStatusChanged() {
+    super.notifyStatusChanged();
+    if (connectivityWarning != null && !warningPublished.isCompleted) {
+      warningPublished.complete();
+    }
+  }
+}
+
+class _HangingDiagnosticClashService extends _TestClashService {
+  @override
+  Duration get diagnosticCheckTimeout => const Duration(milliseconds: 10);
+
+  @override
+  Future<bool> diagnosticCoreAvailable() => Completer<bool>().future;
+
+  @override
+  Future<bool> healthCheck() => Completer<bool>().future;
+
+  @override
+  Future<List<AppDiagnosticCheck>> platformDiagnosticChecks() =>
+      Completer<List<AppDiagnosticCheck>>().future;
 }

--- a/packages/ssrvpn_shared/test/clash_service_base_test.dart
+++ b/packages/ssrvpn_shared/test/clash_service_base_test.dart
@@ -771,11 +771,13 @@ proxies:
 
     service.startStatusMonitor();
     await service.warningPublished.future.timeout(const Duration(seconds: 1));
+    await Future<void>.delayed(const Duration(milliseconds: 25));
     service.stopStatusMonitor();
 
     expect(service.isRunning, isTrue);
     expect(service.connectionDesired, isTrue);
     expect(service.connectivityWarning, contains('未能完成'));
+    expect(service.observationCalls, 1);
   });
 
   group('ClashServiceBase diagnostics', () {
@@ -1343,6 +1345,7 @@ class _HangingHealthClashService extends ClashServiceBase {
 
 class _HangingDataPlaneClashService extends _TestClashService {
   final Completer<void> warningPublished = Completer<void>();
+  int observationCalls = 0;
 
   @override
   Duration get statusMonitorInterval => const Duration(milliseconds: 1);
@@ -1354,7 +1357,10 @@ class _HangingDataPlaneClashService extends _TestClashService {
   Future<bool> healthCheck() async => true;
 
   @override
-  Future<void> observeDataPlaneHealth() => Completer<void>().future;
+  Future<void> observeDataPlaneHealth() {
+    observationCalls++;
+    return Completer<void>().future;
+  }
 
   @override
   void notifyStatusChanged() {

--- a/scripts/check-android-native-bridge-guards.sh
+++ b/scripts/check-android-native-bridge-guards.sh
@@ -32,6 +32,10 @@ NATIVE_SNAPSHOT_STORE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrv
 NATIVE_CONNECTION_SESSION="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSession.kt"
 NATIVE_SESSION_COORDINATOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeVpnSessionCoordinator.kt"
 NATIVE_SESSION_COMMITTER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeSessionCommitter.kt"
+NATIVE_PATH_POLICY="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionPathPolicy.kt"
+NATIVE_START_PAYLOAD_REGISTRY="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeStartPayloadRegistry.kt"
+EXTERNAL_URL_POLICY="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/ExternalUrlPolicy.kt"
+TRAFFIC_TRACKER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTrafficTracker.kt"
 START_RESULT_REGISTRY="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnStartResultRegistry.kt"
 STARTUP_ORCHESTRATOR="$ROOT/SSRVPN_Android/lib/startup/startup_orchestrator.dart"
 CLASH_DART="$ROOT/SSRVPN_Android/lib/services/clash_service.dart"
@@ -221,7 +225,49 @@ PY
 require_text "waitForPendingStart()"
 require_text "VPN is already running; reusing the active session"
 require_text "createStartIntent"
-require_text "intent?.getStringExtra(EXTRA_CONFIG_DIR)"
+if grep -Eq 'EXTRA_(CONFIG_DIR|CONFIG_PATH|API_PORT|API_SECRET|NODE_NAME)' "$SERVICE"; then
+  echo "Android service intents must not carry runtime paths or credentials" >&2
+  exit 1
+fi
+require_text "NativeConnectionSnapshotStore.read(this)"
+require_text "NativeStartPayloadRegistry.consume(startPayloadId)"
+grep -Fq "NativeStartPayloadRegistry.peek(" "$NATIVE_SESSION_COORDINATOR" || {
+  echo "Android activity start lease cannot resolve its in-memory payload" >&2
+  exit 1
+}
+grep -Fq "ConcurrentHashMap<String, NativeConnectionSnapshot>" \
+  "$NATIVE_START_PAYLOAD_REGISTRY" || {
+  echo "Android foreground start payloads lost one-time in-memory ownership" >&2
+  exit 1
+}
+grep -Fq "NativeConnectionPathPolicy.requireTrusted" "$NATIVE_SNAPSHOT_STORE" || {
+  echo "Android native snapshots are not confined to the private app directory" >&2
+  exit 1
+}
+grep -Fq "ExternalUrlPolicy.normalizedHttpUrl" "$MAIN_ACTIVITY" || {
+  echo "Android external URL launch is missing its HTTP(S) policy" >&2
+  exit 1
+}
+for needle in "fun reset()" "fun resetSample()" \
+  "fun update(bytesPerSecond: (Long, Long) -> Long)" "fun snapshot()"; do
+  python3 - "$TRAFFIC_TRACKER" "$needle" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+needle = sys.argv[2]
+position = source.index(needle)
+prefix = source[max(0, position - 40):position]
+if "@Synchronized" not in prefix:
+    raise SystemExit(f"Android traffic state mutation is not atomic: {needle}")
+PY
+done
+grep -Fq "synchronized(this)" "$NATIVE_CONNECTION_SESSION" || {
+  echo "Android native connection compound state is not synchronized" >&2
+  exit 1
+}
+require_text "waitForProtectMonitor("
+require_text "vpnFd = null"
 require_text "BRIDGE_STOP_TIMEOUT_MS"
 require_text "BRIDGE_IS_RUNNING_TIMEOUT_MS"
 require_text "startBridgeWithTimeout"
@@ -332,7 +378,7 @@ intent = tile.index("SsrvpnVpnService.createStartIntent(", claim)
 launch = tile.index("startForegroundService(intent)", intent)
 if not claim < intent < launch:
     raise SystemExit("Android tile start lease is not acquired before service launch")
-main_claim = activity.index("NativeVpnSessionCoordinator.claimPendingStart(serviceIntent)")
+main_claim = activity.index("NativeVpnSessionCoordinator.claimPendingStart(")
 main_launch = activity.index("startVpnService(serviceIntent)", main_claim)
 if main_claim >= main_launch:
     raise SystemExit("Android activity start lease is not acquired before service launch")


### PR DESCRIPTION
## Summary

- confine Android native start credentials and paths to validated app-private state
- make native connection and traffic snapshots atomic, close detached descriptor ownership, and drain the protect monitor
- bound health, data-plane, and diagnostic probes without allowing timed-out data-plane work to overlap
- restrict external navigation to HTTP(S)
- prepare version 3.6.2+3602 and release notes

## Audit result

Validated five external review reports against current source and tests. Applied the ten highest-priority reproducible findings; rejected stale, already-fixed, or lifecycle-unsafe recommendations.

## Verification

- make verify
- shared targeted tests: 46 passed
- Android native unit tests
- secret scan and release tooling tests
- coverage thresholds: Android 63.34%, macOS 64.78%, Windows 47.29%

Windows local tests include 8 platform-conditioned skips; real Windows build remains gated by GitHub Actions.