### PR TITLE
chore: refresh GeoIP and stabilize Windows installer smoke

### DIFF
--- a/docs/GEOIP_SOURCE.txt
+++ b/docs/GEOIP_SOURCE.txt
@@ -1,12 +1,12 @@
 Repo: MetaCubeX/meta-rules-dat
-Release ID: 358377421
+Release ID: 363369342
 Release tag: latest
-Release name: Release 2026-07-23 07:27
-Asset ID: 486533101
-Asset URL: https://api.github.com/repos/MetaCubeX/meta-rules-dat/releases/assets/486533101
-Upstream SHA256: 435ead07913585e4d3c4ce7cf7070a5973cf5a4c2c9ed074d71904f9d4c18ae3
-Bundled gzip SHA256: 50eebb2946658df22dbd07adf9d94e1253c5c5b1f942c06aaf8c2891f84aea61
+Release name: Release 2026-08-01 07:27
+Asset ID: 497302665
+Asset URL: https://api.github.com/repos/MetaCubeX/meta-rules-dat/releases/assets/497302665
+Upstream SHA256: 9eb269b28d85de335f8f41e26825a28ce90e740528ce4fc99cb59f04edb3dd9b
+Bundled gzip SHA256: 1bb715ddaa461316fe7755eaa989341029f29c883554f75a3e4c41a66c94714e
 Mirror repo: Elegying/SSRVPN
 Mirror release tag: core-assets-v1
-Mirror asset name: geoip.metadb-50eebb2946658df22dbd07adf9d94e1253c5c5b1f942c06aaf8c2891f84aea61.gz
-Mirror URL: https://github.com/Elegying/SSRVPN/releases/download/core-assets-v1/geoip.metadb-50eebb2946658df22dbd07adf9d94e1253c5c5b1f942c06aaf8c2891f84aea61.gz
+Mirror asset name: geoip.metadb-1bb715ddaa461316fe7755eaa989341029f29c883554f75a3e4c41a66c94714e.gz
+Mirror URL: https://github.com/Elegying/SSRVPN/releases/download/core-assets-v1/geoip.metadb-1bb715ddaa461316fe7755eaa989341029f29c883554f75a3e4c41a66c94714e.gz

--- a/scripts/test_windows_installer_config.py
+++ b/scripts/test_windows_installer_config.py
@@ -1749,6 +1749,16 @@ class WindowsInstallerConfigTest(unittest.TestCase):
             "'ssrvpn_windows.exe')",
             smoke,
         )
+        start_installed_app = smoke.split(
+            "function Start-InstalledApp", 1
+        )[1].split("function Invoke-SmokeProcess", 1)[0]
+        self.assertIn("Start-Sleep -Milliseconds 750", start_installed_app)
+        self.assertIn("$runningInstalledApp.Refresh()", start_installed_app)
+        self.assertIn("$runningInstalledApp.HasExited", start_installed_app)
+        self.assertLess(
+            start_installed_app.index("Start-Sleep -Milliseconds 750"),
+            start_installed_app.index("return $runningInstalledApp"),
+        )
         self.assertEqual(smoke.count("$upgradeAppProcess = Start-InstalledApp"), 1)
         self.assertEqual(smoke.count("$runningInstalledApp = Start-InstalledApp"), 1)
         upgrade_start = smoke.index("$upgradeAppProcess = Start-InstalledApp")

--- a/scripts/test_windows_installer_package.ps1
+++ b/scripts/test_windows_installer_package.ps1
@@ -98,7 +98,18 @@ function Start-InstalledApp {
           )
         }
     ) | Select-Object -First 1
-    if ($runningInstalledApp) { return $runningInstalledApp }
+    if ($runningInstalledApp) {
+      # The production installer intentionally fails closed if any process
+      # changes identity during enumeration. Let the launcher/main handoff
+      # settle before exercising an upgrade so the smoke fixture represents a
+      # stable running installation instead of a first-frame launch race.
+      Start-Sleep -Milliseconds 750
+      $runningInstalledApp.Refresh()
+      if ($runningInstalledApp.HasExited) {
+        throw 'The installed app exited before its identity stabilized.'
+      }
+      return $runningInstalledApp
+    }
     Start-Sleep -Milliseconds 250
   }
   throw 'No app from the exact installed path started.'


### PR DESCRIPTION
## Summary

- refresh the pinned GeoIP snapshot to the verified 2026-08-01 upstream release
- pin the immutable SSRVPN mirror URL and both compressed/uncompressed SHA-256 values
- stabilize the Windows upgrade smoke by waiting for the newly launched installed app identity before invoking the fail-closed installer
- supersede the accumulated automation PRs #55, #56, #62, #71, #72, #75, #76, #77, and #78

## Verification

- official upstream release ID, asset ID, and GitHub digest match
- public immutable mirror compressed SHA-256 matches `1bb715dd...94714e`
- decompressed SHA-256 matches upstream `9eb269b2...dd9b`
- `bootstrap-core-assets.sh`, `verify-core-assets.sh`, core-asset guards, documentation checks, formatting, and ShellCheck pass
- the new timing guard failed before the fixture fix and passes afterward
- release tooling: 247/247
- the unchanged failed Windows job passed on rerun, confirming the observed identity error was timing-sensitive; final CI must still pass on this fixed commit

No application version, product behavior, production process-identity rule, or release artifact is changed.