### PR TITLE
ci: gate GeoIP refresh on release preparation

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -15,16 +15,13 @@ on:
         description: Immutable release tag required by oss-rollback, for example v3.1.1
         required: false
         type: string
-  schedule:
-    - cron: '17 1 * * *'
-
 permissions:
   contents: read
 
 jobs:
   geoip-refresh:
-    name: Propose a verified GeoIP refresh
-    if: github.event_name == 'schedule' || inputs.task == 'geoip-refresh'
+    name: Prepare the latest GeoIP for a release
+    if: github.event_name == 'workflow_dispatch' && inputs.task == 'geoip-refresh'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -101,7 +98,7 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "chore(assets): refresh GeoIP to $SOURCE_TAG" \
-            --body "Automated verified GeoIP snapshot refresh. Upstream provenance, the raw and deterministic gzip SHA-256 values, and the immutable SSRVPN mirror URL are pinned in docs/GEOIP_SOURCE.txt."
+            --body "Verified pre-release GeoIP snapshot refresh. Upstream provenance, the raw and deterministic gzip SHA-256 values, and the immutable SSRVPN mirror URL are pinned in docs/GEOIP_SOURCE.txt. Merge this PR before creating the release tag."
 
   oss-smoke:
     name: Verify OSS publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
   validate-source:
     name: Validate release source
     runs-on: ubuntu-latest
+    outputs:
+      release_retry: ${{ steps.source.outputs.release_retry }}
+      release_id: ${{ steps.source.outputs.release_id }}
+      release_identity: ${{ steps.source.outputs.release_identity }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -33,6 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Require release source to come from main
+        id: source
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -43,27 +48,30 @@ jobs:
             release_commit="$(git rev-parse --verify "$GITHUB_SHA^{commit}")"
           fi
           main_tip="$(git rev-parse origin/main)"
-          if [ "$release_commit" != "$main_tip" ]; then
-            retry_release="$RUNNER_TEMP/existing-release-retry.json"
-            retry_provenance_dir="$RUNNER_TEMP/existing-release-provenance"
-            if [[ "$GITHUB_REF" == refs/tags/* ]] &&
-              gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" \
-                >"$retry_release" &&
-              mkdir -p "$retry_provenance_dir" &&
-              gh release download "$GITHUB_REF_NAME" \
-                --repo "$GITHUB_REPOSITORY" \
-                --dir "$retry_provenance_dir" \
-                --pattern 'SSRVPN-release-provenance.json' &&
-              python3 scripts/validate-existing-release-retry.py \
-                "$retry_release" \
-                "$retry_provenance_dir/SSRVPN-release-provenance.json" \
-                --expected-tag "$GITHUB_REF_NAME" \
-                --expected-commit "$release_commit"; then
-              echo "Retrying existing release $GITHUB_REF_NAME after main advanced."
+
+          release_retry=false
+          echo "release_retry=false" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            if python3 scripts/authorize-existing-release-retry.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --tag "$GITHUB_REF_NAME" \
+              --commit "$release_commit" \
+              --work-dir "$RUNNER_TEMP/existing-release-retry" \
+              --github-output "$GITHUB_OUTPUT"; then
+              release_retry=true
+              echo "release_retry=true" >> "$GITHUB_OUTPUT"
+              echo "Validated existing release retry for $GITHUB_REF_NAME."
             else
-              echo "::error::New release builds must use the current tested main tip."
-              exit 1
+              retry_status=$?
+              if [ "$retry_status" -ne 3 ]; then
+                exit "$retry_status"
+              fi
             fi
+          fi
+
+          if [ "$release_commit" != "$main_tip" ] && [ "$release_retry" != true ]; then
+            echo "::error::New release builds must use the current tested main tip."
+            exit 1
           fi
 
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
@@ -148,6 +156,16 @@ jobs:
 
       - name: Verify pinned GeoIP assets
         run: bash scripts/verify-core-assets.sh
+
+      - name: Require the latest GeoIP snapshot
+        if: needs.validate-source.outputs.release_retry != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          if ! python3 scripts/sync-geoip-metadb.py --check; then
+            echo "::error::GeoIP is stale. Run Maintenance > geoip-refresh, merge its PR, then create a new release tag."
+            exit 1
+          fi
 
       - name: Upload verified core assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -458,7 +476,7 @@ jobs:
   publish:
     name: Publish Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [shared-test, build-android, build-macos, build-windows]
+    needs: [validate-source, shared-test, build-android, build-macos, build-windows]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -529,6 +547,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ANDROID_RELEASE_CERT_SHA256: ${{ vars.ANDROID_RELEASE_CERT_SHA256 }}
+          EXPECTED_RELEASE_RETRY_ID: ${{ needs.validate-source.outputs.release_id }}
+          EXPECTED_RELEASE_RETRY_IDENTITY: ${{ needs.validate-source.outputs.release_identity }}
+          REQUIRE_AUTHORIZED_RELEASE_RETRY: ${{ needs.validate-source.outputs.release_retry }}
         run: bash scripts/reuse-github-release-assets.sh artifacts
 
       - name: Generate release provenance
@@ -588,7 +609,7 @@ jobs:
           esac
 
       - name: Create GitHub Draft Release
-        if: steps.existing_release.outputs.exists != 'true'
+        if: needs.validate-source.outputs.release_retry != 'true' && steps.existing_release.outputs.exists != 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ steps.notes.outputs.tag }}
@@ -660,6 +681,9 @@ jobs:
         id: promote_oss
         env:
           GH_TOKEN: ${{ github.token }}
+          EXPECTED_RELEASE_RETRY_ID: ${{ needs.validate-source.outputs.release_id }}
+          EXPECTED_RELEASE_RETRY_IDENTITY: ${{ needs.validate-source.outputs.release_identity }}
+          REQUIRE_AUTHORIZED_RELEASE_RETRY: ${{ needs.validate-source.outputs.release_retry }}
           OSS_ACCESS_KEY_ID: ${{ secrets.ALIYUN_OSS_ACCESS_KEY_ID }}
           OSS_ACCESS_KEY_SECRET: ${{ secrets.ALIYUN_OSS_ACCESS_KEY_SECRET }}
           OSS_ENDPOINT: ${{ vars.ALIYUN_OSS_ENDPOINT }}
@@ -675,21 +699,61 @@ jobs:
           cp artifacts/android/SSRVPN.apk* "$public_assets/"
           cp artifacts/macos/SSRVPN.dmg* "$public_assets/"
           cp artifacts/windows/SSRVPN_Setup.exe* "$public_assets/"
+          poll_release_id=""
+          if [ "$REQUIRE_AUTHORIZED_RELEASE_RETRY" = true ]; then
+            python3 scripts/authorize-existing-release-retry.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --tag "$tag" \
+              --commit "$GITHUB_SHA" \
+              --work-dir "$RUNNER_TEMP/pre-finalize-release-retry" \
+              --expected-release-id "$EXPECTED_RELEASE_RETRY_ID" \
+              --expected-release-identity "$EXPECTED_RELEASE_RETRY_IDENTITY"
+            poll_release_id="$EXPECTED_RELEASE_RETRY_ID"
+          fi
           OSS_BACKUP_DIR="$backup_dir" OSS_PRESERVE_BACKUP=1 \
             OSS_VERSIONED_SOURCE_PREFIX="$OSS_PREFIX/releases/$tag" \
             bash scripts/promote-oss-public-channel.sh \
             "$public_assets" artifacts/oss/latest.json
 
+          if [ "$REQUIRE_AUTHORIZED_RELEASE_RETRY" = true ]; then
+            if ! python3 scripts/authorize-existing-release-retry.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --tag "$tag" \
+              --commit "$GITHUB_SHA" \
+              --work-dir "$RUNNER_TEMP/pre-publish-release-retry" \
+              --expected-release-id "$EXPECTED_RELEASE_RETRY_ID" \
+              --expected-release-identity "$EXPECTED_RELEASE_RETRY_IDENTITY"; then
+              echo "::error::Authorized GitHub release changed after OSS promotion; restoring OSS."
+              bash scripts/promote-oss-public-channel.sh --restore "$backup_dir"
+              exit 1
+            fi
+          fi
+
           finalize_status=0
-          gh release edit "$tag" --draft=false --prerelease=false --latest || \
-            finalize_status=$?
+          if [ "$REQUIRE_AUTHORIZED_RELEASE_RETRY" = true ]; then
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/$EXPECTED_RELEASE_RETRY_ID" \
+              -F draft=false -F prerelease=false -f make_latest=true || \
+              finalize_status=$?
+          else
+            gh release edit "$tag" --draft=false --prerelease=false --latest || \
+              finalize_status=$?
+          fi
 
           poll_status=0
           bash scripts/wait-for-github-release-public.sh \
-            "$tag" 5 attempted >/dev/null \
+            "$tag" 5 attempted "$poll_release_id" >/dev/null \
             || poll_status=$?
 
           if [ "$poll_status" -eq 0 ]; then
+            if [ "$REQUIRE_AUTHORIZED_RELEASE_RETRY" = true ]; then
+              python3 scripts/authorize-existing-release-retry.py \
+                --repo "$GITHUB_REPOSITORY" \
+                --tag "$tag" \
+                --commit "$GITHUB_SHA" \
+                --work-dir "$RUNNER_TEMP/post-public-release-retry" \
+                --expected-release-id "$EXPECTED_RELEASE_RETRY_ID" \
+                --expected-release-identity "$EXPECTED_RELEASE_RETRY_IDENTITY"
+            fi
             rm -rf "$backup_dir"
             exit 0
           fi
@@ -717,6 +781,9 @@ jobs:
           OSS_ENDPOINT: ${{ vars.ALIYUN_OSS_ENDPOINT }}
           OSS_BUCKET: ${{ vars.ALIYUN_OSS_BUCKET }}
           OSS_PREFIX: ${{ vars.ALIYUN_OSS_PREFIX }}
+          EXPECTED_RELEASE_RETRY_ID: ${{ needs.validate-source.outputs.release_id }}
+          EXPECTED_RELEASE_RETRY_IDENTITY: ${{ needs.validate-source.outputs.release_identity }}
+          REQUIRE_AUTHORIZED_RELEASE_RETRY: ${{ needs.validate-source.outputs.release_retry }}
         run: |
           set -euo pipefail
           tag="${GITHUB_REF#refs/tags/}"
@@ -725,17 +792,29 @@ jobs:
           manifest_json="$RUNNER_TEMP/published-latest.json"
           public_manifest_url="https://$OSS_BUCKET.$OSS_ENDPOINT/$OSS_PREFIX/latest.json"
 
+          if [ "$REQUIRE_AUTHORIZED_RELEASE_RETRY" = true ]; then
+            final_retry_dir="$RUNNER_TEMP/final-release-retry"
+            python3 scripts/authorize-existing-release-retry.py \
+              --repo "$GITHUB_REPOSITORY" \
+              --tag "$tag" \
+              --commit "$GITHUB_SHA" \
+              --work-dir "$final_retry_dir" \
+              --expected-release-id "$EXPECTED_RELEASE_RETRY_ID" \
+              --expected-release-identity "$EXPECTED_RELEASE_RETRY_IDENTITY"
+            cp "$final_retry_dir/release.json" "$release_json"
+          else
+            for attempt in 1 2 3; do
+              if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag" >"$release_json"; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::Cannot read the published GitHub release."
+                exit 1
+              fi
+              sleep "$attempt"
+            done
+          fi
           bash scripts/check-release-assets.sh "$tag"
-          for attempt in 1 2 3; do
-            if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag" >"$release_json"; then
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::Cannot read the published GitHub release."
-              exit 1
-            fi
-            sleep "$attempt"
-          done
 
           is_prerelease="$(python3 - "$release_json" "$tag" <<'PY'
           import json

--- a/docs/CORE_ASSETS.md
+++ b/docs/CORE_ASSETS.md
@@ -62,18 +62,39 @@ the `Elegying/SSRVPN/releases/download/core-assets-v1/` path and verifies both
 hashes before installing the same bytes for all three platforms. It never needs
 the upstream project's mutable Release during a normal CI or release build.
 
-The daily `Maintenance` workflow's `geoip-refresh` task independently downloads
-and verifies the latest upstream checksum, API digest, and database, produces deterministic gzip,
-uploads a missing content-addressed mirror asset without overwrite, and reads it
-back through the public bootstrap URL. Only after that verification succeeds may
-it open a uniquely named PR changing `GEOIP_SOURCE.txt`. An expired Asset ID in
-the previous upstream provenance therefore cannot block the refresh. The trust
-boundary disables redirects on authenticated API calls; mirror readback permits
-only GitHub's HTTPS download/CDN hosts and strips credentials from redirects.
-Concurrent same-name uploads are re-listed and accepted only when the public
-gzip/raw hashes match. These trust boundaries and the prohibition on replacing
-or deleting referenced assets are recorded in
-[ADR-005](decisions/005-content-addressed-geoip-mirror.md).
+The `Maintenance` workflow's manual `geoip-refresh` task is the first required
+release-preparation step. It independently downloads and verifies the latest
+upstream checksum, API digest, and database, produces deterministic gzip, uploads
+a missing content-addressed mirror asset without overwrite, and reads it back
+through the public bootstrap URL. Only after that verification succeeds may it
+open a uniquely named PR changing `GEOIP_SOURCE.txt`; merge that PR before
+creating the application release tag. There is no scheduled GeoIP freshness job.
+An expired Asset ID in the previous upstream provenance therefore cannot block
+the manual refresh. The trust boundary disables redirects on authenticated API
+calls; mirror readback permits only GitHub's HTTPS download/CDN hosts and strips
+credentials from redirects. Concurrent same-name uploads are re-listed and
+accepted only when the public gzip/raw hashes match.
+
+For a new release, `release.yml` bootstraps and verifies the reviewed pinned
+asset, then runs `sync-geoip-metadb.py --check` against upstream `latest` without
+writing files. It re-reads the upstream release and asset identity after content
+verification, so a concurrent `latest` rollover also fails before platform builds.
+Only a recovery retry backed by an exact-tag Release whose IDs, upload states,
+digests, commit, and provenance all validate may reuse the immutable snapshot
+without repeating the live freshness gate. Hidden drafts are located through a
+read-only paginated API fallback and provenance is fetched by validated asset ID;
+missing, duplicate, incomplete, or unreachable releases fail closed. The validated
+Release ID and a canonical hash of every asset identity are passed to the publish
+job and verified again. If that Release disappears or changes while builds run,
+publishing fails instead of deleting the draft or creating a replacement. Retry
+finalization, public-state polling, and post-publication validation use that numeric
+Release ID; only the expected draft-to-public transition is excluded from the
+immutable asset identity. The retry identity is checked after OSS promotion but
+before the numeric-ID PATCH, and again after the public-state poll before the OSS
+recovery backup is discarded. These trust boundaries are recorded in
+[ADR-005](decisions/005-content-addressed-geoip-mirror.md), and the release-only
+refresh policy is recorded in
+[ADR-011](decisions/011-release-gated-geoip-refresh.md).
 
 `scripts/verify-core-assets.sh` checks fixed SHA256 hashes, macOS decompressed
 executable equivalence, and bundled GeoIP databases. The same checks run in CI

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -55,8 +55,9 @@ This guide keeps local development, GitHub automation, and releases aligned.
 
 - Keep pull-request and branch checks in `ci.yml`.
 - Keep tag-triggered publishing in `release.yml`.
-- Add scheduled or manual operator tasks to `maintenance.yml`; prefer a new task
-  over another workflow file.
+- Add manual operator tasks to `maintenance.yml`; prefer a new task over another
+  workflow file. GeoIP refresh is deliberately manual and release-gated, so it
+  must not gain a `schedule` trigger.
 - Split a workflow only when it needs an incompatible trigger, permission boundary,
   or concurrency lock.
 - Pin every third-party action to a full commit SHA. Dependency Review on pull requests
@@ -141,29 +142,47 @@ and run both platform suites for shared desktop changes.
 
 ## Release Checklist
 
-1. Confirm `main` CI is green.
-2. Review `CHANGELOG.md` and move relevant entries from `Unreleased` to the target version.
-3. Verify bundled core assets:
+1. Manually run `Maintenance` with `geoip-refresh`, review and merge the generated
+   source-record PR, and wait for the resulting `main` CI to pass. Do this before
+   creating the application release tag.
+2. Confirm `main` CI is green.
+3. Review `CHANGELOG.md` and move relevant entries from `Unreleased` to the target version.
+4. Verify the pinned assets and prove that GeoIP still matches upstream `latest`:
 
    ```bash
+   make assets
    scripts/verify-core-assets.sh
+   python3 scripts/sync-geoip-metadb.py --check
    ```
 
-4. Verify the free Android self-signed keystore secrets are available. Desktop
+   The check re-reads the upstream Release and asset identity after verifying the
+   downloaded content. A `latest` rollover during verification is a failure, not
+   permission to accept either snapshot.
+
+5. Verify the free Android self-signed keystore secrets are available. Desktop
    releases always use the documented free path: macOS ad-hoc without
    notarization and Windows without Authenticode. Do not add Apple/Microsoft
    certificate secrets or paid-signing branches. See `docs/RELEASE_SIGNING.md`.
-5. Create and push a version tag:
+6. Create and push a version tag:
 
    ```bash
    git tag -a vX.Y.Z -m "SSRVPN vX.Y.Z"
    git push origin vX.Y.Z
    ```
 
-6. Watch the `Release` workflow.
-7. Download artifacts, verify checksums, and optionally run `scripts/check-release-assets.sh vX.Y.Z`.
-8. Confirm the Windows build log includes the native registry-sandbox proxy recovery test and the real `SSRVPN_Setup.exe` install/uninstall smoke test, not only packaging and static checks.
-9. Smoke test at least one install/run path per platform before announcing.
+7. Watch the `Release` workflow. New releases fail before platform builds if the
+   reviewed GeoIP pointer is no longer current; the workflow never rewrites a tag.
+   An existing-release retry bypasses this live check only after the exact tag,
+   completed asset states, IDs, digests, commit, and provenance all validate.
+   The publish job must then find the same Release ID and canonical asset identity;
+   it cannot delete or replace an authorized retry if the Release changes mid-run.
+   Finalization, polling, and post-publication validation stay bound to that numeric
+   ID while allowing only the expected draft-to-public state transition. The asset
+   identity is rechecked after OSS promotion and after the public-state poll before
+   the recovery backup is discarded.
+8. Download artifacts, verify checksums, and optionally run `scripts/check-release-assets.sh vX.Y.Z`.
+9. Confirm the Windows build log includes the native registry-sandbox proxy recovery test and the real `SSRVPN_Setup.exe` install/uninstall smoke test, not only packaging and static checks.
+10. Smoke test at least one install/run path per platform before announcing.
 
 ## Online/Offline Consistency
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@
 - [ADR-008：macOS API Secret 的会话轮换边界](decisions/008-macos-session-api-secret-rotation.md)
 - [ADR-009：macOS Release 权限最小化](decisions/009-macos-release-entitlement-minimization.md)
 - [ADR-010：以行为证据控制高风险职责拆分](decisions/010-risk-controlled-maintainability-boundaries.md)
+- [ADR-011：只在正式发版前刷新并强制验证 GeoIP](decisions/011-release-gated-geoip-refresh.md)
 
 ## 文档维护规则
 

--- a/docs/RELEASE_CHECKLIST.zh-CN.md
+++ b/docs/RELEASE_CHECKLIST.zh-CN.md
@@ -4,40 +4,55 @@
 
 ## 发布前
 
-1. 确认版本号一致：
+1. 在 GitHub Actions 手动运行 `Maintenance`，任务选择 `geoip-refresh`。审查并合并它创建的
+   `GEOIP_SOURCE.txt` 更新 PR，等待合并后的 `main` CI 全绿；完成前不得创建或推送应用版本
+   tag。GeoIP 不再定时自动检查。
+2. 确认版本号一致：
 
    ```bash
    scripts/check-version-sync.sh
    ```
-2. 确认本地或 GitHub CI 通过：
+3. 确认本地或 GitHub CI 通过：
    - `packages/ssrvpn_shared`
    - `SSRVPN_Android`
    - `SSRVPN_MacOS`
    - `SSRVPN_Windows`
    - Windows 日志包含 PowerShell 5.1 全脚本兼容性和新生成安装包真实安装/卸载通过记录；不得只依据 job 绿色，日志中任何脚本或安装器错误都必须对应失败步骤。
-3. 确认三端项目地址都指向：
+4. 确认三端项目地址都指向：
    - `https://github.com/Elegying/SSRVPN`
-4. 确认 Release workflow 需要的 Android 自签名 secrets 已配置。桌面端固定走免费分发：
+5. 确认 Release workflow 需要的 Android 自签名 secrets 已配置。桌面端固定走免费分发：
    macOS ad-hoc、未公证，Windows 未签名；仓库和 GitHub 配置中不应出现 Apple/Microsoft
    付费证书 secrets 或启用变量。
-5. 确认核心二进制和 geo 数据库哈希：
+6. 引导并确认核心二进制和 GeoIP 数据库哈希，同时以只读方式确认仓库固定的 GeoIP 仍是
+   上游最新版本：
 
    ```bash
+   make assets
    scripts/verify-core-assets.sh
+   python3 scripts/sync-geoip-metadb.py --check
    ```
-6. 确认没有明显密钥泄露、覆盖率没有低于当前保守门槛：
+   正式 Release workflow 会在三端构建前重复这项最新性门禁；失败时必须重新运行手动刷新、
+   合并新 PR 后再创建新的 release tag，禁止在 Release 中动态改写已有 tag 的输入。门禁会在
+   内容校验完成后再次确认上游 Release 和资产身份；校验期间 `latest` 发生滚动也必须失败。
+   只有精确 tag 下的 Release/资产 ID、上传完成状态、摘要、commit 与 provenance 全部一致的
+   已有发布恢复重试，才允许复用原 tag 快照；授权阶段固定的 Release ID 与全资产规范身份会在
+   发布 job 再次验证。构建期间 Release 消失、变残或被替换时必须失败，禁止删除后新建；缺失、
+   重复、网络异常或不完整 draft 均失败关闭。最终公开、轮询和发布后终验继续绑定 numeric
+   Release ID；只有预期的 draft → public 状态迁移不计入不可变资产身份。
+   OSS 推广后、numeric-ID PATCH 前，以及公开轮询成功后、删除恢复备份前都会再次复核资产身份。
+7. 确认没有明显密钥泄露、覆盖率没有低于当前保守门槛：
 
    ```bash
    scripts/check-secrets.sh
    gitleaks git --config .gitleaks.toml --redact --log-opts=--all
    make verify
    ```
-7. 如本地已有安装包产物，做一次结构 smoke：
+8. 如本地已有安装包产物，做一次结构 smoke：
 
    ```bash
    scripts/smoke-release-artifacts.sh --allow-missing
    ```
-8. 发布前后至少记录一次性能基准，用于对比低配设备体验是否退化：
+9. 发布前后至少记录一次性能基准，用于对比低配设备体验是否退化：
 
    ```bash
    scripts/performance-baseline.sh

--- a/docs/decisions/005-content-addressed-geoip-mirror.md
+++ b/docs/decisions/005-content-addressed-geoip-mirror.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-已接受
+已接受；每日自动刷新策略已由 [ADR-011](011-release-gated-geoip-refresh.md) 取代
 
 ## 日期
 
@@ -31,14 +31,14 @@ freshness 任务把未经校验的上游内容直接带入发布构建。
    - 上游仓库、Release/Asset ID 与 URL、解压后原始文件 SHA-256；
    - SSRVPN 镜像仓库、固定支持 tag、内容寻址资产名、精确下载 URL 与 deterministic
      gzip SHA-256。
-4. 普通 CI、正式 Release 和本地 `bootstrap-core-assets.sh` 不再读取上游 Asset URL。
-   它们只接受精确的
+4. 普通 CI、本地 `bootstrap-core-assets.sh` 和正式 Release 的构建输入不再来自上游
+   Asset URL。它们只接受精确的
    `https://github.com/Elegying/SSRVPN/releases/download/core-assets-v1/`
    路径，限制下载大小、协议和超时，并同时验证 gzip SHA-256 与有界解压后的原始 SHA-256。
    镜像回读只允许 `github.com`、`release-assets.githubusercontent.com` 和
    `objects.githubusercontent.com` 的 HTTPS 链路，拒绝降级到 HTTP 或跳转到其他主机。
-5. `Maintenance` 的 `geoip-refresh` 任务是唯一主动读取上游 `latest` 的自动化边界。
-   它按以下顺序执行：
+5. `Maintenance` 的手动 `geoip-refresh` 是唯一会根据上游 `latest` 写入候选来源记录并上传
+   镜像的自动化边界。它按以下顺序执行：
    上游 checksum/API digest/实际内容校验 → deterministic gzip → 缺失时上传内容寻址镜像
    → 从公共镜像 URL 回读并验证双 SHA-256 → 创建只修改来源记录的 PR。旧来源记录中的
    upstream URL 即使已返回 404，也不得在这条自愈链路开始前被 bootstrap 访问。
@@ -47,9 +47,9 @@ freshness 任务把未经校验的上游内容直接带入发布构建。
    提示修复支持 Release；已存在同名资产时只回读验证，不覆盖。回读失败或内容不符时不得
    创建更新 PR。若“列出资产”和“上传资产”之间发生同名竞态，上传不得 clobber；流程重新
    列出资产并以公共 URL 的 gzip/raw 双哈希回读为最终判断，匹配则复用，不匹配则失败。
-7. 正式 Release workflow 与普通 CI 继续共享提交中已审核的镜像指针。定时检查失败不会
-   破坏当前已锁定快照的构建；镜像本身缺失或损坏则安全失败，不能回退到上游 mutable
-   `latest`。
+7. 正式 Release workflow 与普通 CI 继续共享提交中已审核的镜像指针。新 Release 会只读
+   访问上游 `latest` 来证明该指针仍然最新，但不会把上游响应直接作为构建输入。上游状态
+   无法确认、镜像缺失或损坏时均安全失败，不能回退到 mutable `latest`。
 
 ## 信任边界
 
@@ -61,12 +61,14 @@ freshness 任务把未经校验的上游内容直接带入发布构建。
   的命令路径。代码审查和仓库权限仍需保护支持 Release 不被人工删除。
 - `core-assets-v1` tag 已纳入仓库 release-tag ruleset；tag 更新和删除都会被拒绝。Release
   管理员仍可操作资产，因此内容寻址名称、双哈希和禁止 clobber 的流程约束仍不可省略。
-- 普通 CI 和正式发版不需要信任当前上游状态，也不会因上游旧 Asset ID 被回收而改变输入。
+- 普通 CI 不需要信任当前上游状态；新正式发版必须通过只读最新性证明，但不会因上游旧
+  Asset ID 被回收而改变构建输入。
 
 ## 结果
 
 - 全新 runner 可以仅凭已提交来源记录重建三端 GeoIP 资产。
-- 每日更新仍保留完整上游出处，且镜像存在并能从真实 bootstrap URL 回读后才进入代码审查。
+- 每次发版前的手动更新仍保留完整上游出处，且镜像存在并能从真实 bootstrap URL 回读后
+  才进入代码审查。
 - 支持 prerelease 成为必须长期保留的运维资源；仓库所有者需保护其 tag 和已引用资产，
   并确保它永远不成为应用 `latest`。
 - GitHub Release 仍由仓库管理员控制，并非不可篡改账本；内容寻址名称和双哈希让错误替换
@@ -108,3 +110,4 @@ Asset ID 会随上游每日 Release 替换被删除，已经证明不能提供�
 - [核心资产来源](../CORE_ASSETS.md)
 - [GeoIP 来源记录](../GEOIP_SOURCE.txt)
 - [发布检查清单](../RELEASE_CHECKLIST.zh-CN.md)
+- [ADR-011：只在正式发版前刷新并强制验证 GeoIP](011-release-gated-geoip-refresh.md)

--- a/docs/decisions/011-release-gated-geoip-refresh.md
+++ b/docs/decisions/011-release-gated-geoip-refresh.md
@@ -1,0 +1,86 @@
+# ADR-011：只在正式发版前刷新并强制验证 GeoIP
+
+## 状态
+
+已接受；取代 ADR-005 中的每日自动刷新策略，不改变其内容寻址镜像和双哈希信任边界
+
+## 日期
+
+2026-08-02
+
+## 背景
+
+上游 MetaCubeX 会频繁替换 `latest` GeoIP 资产。每日自动检查会为每次上游变化创建新的
+来源记录 PR，但已安装客户端只有随正式版本获得新数据库，非发版期间持续合并这些 PR
+不会立即改善用户行为，反而增加审查通知、分支和 CI 噪声。
+
+正式发布仍必须携带当时最新、可追溯且三端一致的 `geoip.metadb`。这个要求不能通过在
+Release 构建阶段直接写入上游 `latest` 实现，因为应用 tag、提交、来源记录和构建输入必须
+保持一致且可复现。
+
+## 决策
+
+1. `Maintenance` 不再包含 GeoIP `schedule` 触发器。`geoip-refresh` 只允许维护者通过
+   `workflow_dispatch` 手动运行。
+2. 创建应用版本 tag 前，维护者必须手动运行 `Maintenance > geoip-refresh`，审查并合并它
+   创建的 `GEOIP_SOURCE.txt` PR，再等待合并后的 `main` CI 通过。
+3. 新 Release 在三端构建前先从提交中固定的内容寻址镜像引导并验证 GeoIP，再运行
+   `sync-geoip-metadb.py --check`。该命令只读比较上游 `latest`、来源记录和三端资产；任何
+   不一致或上游不可确认状态都失败关闭。校验完成前会再次读取上游 Release 与资产身份；
+   若期间 `latest` 滚动，即使第一次下载内容匹配也必须失败并重新验证稳定快照。
+4. Release workflow 不运行 GeoIP 写入模式、不上传新镜像、不创建 PR，也不改写已经推送的
+   tag。最新性门禁失败时，必须重新完成手动刷新和审核流程后再创建新的发布提交与 tag。
+5. 只有已经存在完整 Release 资产、且 tag、commit、Release/asset ID、上传完成状态、
+   provenance 和资产摘要全部通过校验的恢复重试，才可以继续使用原 tag 固定的 GeoIP，
+   避免第二天的上游变化破坏不可变发布的故障恢复。授权脚本在 tag API 看不到 draft 时会
+   只读分页查找精确 tag，并按资产 ID 下载 provenance；未找到返回专用状态，重复、网络
+   故障、空或不完整 draft 均失败关闭，不能绕过最新性门禁。授权阶段还会把 Release ID
+   与由 tag、全部资产 ID、状态、大小和摘要计算的规范化身份哈希传给发布 job；draft 到
+   public 是唯一允许的状态迁移，不改变该不可变身份。发布 job 必须重新验证并复用同一身份。
+   获授权的 Release 若在构建期间消失、变残或被替换，
+   工作流立即失败，禁止删除旧 draft 或退化为新建 Release。最终公开使用 numeric Release
+   ID 执行 PATCH，公开状态轮询与发布后终验也绑定同一 ID 和资产身份，不再按 tag 接受替代对象。
+   OSS 推广后、PATCH 前会再次验证身份；公开轮询成功后、删除 OSS 恢复备份前还会验证一次。
+   前者失败会恢复 OSS，后者失败会保留恢复备份并终止，避免资产变更被公开链静默接受。
+6. Android、macOS 和 Windows 构建继续只消费同一个 `prepare-geoip` 产物，因此三端携带的
+   GeoIP 字节与 `GEOIP_SOURCE.txt` 的双 SHA-256 保持一致。
+
+## 结果
+
+- 非发版期间不会再产生每日 GeoIP PR 或代码所有者审查通知。
+- 正式发版多一个明确的人工准备步骤；遗漏时 Release 会在平台构建前失败，不会发布旧数据。
+- 上游不可用时不能开始新的正式发布，但已验证发布的恢复路径不受后续上游滚动更新影响。
+- 构建输入仍由应用 tag 内审核过的来源记录决定；对上游 `latest` 的访问只用于新发布的
+  fail-closed 最新性证明，不会让可变输入直接进入安装包。
+
+## 未采用的方案
+
+### 每日自动创建 GeoIP PR
+
+数据在非发版期间不会进入已安装客户端，持续 PR 的运维噪声高于收益，因此取消。
+
+### Release 阶段直接下载并打包上游 latest
+
+它会让同一 tag 在不同时间产生不同字节，并绕过来源记录审查，违反可复现发布要求。
+
+### 只依赖人工清单，不设置发布门禁
+
+人工步骤容易遗漏，无法满足“每个正式版本必须携带最新 GeoIP”的强制要求。
+
+## 验证守卫
+
+- `scripts/test_geoip_workflow.py` 检查 `Maintenance` 无 `schedule`、手动刷新仍使用完整镜像校验
+  链，并验证新 Release 在上传共享核心资产前执行只读最新性门禁，同时拒绝校验期间滚动的
+  上游 `latest`。
+- `scripts/test_verify_release_transition.py` 禁止 Release 运行 GeoIP 写入模式。
+- `scripts/authorize-existing-release-retry.py` 与
+  `scripts/validate-existing-release-retry.py` 限制只有精确 tag、完整已上传资产且 provenance
+  一致的 Release 才能进入恢复重试路径；测试覆盖公开 Release、隐藏 draft、重复 tag、网络
+  故障与未完成资产。`scripts/reuse-github-release-assets.sh` 再次要求跨 job 的 Release ID 与
+  规范化资产身份完全相同，并测试消失、替换和不完整状态均不得删除或新建。
+
+## 相关文档
+
+- [ADR-005：使用 SSRVPN 自控的内容寻址 GeoIP 镜像](005-content-addressed-geoip-mirror.md)
+- [核心资产来源](../CORE_ASSETS.md)
+- [发布检查清单](../RELEASE_CHECKLIST.zh-CN.md)

--- a/scripts/authorize-existing-release-retry.py
+++ b/scripts/authorize-existing-release-retry.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Authorize reuse of an already complete GitHub Release without mutating it."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+MISSING_RELEASE_EXIT = 3
+TRANSIENT_ERROR = re.compile(
+    r"HTTP (408|429|500|502|503|504)|rate.?limit|timed? ?out|timeout|"
+    r"connection (reset|refused)|temporar(il)?y unavailable|TLS handshake|"
+    r"unexpected EOF",
+    re.IGNORECASE,
+)
+NOT_FOUND_ERROR = re.compile(r"HTTP 404|Not Found.*404|404.*Not Found")
+
+
+def load_validator():
+    path = Path(__file__).with_name("validate-existing-release-retry.py")
+    spec = importlib.util.spec_from_file_location("existing_release_retry", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load the existing release retry validator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class GithubApiError(RuntimeError):
+    def __init__(self, stderr: str):
+        super().__init__(stderr.strip() or "GitHub API request failed")
+        self.stderr = stderr
+
+
+def github_api(*args: str) -> bytes:
+    attempts_raw = os.environ.get("GITHUB_API_RETRY_ATTEMPTS", "4")
+    delay_raw = os.environ.get("GITHUB_API_RETRY_BASE_SECONDS", "1")
+    if not attempts_raw.isdigit() or not 1 <= int(attempts_raw) <= 10:
+        raise ValueError("GITHUB_API_RETRY_ATTEMPTS must be between 1 and 10")
+    if not delay_raw.isdigit() or not 0 <= int(delay_raw) <= 30:
+        raise ValueError("GITHUB_API_RETRY_BASE_SECONDS must be between 0 and 30")
+    max_attempts = int(attempts_raw)
+    base_delay = int(delay_raw)
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            result = subprocess.run(
+                ["gh", "api", *args],
+                capture_output=True,
+                check=False,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired as error:
+            stderr = f"GitHub API request timed out after {error.timeout}s"
+        else:
+            if result.returncode == 0:
+                return result.stdout
+            stderr = result.stderr.decode("utf-8", errors="replace")
+        if attempt == max_attempts or TRANSIENT_ERROR.search(stderr) is None:
+            raise GithubApiError(stderr)
+        delay = min(base_delay * (1 << (attempt - 1)), 30)
+        print(
+            f"Transient GitHub API failure (attempt {attempt}/{max_attempts}); "
+            f"retrying in {delay}s",
+            file=sys.stderr,
+        )
+        time.sleep(delay)
+    raise AssertionError("unreachable")
+
+
+def parse_json(payload: bytes, label: str) -> object:
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{label} is not valid JSON") from error
+
+
+def find_release(
+    repo: str,
+    tag: str,
+    expected_release_id: int | None = None,
+) -> dict[str, object] | None:
+    if expected_release_id is not None:
+        payload = github_api(f"repos/{repo}/releases/{expected_release_id}")
+        release = parse_json(payload, "GitHub release response")
+        if not isinstance(release, dict):
+            raise ValueError("GitHub release response is not an object")
+        return release
+
+    try:
+        payload = github_api(f"repos/{repo}/releases/tags/{tag}")
+    except GithubApiError as error:
+        if NOT_FOUND_ERROR.search(error.stderr) is None:
+            raise
+        payload = github_api(
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/releases?per_page=100",
+        )
+        pages = parse_json(payload, "GitHub paginated release response")
+        if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+            raise ValueError("GitHub paginated release response is invalid")
+        matches = [
+            release
+            for page in pages
+            for release in page
+            if isinstance(release, dict) and release.get("tag_name") == tag
+        ]
+        if not matches:
+            return None
+        if len(matches) != 1:
+            raise ValueError(f"Multiple GitHub releases use tag {tag}")
+        return matches[0]
+
+    release = parse_json(payload, "GitHub release response")
+    if not isinstance(release, dict):
+        raise ValueError("GitHub release response is not an object")
+    return release
+
+
+def authorize(
+    repo: str,
+    tag: str,
+    commit: str,
+    work_dir: Path,
+    expected_release_id: int | None = None,
+) -> dict[str, object] | None:
+    validator = load_validator()
+    release = find_release(repo, tag, expected_release_id)
+    if release is None:
+        return None
+
+    assets = validator.validate_release_asset_metadata(release, expected_tag=tag)
+    provenance_asset = assets["SSRVPN-release-provenance.json"]
+    provenance_id = provenance_asset["id"]
+    provenance = github_api(
+        "-H",
+        "Accept: application/octet-stream",
+        f"repos/{repo}/releases/assets/{provenance_id}",
+    )
+    validator.validate_downloaded_asset_digest(
+        release,
+        "SSRVPN-release-provenance.json",
+        provenance,
+    )
+    provenance_data = parse_json(provenance, "release provenance")
+    validator.validate_release_metadata(
+        release,
+        provenance_data,
+        expected_tag=tag,
+        expected_commit=commit,
+    )
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "release.json").write_text(
+        json.dumps(release, sort_keys=True), encoding="utf-8"
+    )
+    (work_dir / "SSRVPN-release-provenance.json").write_bytes(provenance)
+    return release
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--work-dir", required=True, type=Path)
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--expected-release-id", type=int)
+    parser.add_argument("--expected-release-identity")
+    args = parser.parse_args()
+    try:
+        has_expected_id = args.expected_release_id is not None
+        has_expected_identity = args.expected_release_identity is not None
+        if has_expected_id != has_expected_identity:
+            raise ValueError("expected release ID and identity must be provided together")
+        if has_expected_id and args.expected_release_id <= 0:
+            raise ValueError("expected release ID must be positive")
+        if has_expected_identity and re.fullmatch(
+            r"[0-9a-f]{64}", args.expected_release_identity
+        ) is None:
+            raise ValueError("expected release identity is invalid")
+
+        release = authorize(
+            args.repo,
+            args.tag,
+            args.commit,
+            args.work_dir,
+            args.expected_release_id,
+        )
+        if release is None:
+            print(f"No existing GitHub release found for {args.tag}.")
+            return MISSING_RELEASE_EXIT
+        validator = load_validator()
+        identity = validator.release_identity_digest(
+            release,
+            expected_tag=args.tag,
+        )
+        if has_expected_id and release.get("id") != args.expected_release_id:
+            raise ValueError("GitHub release ID does not match the authorized retry")
+        if has_expected_identity and identity != args.expected_release_identity:
+            raise ValueError("GitHub release identity does not match the authorized retry")
+        if args.github_output is not None:
+            with args.github_output.open("a", encoding="utf-8") as output:
+                output.write(f"release_id={release['id']}\n")
+                output.write(f"release_identity={identity}\n")
+    except (GithubApiError, OSError, ValueError) as error:
+        print(f"Existing release retry validation failed: {error}", file=sys.stderr)
+        return 1
+    print(f"Validated existing release retry for {args.tag}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reuse-github-release-assets.sh
+++ b/scripts/reuse-github-release-assets.sh
@@ -5,6 +5,26 @@ artifact_root="${1:?usage: reuse-github-release-assets.sh <artifact-root>}"
 tag="${GITHUB_REF_NAME:-${GITHUB_REF#refs/tags/}}"
 repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 output_file="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+expected_retry_id="${EXPECTED_RELEASE_RETRY_ID:-}"
+expected_retry_identity="${EXPECTED_RELEASE_RETRY_IDENTITY:-}"
+require_authorized_retry="${REQUIRE_AUTHORIZED_RELEASE_RETRY:-false}"
+strict_retry=false
+
+if [ "$require_authorized_retry" != true ] &&
+  [ "$require_authorized_retry" != false ]; then
+  echo "REQUIRE_AUTHORIZED_RELEASE_RETRY must be true or false" >&2
+  exit 1
+fi
+
+if [ "$require_authorized_retry" = true ] ||
+  [ -n "$expected_retry_id" ] || [ -n "$expected_retry_identity" ]; then
+  if [[ ! "$expected_retry_id" =~ ^[1-9][0-9]*$ ]] ||
+    [[ ! "$expected_retry_identity" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "Authorized release retry identity is incomplete or invalid" >&2
+    exit 1
+  fi
+  strict_retry=true
+fi
 
 if [[ ! "$tag" =~ ^v[0-9]+(\.[0-9]+){1,3}$ ]]; then
   echo "Invalid release tag: $tag" >&2
@@ -92,8 +112,12 @@ elif len(matches) == 1:
 else:
     raise SystemExit(f"Multiple GitHub releases use tag {expected_tag}")
 PY
-)"
+    )"
     if [ "$selection" = missing ]; then
+      if [ "$strict_retry" = true ]; then
+        echo "Previously authorized release $expected_retry_id is no longer available" >&2
+        exit 1
+      fi
       echo "exists=false" >>"$output_file"
       exit 0
     fi
@@ -106,6 +130,7 @@ fi
 
 inspection="$(python3 - "$release_json" "$tag" "$asset_map" <<'PY'
 import json
+import hashlib
 import re
 import sys
 from pathlib import Path
@@ -192,20 +217,60 @@ draft = release["draft"]
 prerelease = release["prerelease"]
 visibility = "prerelease" if prerelease else ("draft" if draft else "public")
 if oversized:
-    print(f"invalid\t{visibility}\t{release_id}\toversized asset")
+    state, reason = "invalid", "oversized asset"
 elif invalid_metadata and not (missing or unexpected or empty or unfinished):
-    print(f"invalid\t{visibility}\t{release_id}\tinvalid asset metadata")
+    state, reason = "invalid", "invalid asset metadata"
 elif missing or unexpected or empty or unfinished:
-    print(f"incomplete\t{visibility}\t{release_id}\tincomplete asset set")
+    state, reason = "incomplete", "incomplete asset set"
 else:
     asset_map_path.write_text(
         "".join(f"{name}\t{assets[name]['id']}\n" for name in sorted(required)),
         encoding="utf-8",
     )
-    print(f"complete\t{visibility}\t{release_id}\tverified asset metadata")
+    state, reason = "complete", "verified asset metadata"
+
+identity = "unavailable"
+if state == "complete":
+    identity_payload = {
+        "id": release_id,
+        "tag_name": release["tag_name"],
+        "assets": [
+            {
+                "id": assets[name]["id"],
+                "name": name,
+                "size": assets[name]["size"],
+                "digest": assets[name]["digest"],
+                "state": assets[name]["state"],
+            }
+            for name in sorted(required)
+        ],
+    }
+    canonical = json.dumps(
+        identity_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    identity = hashlib.sha256(canonical).hexdigest()
+print(f"{state}\t{visibility}\t{release_id}\t{reason}\t{identity}")
 PY
 )"
-IFS=$'\t' read -r state visibility release_id inspection_reason <<<"$inspection"
+IFS=$'\t' read -r state visibility release_id inspection_reason release_identity \
+  <<<"$inspection"
+
+if [ "$strict_retry" = true ]; then
+  if [ "$release_id" != "$expected_retry_id" ]; then
+    echo "Previously authorized release ID changed" >&2
+    exit 1
+  fi
+  if [ "$state" != complete ]; then
+    echo "Previously authorized release $release_id is no longer complete" >&2
+    exit 1
+  fi
+  if [ "$release_identity" != "$expected_retry_identity" ]; then
+    echo "Previously authorized release identity changed" >&2
+    exit 1
+  fi
+fi
 
 if [ "$state" = invalid ]; then
   echo "GitHub release $tag has $inspection_reason; refusing to download it" >&2

--- a/scripts/sync-geoip-metadb.py
+++ b/scripts/sync-geoip-metadb.py
@@ -147,6 +147,25 @@ def asset_digest(asset: dict[str, object]) -> str | None:
     return digest.removeprefix(prefix).lower() if digest.startswith(prefix) else None
 
 
+def latest_release_identity(release: dict[str, object]) -> tuple[object, ...]:
+    asset = find_asset(release, ASSET_NAME)
+    checksum_asset = find_asset(release, CHECKSUM_ASSET_NAME)
+    identity = (
+        release.get("id"),
+        release.get("tag_name"),
+        asset.get("id"),
+        asset.get("browser_download_url"),
+        asset.get("digest"),
+        checksum_asset.get("id"),
+        checksum_asset.get("browser_download_url"),
+        checksum_asset.get("digest"),
+    )
+    required = identity[:4] + identity[5:7]
+    if any(value in (None, "") for value in required):
+        raise SystemExit("upstream latest release identity is incomplete")
+    return identity
+
+
 def build_source_record(
     release: dict[str, object],
     asset: dict[str, object],
@@ -176,6 +195,7 @@ def build_source_record(
 
 def sync(check: bool) -> int:
     release = load_latest_release()
+    initial_identity = latest_release_identity(release)
     asset = find_asset(release, ASSET_NAME)
     checksum_asset = find_asset(release, CHECKSUM_ASSET_NAME)
 
@@ -200,6 +220,10 @@ def sync(check: bool) -> int:
     gzipped = stable_gzip(raw)
     gzip_hash = sha256(gzipped)
     source_record = build_source_record(release, asset, actual_hash, gzip_hash)
+
+    final_release = load_latest_release()
+    if latest_release_identity(final_release) != initial_identity:
+        raise SystemExit("upstream latest changed during verification")
 
     mismatches = [
         path

--- a/scripts/test-release-tooling.sh
+++ b/scripts/test-release-tooling.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 python3 -m unittest \
+  scripts/test_authorize_existing_release_retry.py \
   scripts/test_check_coverage_thresholds.py \
   scripts/test_dependency_security.py \
   scripts/test_macos_native_gate.py \
@@ -24,6 +25,7 @@ python3 -m unittest \
   scripts/test_secret_scanning.py \
   scripts/test_validate_existing_release_retry.py \
   scripts/test_verify_release_transition.py \
+  scripts/test_wait_for_github_release_public.py \
   scripts/test_windows_installer_config.py \
   scripts/test_windows_proxy_shutdown_recovery.py \
   scripts/test_windows_runonce_proxy_recovery.py

--- a/scripts/test_authorize_existing_release_retry.py
+++ b/scripts/test_authorize_existing_release_retry.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/authorize-existing-release-retry.py"
+COMMIT = "b" * 40
+TAG = "v3.2.0"
+REQUIRED_ASSETS = (
+    "SSRVPN.apk",
+    "SSRVPN.apk.sha256",
+    "SSRVPN.dmg",
+    "SSRVPN.dmg.sha256",
+    "SSRVPN_Setup.exe",
+    "SSRVPN_Setup.exe.sha256",
+    "SSRVPN-release-provenance.json",
+)
+
+
+class AuthorizeExistingReleaseRetryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.work_dir = self.root / "work"
+        self.release_json = self.root / "release.json"
+        self.provenance = self.root / "provenance.json"
+        self.log = self.root / "gh.log"
+        self.github_output = self.root / "github-output"
+
+        provenance = {
+            "schema": 1,
+            "tag": TAG,
+            "commit": COMMIT,
+            "assets": {
+                "SSRVPN.apk": "a" * 64,
+                "SSRVPN.dmg": "a" * 64,
+                "SSRVPN_Setup.exe": "a" * 64,
+            },
+        }
+        provenance_bytes = json.dumps(provenance, sort_keys=True).encode("utf-8")
+        self.provenance.write_bytes(provenance_bytes)
+
+        assets = []
+        for asset_id, name in enumerate(REQUIRED_ASSETS, start=10):
+            digest = "a" * 64
+            if name == "SSRVPN-release-provenance.json":
+                digest = hashlib.sha256(provenance_bytes).hexdigest()
+            assets.append(
+                {
+                    "id": asset_id,
+                    "name": name,
+                    "size": len(provenance_bytes) if name.endswith(".json") else 1024,
+                    "digest": f"sha256:{digest}",
+                    "state": "uploaded",
+                }
+            )
+        self.release_json.write_text(
+            json.dumps(
+                {
+                    "id": 9,
+                    "tag_name": TAG,
+                    "draft": True,
+                    "prerelease": False,
+                    "assets": assets,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        gh = self.bin_dir / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+if [[ "$*" == *'/releases/tags/'* ]]; then
+  if [ "$FAKE_GH_MODE" = public ]; then
+    cat "$FAKE_RELEASE_JSON"
+    exit 0
+  fi
+  if [ "$FAKE_GH_MODE" = network-failure ]; then
+    echo 'gh: connection reset' >&2
+    exit 1
+  fi
+  echo 'gh: Not Found (HTTP 404)' >&2
+  exit 1
+fi
+if [[ "$*" == *'/releases/9'* ]]; then
+  cat "$FAKE_RELEASE_JSON"
+  exit 0
+fi
+if [[ "$*" == *'/releases?per_page=100'* ]]; then
+  if [ "$FAKE_GH_MODE" = missing ]; then
+    echo '[[]]'
+  elif [ "$FAKE_GH_MODE" = duplicate ]; then
+    printf '[['
+    cat "$FAKE_RELEASE_JSON"
+    printf ','
+    cat "$FAKE_RELEASE_JSON"
+    printf ']]\n'
+  else
+    printf '[['
+    cat "$FAKE_RELEASE_JSON"
+    printf ']]\n'
+  fi
+  exit 0
+fi
+if [[ "$*" == *'/releases/assets/'* ]]; then
+  cat "$FAKE_PROVENANCE"
+  exit 0
+fi
+echo 'gh: connection reset' >&2
+exit 1
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _run(
+        self,
+        mode: str = "hidden-draft",
+        *extra_args: str,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.bin_dir}:{env['PATH']}",
+                "FAKE_GH_MODE": mode,
+                "FAKE_GH_LOG": str(self.log),
+                "FAKE_RELEASE_JSON": str(self.release_json),
+                "FAKE_PROVENANCE": str(self.provenance),
+                "GITHUB_API_RETRY_BASE_SECONDS": "0",
+            }
+        )
+        return subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                "--repo",
+                "Elegying/SSRVPN",
+                "--tag",
+                TAG,
+                "--commit",
+                COMMIT,
+                "--work-dir",
+                str(self.work_dir),
+                "--github-output",
+                str(self.github_output),
+                *extra_args,
+            ],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+    def test_hidden_complete_draft_is_found_and_validated_by_asset_id(self) -> None:
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertIn("--paginate --slurp", calls)
+        self.assertIn("/releases/assets/16", calls)
+        self.assertNotIn("release download", calls)
+        outputs = self.github_output.read_text(encoding="utf-8")
+        self.assertIn("release_id=9\n", outputs)
+        self.assertRegex(outputs, r"release_identity=[0-9a-f]{64}\n")
+
+    def test_exact_authorized_release_id_and_identity_can_be_revalidated(self) -> None:
+        initial = self._run()
+        self.assertEqual(initial.returncode, 0, initial.stderr)
+        outputs = dict(
+            line.split("=", 1)
+            for line in self.github_output.read_text(encoding="utf-8").splitlines()
+        )
+        self.github_output.unlink()
+        self.log.unlink()
+
+        result = self._run(
+            "exact",
+            "--expected-release-id",
+            outputs["release_id"],
+            "--expected-release-identity",
+            outputs["release_identity"],
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertIn("repos/Elegying/SSRVPN/releases/9", calls)
+        self.assertNotIn("/releases/tags/", calls)
+
+    def test_missing_release_uses_the_documented_non_error_exit(self) -> None:
+        result = self._run("missing")
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+
+    def test_public_release_uses_the_tag_endpoint_without_pagination(self) -> None:
+        result = self._run("public")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertNotIn("--paginate --slurp", calls)
+
+    def test_duplicate_hidden_releases_fail_closed(self) -> None:
+        result = self._run("duplicate")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Multiple GitHub releases", result.stderr)
+
+    def test_network_failure_is_not_treated_as_missing_release(self) -> None:
+        result = self._run("network-failure")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("connection reset", result.stderr)
+
+    def test_unfinished_asset_is_rejected_before_download(self) -> None:
+        release = json.loads(self.release_json.read_text(encoding="utf-8"))
+        release["assets"][0]["state"] = "starter"
+        self.release_json.write_text(json.dumps(release), encoding="utf-8")
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not uploaded", result.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertNotIn("/releases/assets/", calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_geoip_workflow.py
+++ b/scripts/test_geoip_workflow.py
@@ -248,6 +248,68 @@ class GeoIpWorkflowTest(unittest.TestCase):
             record,
         )
 
+    def test_check_fails_when_latest_rolls_during_verification(self) -> None:
+        raw = b"geoip-current"
+        gzipped = _stable_gzip(raw)
+        first_release = {
+            "id": 100,
+            "tag_name": "latest",
+            "name": "first",
+            "assets": [
+                {
+                    "id": 101,
+                    "name": "geoip.metadb",
+                    "browser_download_url": "https://github.com/upstream/geoip",
+                    "url": "https://api.github.com/upstream/101",
+                    "digest": f"sha256:{_sha256(raw)}",
+                },
+                {
+                    "id": 102,
+                    "name": "geoip.metadb.sha256sum",
+                    "browser_download_url": "https://github.com/upstream/checksum",
+                },
+            ],
+        }
+        second_release = {
+            **first_release,
+            "id": 200,
+            "name": "rolled",
+            "assets": [
+                {**first_release["assets"][0], "id": 201},
+                {**first_release["assets"][1], "id": 202},
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            assets = [root / name for name in ("android.gz", "macos.gz", "windows.gz")]
+            for asset_path in assets:
+                asset_path.write_bytes(gzipped)
+            source = root / "GEOIP_SOURCE.txt"
+            source.write_text(
+                SYNC.build_source_record(
+                    first_release,
+                    first_release["assets"][0],
+                    _sha256(raw),
+                    _sha256(gzipped),
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(SYNC, "ASSET_PATHS", assets), patch.object(
+                SYNC, "SOURCE_RECORD", source
+            ), patch.object(
+                SYNC,
+                "load_latest_release",
+                side_effect=[first_release, second_release],
+            ), patch.object(
+                SYNC,
+                "download",
+                side_effect=[f"{_sha256(raw)}  geoip.metadb\n".encode(), raw],
+            ):
+                with self.assertRaisesRegex(SystemExit, "changed during verification"):
+                    SYNC.sync(check=True)
+
     def test_clean_bootstrap_ignores_a_deleted_upstream_asset(self) -> None:
         raw = b"verified upstream GeoIP payload"
         gzipped = _stable_gzip(raw)
@@ -702,11 +764,19 @@ cp "$FAKE_MIRROR_FILE" "$output"
                         upload=True,
                     )
 
-    def test_freshness_workflow_opens_scoped_immutable_update_prs(self) -> None:
+    def test_release_geoip_refresh_is_manual_and_fail_closed(self) -> None:
         workflow = (ROOT / ".github/workflows/maintenance.yml").read_text(
             encoding="utf-8"
         )
 
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("\n  schedule:\n", workflow)
+        self.assertNotIn("github.event_name == 'schedule'", workflow)
+        self.assertIn(
+            "github.event_name == 'workflow_dispatch' && "
+            "inputs.task == 'geoip-refresh'",
+            workflow,
+        )
         self.assertIn("contents: write", workflow)
         self.assertIn("pull-requests: write", workflow)
         self.assertIn("python3 scripts/sync-geoip-metadb.py", workflow)
@@ -744,6 +814,33 @@ cp "$FAKE_MIRROR_FILE" "$output"
             "SSRVPN_Windows",
         ):
             self.assertIn(path, sync_script)
+
+        release_workflow = (ROOT / ".github/workflows/release.yml").read_text(
+            encoding="utf-8"
+        )
+        freshness_check = "python3 scripts/sync-geoip-metadb.py --check"
+        self.assertIn("Require the latest GeoIP snapshot", release_workflow)
+        self.assertIn(
+            "release_retry: ${{ steps.source.outputs.release_retry }}",
+            release_workflow,
+        )
+        self.assertIn(
+            'echo "release_retry=true" >> "$GITHUB_OUTPUT"',
+            release_workflow,
+        )
+        self.assertIn(
+            "if: needs.validate-source.outputs.release_retry != 'true'",
+            release_workflow,
+        )
+        self.assertIn(freshness_check, release_workflow)
+        self.assertLess(
+            release_workflow.index("bash scripts/bootstrap-core-assets.sh"),
+            release_workflow.index(freshness_check),
+        )
+        self.assertLess(
+            release_workflow.index(freshness_check),
+            release_workflow.index("name: Upload verified core assets"),
+        )
 
     def test_existing_geoip_pull_request_state_policy(self) -> None:
         policy_path = ROOT / "scripts/geoip-pr-state-policy.py"

--- a/scripts/test_release_tooling_entrypoint.py
+++ b/scripts/test_release_tooling_entrypoint.py
@@ -127,7 +127,8 @@ python3 -m unittest \\
         publish = workflow[workflow.index("  publish:\n") :]
         publish_header = publish[: publish.index("    steps:\n")]
         self.assertIn(
-            "    needs: [shared-test, build-android, build-macos, build-windows]\n",
+            "    needs: [validate-source, shared-test, build-android, "
+            "build-macos, build-windows]\n",
             publish_header,
         )
 

--- a/scripts/test_reuse_github_release_assets.py
+++ b/scripts/test_reuse_github_release_assets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
 import os
 import subprocess
@@ -18,6 +19,13 @@ NAMES = (
 )
 CERT = "ab" * 32
 COMMIT = "c" * 40
+VALIDATOR_PATH = ROOT / "scripts" / "validate-existing-release-retry.py"
+VALIDATOR_SPEC = importlib.util.spec_from_file_location(
+    "existing_release_retry_validator", VALIDATOR_PATH
+)
+assert VALIDATOR_SPEC and VALIDATOR_SPEC.loader
+VALIDATOR = importlib.util.module_from_spec(VALIDATOR_SPEC)
+VALIDATOR_SPEC.loader.exec_module(VALIDATOR)
 
 
 class ReuseGithubReleaseAssetsTest(unittest.TestCase):
@@ -200,7 +208,14 @@ fi
             encoding="utf-8",
         )
 
-    def _run(self, mode: str) -> subprocess.CompletedProcess[str]:
+    def _run(
+        self,
+        mode: str,
+        *,
+        expected_release_id: str | None = None,
+        expected_release_identity: str | None = None,
+        require_authorized_retry: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
             {
@@ -221,6 +236,13 @@ fi
                 "ANDROID_HOME": str(self.android_home),
                 "ANDROID_RELEASE_CERT_SHA256": CERT,
             }
+        )
+        if expected_release_id is not None:
+            env["EXPECTED_RELEASE_RETRY_ID"] = expected_release_id
+        if expected_release_identity is not None:
+            env["EXPECTED_RELEASE_RETRY_IDENTITY"] = expected_release_identity
+        env["REQUIRE_AUTHORIZED_RELEASE_RETRY"] = (
+            "true" if require_authorized_retry else "false"
         )
         return subprocess.run(
             ["bash", str(SCRIPT), str(self.artifacts)],
@@ -269,6 +291,71 @@ fi
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertTrue(self.delete_marker.is_file())
         self.assertEqual(self.output.read_text(), "exists=false\n")
+
+    def test_authorized_retry_missing_release_fails_closed(self) -> None:
+        result = self._run(
+            "missing",
+            expected_release_id="42",
+            expected_release_identity="f" * 64,
+            require_authorized_retry=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("authorized release", result.stderr)
+
+    def test_authorized_retry_rejects_replaced_release_identity(self) -> None:
+        self._write_release(draft=True)
+
+        result = self._run(
+            "found",
+            expected_release_id="42",
+            expected_release_identity="f" * 64,
+            require_authorized_retry=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("identity", result.stderr)
+        self.assertFalse(self.delete_marker.exists())
+
+    def test_authorized_retry_never_deletes_an_incomplete_draft(self) -> None:
+        self._write_release(draft=True, missing="SSRVPN.dmg")
+
+        result = self._run(
+            "found",
+            expected_release_id="42",
+            expected_release_identity="f" * 64,
+            require_authorized_retry=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("authorized release", result.stderr)
+        self.assertFalse(self.delete_marker.exists())
+
+    def test_authorized_retry_reuses_the_exact_validated_release(self) -> None:
+        self._write_release(draft=True)
+        release = json.loads(self.release_json.read_text(encoding="utf-8"))
+        identity = VALIDATOR.release_identity_digest(
+            release,
+            expected_tag="v3.2.0",
+        )
+
+        result = self._run(
+            "found",
+            expected_release_id="42",
+            expected_release_identity=identity,
+            require_authorized_retry=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("exists=true", self.output.read_text(encoding="utf-8"))
+
+    def test_authorized_retry_requires_cross_job_identity_outputs(self) -> None:
+        self._write_release(draft=True)
+
+        result = self._run("found", require_authorized_retry=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("identity is incomplete", result.stderr)
 
     def test_hidden_partial_draft_is_discovered_and_deleted_by_release_id(self) -> None:
         self._write_release(draft=True, missing="SSRVPN.dmg")

--- a/scripts/test_validate_existing_release_retry.py
+++ b/scripts/test_validate_existing_release_retry.py
@@ -24,17 +24,25 @@ def release(
     draft: bool = False,
 ) -> dict:
     assets = []
-    for name in sorted(MODULE.REQUIRED_ASSETS):
+    for asset_id, name in enumerate(sorted(MODULE.REQUIRED_ASSETS), start=1):
         if name == missing:
             continue
         assets.append(
             {
+                "id": asset_id,
                 "name": name,
                 "size": 64 if name.endswith(".sha256") else 1024,
                 "digest": "sha256:" + "a" * 64,
+                "state": "uploaded",
             }
         )
-    return {"draft": draft, "prerelease": prerelease, "assets": assets}
+    return {
+        "id": 100,
+        "tag_name": "v3.2.0",
+        "draft": draft,
+        "prerelease": prerelease,
+        "assets": assets,
+    }
 
 
 def provenance(**overrides: object) -> dict:
@@ -70,6 +78,44 @@ class ExistingReleaseRetryTest(unittest.TestCase):
                 expected_tag="v3.2.0",
                 expected_commit=COMMIT,
             )
+
+    def test_release_tag_name_must_match_the_retry_tag(self) -> None:
+        data = release(draft=True)
+        data["tag_name"] = "v3.1.0"
+
+        with self.assertRaisesRegex(ValueError, "tag does not match"):
+            MODULE.validate_release_metadata(
+                data,
+                provenance(),
+                expected_tag="v3.2.0",
+                expected_commit=COMMIT,
+            )
+
+    def test_unfinished_release_asset_cannot_authorize_retry(self) -> None:
+        data = release(draft=True)
+        data["assets"][0]["state"] = "starter"
+
+        with self.assertRaisesRegex(ValueError, "not uploaded"):
+            MODULE.validate_release_metadata(
+                data,
+                provenance(),
+                expected_tag="v3.2.0",
+                expected_commit=COMMIT,
+            )
+
+    def test_release_identity_tracks_assets_but_allows_publication(self) -> None:
+        draft = release(draft=True)
+        public = release(draft=False)
+
+        self.assertEqual(
+            MODULE.release_identity_digest(draft, expected_tag="v3.2.0"),
+            MODULE.release_identity_digest(public, expected_tag="v3.2.0"),
+        )
+        public["assets"][0]["id"] += 100
+        self.assertNotEqual(
+            MODULE.release_identity_digest(draft, expected_tag="v3.2.0"),
+            MODULE.release_identity_digest(public, expected_tag="v3.2.0"),
+        )
 
     def test_downloaded_provenance_must_match_the_github_asset_digest(self) -> None:
         payload = json.dumps(provenance(), sort_keys=True).encode("utf-8")

--- a/scripts/test_verify_release_transition.py
+++ b/scripts/test_verify_release_transition.py
@@ -72,15 +72,30 @@ class VerifyReleaseTransitionTest(unittest.TestCase):
         self.assertIn("--target-build-code", workflow)
         self.assertIn("--current-version", workflow)
         self.assertIn('if [ "$release_commit" != "$main_tip" ]', workflow)
-        self.assertIn("validate-existing-release-retry.py", workflow)
-        self.assertIn("releases/tags/$GITHUB_REF_NAME", workflow)
+        self.assertIn("authorize-existing-release-retry.py", workflow)
+        self.assertIn('--repo "$GITHUB_REPOSITORY"', workflow)
+        self.assertIn('--tag "$GITHUB_REF_NAME"', workflow)
+        self.assertIn('--commit "$release_commit"', workflow)
+        self.assertIn('--work-dir "$RUNNER_TEMP/existing-release-retry"', workflow)
+        self.assertIn('--github-output "$GITHUB_OUTPUT"', workflow)
+        self.assertIn(
+            "release_id: ${{ steps.source.outputs.release_id }}", workflow
+        )
+        self.assertIn(
+            "release_identity: ${{ steps.source.outputs.release_identity }}",
+            workflow,
+        )
         self.assertIn("SSRVPN-release-provenance.json", workflow)
         self.assertIn("generate-release-provenance.py", workflow)
-        self.assertIn('--expected-commit "$release_commit"', workflow)
         self.assertIn("--ignore-existing", workflow)
         self.assertIn('cmp "$file" "$downloaded"', workflow)
         self.assertNotIn("Sync latest geoip.metadb", workflow)
-        self.assertNotIn("scripts/sync-geoip-metadb.py", workflow)
+        self.assertIn("Require the latest GeoIP snapshot", workflow)
+        self.assertIn("scripts/sync-geoip-metadb.py --check", workflow)
+        self.assertNotRegex(
+            workflow,
+            r"(?m)^\s*python3 scripts/sync-geoip-metadb\.py\s*$",
+        )
         self.assertGreaterEqual(
             workflow.count("scripts/run-flutter-coverage.sh"),
             4,
@@ -112,7 +127,50 @@ class VerifyReleaseTransitionTest(unittest.TestCase):
         self.assertLess(validate, retry_reuse)
         self.assertLess(retry_reuse, github_release)
         self.assertIn("scripts/reuse-github-release-assets.sh", workflow)
-        self.assertIn("steps.existing_release.outputs.exists != 'true'", workflow)
+        self.assertIn(
+            "EXPECTED_RELEASE_RETRY_ID: "
+            "${{ needs.validate-source.outputs.release_id }}",
+            workflow,
+        )
+        self.assertIn(
+            "EXPECTED_RELEASE_RETRY_IDENTITY: "
+            "${{ needs.validate-source.outputs.release_identity }}",
+            workflow,
+        )
+        self.assertIn(
+            "REQUIRE_AUTHORIZED_RELEASE_RETRY: "
+            "${{ needs.validate-source.outputs.release_retry }}",
+            workflow,
+        )
+        reuse_start = workflow.index("Reuse an existing GitHub release on retry")
+        reuse_end = workflow.index("Generate release provenance", reuse_start)
+        reuse_step = workflow[reuse_start:reuse_end]
+        for expected in (
+            "EXPECTED_RELEASE_RETRY_ID:",
+            "EXPECTED_RELEASE_RETRY_IDENTITY:",
+            "REQUIRE_AUTHORIZED_RELEASE_RETRY:",
+        ):
+            self.assertIn(expected, reuse_step)
+        manifest_start = workflow.index("Generate verified OSS update manifest")
+        manifest_end = workflow.index("Reject a public-channel rollback", manifest_start)
+        manifest_step = workflow[manifest_start:manifest_end]
+        self.assertNotIn("EXPECTED_RELEASE_RETRY", manifest_step)
+        self.assertNotIn("REQUIRE_AUTHORIZED_RELEASE_RETRY", manifest_step)
+        self.assertGreaterEqual(
+            workflow.count('--expected-release-id "$EXPECTED_RELEASE_RETRY_ID"'),
+            2,
+        )
+        self.assertGreaterEqual(
+            workflow.count(
+                '--expected-release-identity "$EXPECTED_RELEASE_RETRY_IDENTITY"'
+            ),
+            2,
+        )
+        self.assertIn(
+            "needs.validate-source.outputs.release_retry != 'true' && "
+            "steps.existing_release.outputs.exists != 'true'",
+            workflow,
+        )
         oss_publish = workflow.index("Publish immutable release to OSS")
         github_finalize = workflow.index('gh release edit "$tag" --draft=false')
         self.assertLess(github_release, oss_publish)
@@ -123,15 +181,48 @@ class VerifyReleaseTransitionTest(unittest.TestCase):
         self.assertIn("OSS_PRESERVE_BACKUP=1", workflow)
         self.assertIn('--restore "$backup_dir"', workflow)
         self.assertIn("--prerelease=false --latest", workflow)
+        self.assertIn(
+            'gh api --method PATCH "repos/$GITHUB_REPOSITORY/releases/'
+            '$EXPECTED_RELEASE_RETRY_ID"',
+            workflow,
+        )
         self.assertIn("scripts/wait-for-github-release-public.sh", workflow)
         self.assertRegex(
             workflow,
             r'scripts/wait-for-github-release-public\.sh\s+\\?\s*'
-            r'"\$tag" 5 attempted',
+            r'"\$tag" 5 attempted "\$poll_release_id"',
         )
         publication_poll = WAIT_FOR_PUBLIC_RELEASE.read_text(encoding="utf-8")
         self.assertIn("--json isDraft,isPrerelease", publication_poll)
         self.assertIn("Preserve OSS recovery backup", workflow)
+
+        promote_step_start = workflow.index(
+            "Promote OSS public channel and finalize GitHub Release"
+        )
+        promote_step_end = workflow.index(
+            "Verify published GitHub and OSS channels", promote_step_start
+        )
+        promote_step = workflow[promote_step_start:promote_step_end]
+        first_identity = promote_step.index("pre-finalize-release-retry")
+        oss_promotion = promote_step.index(
+            "scripts/promote-oss-public-channel.sh"
+        )
+        second_identity = promote_step.index("pre-publish-release-retry")
+        exact_patch = promote_step.index("gh api --method PATCH")
+        public_poll = promote_step.index("wait-for-github-release-public.sh")
+        third_identity = promote_step.index("post-public-release-retry")
+        discard_backup = promote_step.index('rm -rf "$backup_dir"')
+        self.assertLess(first_identity, oss_promotion)
+        self.assertLess(oss_promotion, second_identity)
+        self.assertLess(second_identity, exact_patch)
+        self.assertLess(exact_patch, public_poll)
+        self.assertLess(public_poll, third_identity)
+        self.assertLess(third_identity, discard_backup)
+        post_oss_guard = promote_step[oss_promotion:exact_patch]
+        self.assertIn(
+            'scripts/promote-oss-public-channel.sh --restore "$backup_dir"',
+            post_oss_guard,
+        )
 
         published_verify = workflow.index(
             "Verify published GitHub and OSS channels"

--- a/scripts/test_wait_for_github_release_public.py
+++ b/scripts/test_wait_for_github_release_public.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/wait-for-github-release-public.sh"
+
+
+class WaitForGithubReleasePublicTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.log = self.root / "gh.log"
+        gh = self.root / "gh"
+        gh.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+if [ "$1" = api ]; then
+  if [ "$FAKE_GH_MODE" = exact-public ]; then
+    printf '42\tv3.2.0\tfalse\tfalse\n'
+    exit 0
+  fi
+  echo 'gh: Not Found (HTTP 404)' >&2
+  exit 1
+fi
+if [ "$1" = release ] && [ "$FAKE_GH_MODE" = tag-public ]; then
+  printf 'false\tfalse\n'
+  exit 0
+fi
+exit 1
+""",
+            encoding="utf-8",
+        )
+        gh.chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _run(self, mode: str, expected_id: str = "") -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.root}:{env['PATH']}",
+                "FAKE_GH_LOG": str(self.log),
+                "FAKE_GH_MODE": mode,
+                "GITHUB_REPOSITORY": "Elegying/SSRVPN",
+            }
+        )
+        return subprocess.run(
+            ["bash", str(SCRIPT), "v3.2.0", "1", "attempted", expected_id],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+    def test_exact_release_id_becomes_public(self) -> None:
+        result = self._run("exact-public", "42")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertIn("repos/Elegying/SSRVPN/releases/42", calls)
+        self.assertNotIn("release view", calls)
+
+    def test_same_tag_replacement_cannot_satisfy_an_exact_id_poll(self) -> None:
+        result = self._run("tag-public", "42")
+
+        self.assertEqual(result.returncode, 87)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertIn("repos/Elegying/SSRVPN/releases/42", calls)
+        self.assertNotIn("release view", calls)
+
+    def test_new_release_keeps_the_tag_polling_path(self) -> None:
+        result = self._run("tag-public")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text(encoding="utf-8")
+        self.assertIn("release view v3.2.0", calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-existing-release-retry.py
+++ b/scripts/validate-existing-release-retry.py
@@ -29,6 +29,99 @@ CANONICAL_BINARIES = {
 }
 
 
+def validate_release_asset_metadata(
+    release: object,
+    *,
+    expected_tag: str,
+) -> dict[str, dict[str, object]]:
+    if not isinstance(release, dict):
+        raise ValueError("GitHub release response is not an object")
+    if release.get("tag_name") != expected_tag:
+        raise ValueError("GitHub release tag does not match the retry tag")
+    release_id = release.get("id")
+    if isinstance(release_id, bool) or not isinstance(release_id, int) or release_id <= 0:
+        raise ValueError("GitHub release ID is invalid")
+    if not isinstance(release.get("draft"), bool):
+        raise ValueError("GitHub release draft state is invalid")
+    if not isinstance(release.get("prerelease"), bool):
+        raise ValueError("GitHub release prerelease state is invalid")
+    if release["prerelease"] is True:
+        raise ValueError("prerelease cannot be retried into the stable channel")
+
+    raw_assets = release.get("assets")
+    if not isinstance(raw_assets, list):
+        raise ValueError("GitHub release has no asset list")
+    assets: dict[str, dict[str, object]] = {}
+    asset_ids: set[int] = set()
+    for item in raw_assets:
+        if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            raise ValueError("GitHub release has invalid assets")
+        name = item["name"]
+        if name in assets:
+            raise ValueError(f"GitHub release asset is duplicated: {name}")
+        assets[name] = item
+
+    missing = sorted(REQUIRED_ASSETS - set(assets))
+    if missing:
+        raise ValueError("GitHub release is incomplete: " + ", ".join(missing))
+    unexpected = sorted(set(assets) - REQUIRED_ASSETS)
+    if unexpected:
+        raise ValueError(
+            "GitHub release has unexpected assets: " + ", ".join(unexpected)
+        )
+
+    for name in sorted(REQUIRED_ASSETS):
+        asset = assets[name]
+        if asset.get("state") != "uploaded":
+            raise ValueError(f"GitHub release asset is not uploaded: {name}")
+        asset_id = asset.get("id")
+        if (
+            isinstance(asset_id, bool)
+            or not isinstance(asset_id, int)
+            or asset_id <= 0
+            or asset_id in asset_ids
+        ):
+            raise ValueError(f"GitHub release asset ID is invalid: {name}")
+        asset_ids.add(asset_id)
+        size = asset.get("size")
+        limit = (
+            64 * 1024
+            if name.endswith(".sha256") or name.endswith(".json")
+            else 300 * 1024 * 1024
+        )
+        if isinstance(size, bool) or not isinstance(size, int) or size <= 0 or size > limit:
+            raise ValueError(f"GitHub release asset has invalid size: {name}")
+        digest = str(asset.get("digest") or "")
+        if SHA256_DIGEST.fullmatch(digest) is None:
+            raise ValueError(f"GitHub release asset has no trusted digest: {name}")
+    return assets
+
+
+def release_identity_digest(release: object, *, expected_tag: str) -> str:
+    assets = validate_release_asset_metadata(release, expected_tag=expected_tag)
+    assert isinstance(release, dict)
+    identity = {
+        "id": release["id"],
+        "tag_name": release["tag_name"],
+        "assets": [
+            {
+                "id": assets[name]["id"],
+                "name": name,
+                "size": assets[name]["size"],
+                "digest": assets[name]["digest"],
+                "state": assets[name]["state"],
+            }
+            for name in sorted(REQUIRED_ASSETS)
+        ],
+    }
+    canonical = json.dumps(
+        identity,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
 def validate_downloaded_asset_digest(
     release: object,
     asset_name: str,
@@ -56,45 +149,7 @@ def validate_release_metadata(
     expected_tag: str,
     expected_commit: str,
 ) -> None:
-    if not isinstance(release, dict):
-        raise ValueError("GitHub release response is not an object")
-    if not isinstance(release.get("draft"), bool):
-        raise ValueError("GitHub release draft state is invalid")
-    if not isinstance(release.get("prerelease"), bool):
-        raise ValueError("GitHub release prerelease state is invalid")
-    if release["prerelease"] is True:
-        raise ValueError("prerelease cannot be retried into the stable channel")
-    raw_assets = release.get("assets")
-    if not isinstance(raw_assets, list):
-        raise ValueError("GitHub release has no asset list")
-    assets = {
-        item.get("name"): item
-        for item in raw_assets
-        if isinstance(item, dict) and isinstance(item.get("name"), str)
-    }
-    if len(assets) != len(raw_assets):
-        raise ValueError("GitHub release has invalid or duplicated assets")
-    missing = sorted(REQUIRED_ASSETS - set(assets))
-    if missing:
-        raise ValueError("GitHub release is incomplete: " + ", ".join(missing))
-    unexpected = sorted(set(assets) - REQUIRED_ASSETS)
-    if unexpected:
-        raise ValueError(
-            "GitHub release has unexpected assets: " + ", ".join(unexpected)
-        )
-    for name in sorted(REQUIRED_ASSETS):
-        asset = assets[name]
-        size = int(asset.get("size") or 0)
-        limit = (
-            64 * 1024
-            if name.endswith(".sha256") or name.endswith(".json")
-            else 300 * 1024 * 1024
-        )
-        if size <= 0 or size > limit:
-            raise ValueError(f"GitHub release asset has invalid size: {name}")
-        digest = str(asset.get("digest") or "")
-        if SHA256_DIGEST.fullmatch(digest) is None:
-            raise ValueError(f"GitHub release asset has no trusted digest: {name}")
+    assets = validate_release_asset_metadata(release, expected_tag=expected_tag)
     if not isinstance(provenance, dict) or provenance.get("schema") != 1:
         raise ValueError("release provenance is invalid")
     if provenance.get("tag") != expected_tag:

--- a/scripts/wait-for-github-release-public.sh
+++ b/scripts/wait-for-github-release-public.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-tag=${1:?Usage: wait-for-github-release-public.sh <tag> [attempts] [attempted|not-attempted]}
+tag=${1:?Usage: wait-for-github-release-public.sh <tag> [attempts] [attempted|not-attempted] [expected-release-id]}
 attempts=${2:-5}
 mutation_state=${3:-attempted}
+expected_release_id=${4:-}
 
 if ! [[ $attempts =~ ^[1-9][0-9]*$ ]]; then
   echo "attempts must be a positive integer" >&2
@@ -13,22 +14,47 @@ if [[ $mutation_state != attempted && $mutation_state != not-attempted ]]; then
   echo "mutation state must be attempted or not-attempted" >&2
   exit 64
 fi
+if [[ -n $expected_release_id && ! $expected_release_id =~ ^[1-9][0-9]*$ ]]; then
+  echo "expected release ID must be a positive integer" >&2
+  exit 64
+fi
+if [[ -n $expected_release_id && -z ${GITHUB_REPOSITORY:-} ]]; then
+  echo "GITHUB_REPOSITORY is required for an exact release poll" >&2
+  exit 64
+fi
 
 release_state=""
 for ((attempt = 1; attempt <= attempts; attempt++)); do
-  if release_state="$(gh release view "$tag" \
-    --json isDraft,isPrerelease \
-    --jq '[.isDraft, .isPrerelease] | @tsv' 2>/dev/null)"; then
+  if [[ -n $expected_release_id ]]; then
+    release_state="$(gh api \
+      "repos/$GITHUB_REPOSITORY/releases/$expected_release_id" \
+      --jq '[.id, .tag_name, .draft, .prerelease] | @tsv' \
+      2>/dev/null)" || release_state=""
     case "$release_state" in
-      $'false\tfalse')
+      "${expected_release_id}"$'\t'"${tag}"$'\tfalse\tfalse')
         printf '%s\n' "$release_state"
         exit 0
         ;;
-      $'true\tfalse' | $'false\ttrue' | $'true\ttrue') ;;
+      "${expected_release_id}"$'\t'"${tag}"$'\ttrue\tfalse' | \
+        "${expected_release_id}"$'\t'"${tag}"$'\tfalse\ttrue' | \
+        "${expected_release_id}"$'\t'"${tag}"$'\ttrue\ttrue') ;;
       *) release_state="" ;;
     esac
   else
-    release_state=""
+    if release_state="$(gh release view "$tag" \
+      --json isDraft,isPrerelease \
+      --jq '[.isDraft, .isPrerelease] | @tsv' 2>/dev/null)"; then
+      case "$release_state" in
+        $'false\tfalse')
+          printf '%s\n' "$release_state"
+          exit 0
+          ;;
+        $'true\tfalse' | $'false\ttrue' | $'true\ttrue') ;;
+        *) release_state="" ;;
+      esac
+    else
+      release_state=""
+    fi
   fi
 
   if ((attempt < attempts)); then


### PR DESCRIPTION
## 变更摘要\n\n- 移除 GeoIP 每日自动检查，仅保留正式发版前的手动刷新入口\n- 新版本构建前只读校验 GeoIP 是否为上游最新；过期时失败关闭，要求先合并刷新 PR\n- 对已有完整 Release 的重跑锁定数字 Release ID、资产 ID、大小、摘要、状态和 provenance，防止重跑期间对象被替换\n- 在 OSS 提升前后、GitHub 发布后及最终核验阶段重复校验同一 Release 身份\n- 更新维护说明、核心资产说明、发版清单和 ADR-011\n\n## 验证\n\n- make verify\n  - 发布工具：267/267\n  - shared：469\n  - Android：218\n  - macOS：243\n  - Windows：209（非 Windows 环境正常跳过 8 项）\n  - 所有覆盖率门槛通过\n- actionlint\n- shellcheck scripts/reuse-github-release-assets.sh scripts/wait-for-github-release-public.sh\n- git diff --check\n- 实际运行 GeoIP 只读检查：当前仓库快照相对上游已过期并按预期返回失败，且未修改工作树\n\n## 发版说明\n\n本 PR 不修改版本号、不创建标签、也不发布软件。下一次正式发版前需手动运行 Maintenance > geoip-refresh，并先合并生成的资产 PR。