### PR TITLE
ci: automate pre-release GeoIP preparation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,47 @@
+name: Prepare Release
+run-name: Prepare ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: New release tag matching the app version, for example v4.0.2
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ssrvpn-release-preparation
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    name: Refresh GeoIP, verify, tag, and release
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ inputs.tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Prepare and start the release
+        id: prepare
+        run: bash scripts/prepare-release.sh "$RELEASE_TAG"
+
+      - name: Report release orchestration
+        if: always()
+        env:
+          RELEASE_RUN_URL: ${{ steps.prepare.outputs.release_run_url }}
+        run: |
+          if [ -n "$RELEASE_RUN_URL" ]; then
+            echo "Release workflow: $RELEASE_RUN_URL" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           if ! python3 scripts/sync-geoip-metadb.py --check; then
-            echo "::error::GeoIP is stale. Run Maintenance > geoip-refresh, merge its PR, then create a new release tag."
+            echo "::error::GeoIP is stale. Start new releases through Prepare Release, or use Maintenance > geoip-refresh as the manual fallback before creating a new tag."
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 改进
 
+- 正式发版新增一键 `Prepare Release` 编排：自动刷新并固定 GeoIP，临时分支 CI 与合并后精确 `main` CI 均通过后才创建不可变标签并启动既有 Release；任一前置检查失败都会停在标签之前，标签后的发布失败则保留原标签供安全重试。
 - 共享更新服务按稳定入口、下载/取消、校验后发布/恢复拆分；macOS 原生核心支持、单实例租约和窗口恢复从 `AppDelegate` 迁出；Windows 系统代理快照与取消模型迁入同一 Dart library 的独立 part。
 - 新增职责回流与规模护栏，固定更新服务、macOS 原生支持、Windows 系统代理、Android VPN Service 和 Windows 安装恢复的渐进维护边界；高风险事务执行顺序保持不变。
 - 全部受版本控制 Dart 源码纳入格式门禁，全部 Shell 脚本纳入 ShellCheck；共享包和三端启用严格类型分析并清理现有告警。

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Pull Request 还会执行 GitHub Dependency Review；新增中等及以上已知
 
 ## 发布
 
-匹配 `v*` 的 tag 会触发 GitHub Actions 构建并上传三端产物及 SHA-256。macOS 始终生成 ad-hoc、未公证 DMG，Windows 只生成未签名安装器；仓库不保留付费桌面签名自动化。发布前必须保持 `main`、版本号、CHANGELOG 与资产清单一致，并在发布后重新下载校验。
+正式发版从 GitHub Actions 的 `Prepare Release` 启动：输入与源码版本一致的新 `v*` tag 后，工作流会自动刷新 GeoIP、验证临时分支、合并来源记录、复验精确 `main`、创建标签并启动 `Release`。macOS 始终生成 ad-hoc、未公证 DMG，Windows 只生成未签名安装器；仓库不保留付费桌面签名自动化。发布前必须保持 `main`、版本号、CHANGELOG 与资产清单一致，并在发布后重新下载校验。
 
 详细流程见 [发布检查清单](docs/RELEASE_CHECKLIST.zh-CN.md)、[免费分发与签名说明](docs/RELEASE_SIGNING.md) 与 [OSS 运维手册](docs/OSS_RELEASE_OPERATIONS.zh-CN.md)。
 

--- a/docs/CORE_ASSETS.md
+++ b/docs/CORE_ASSETS.md
@@ -62,13 +62,15 @@ the `Elegying/SSRVPN/releases/download/core-assets-v1/` path and verifies both
 hashes before installing the same bytes for all three platforms. It never needs
 the upstream project's mutable Release during a normal CI or release build.
 
-The `Maintenance` workflow's manual `geoip-refresh` task is the first required
-release-preparation step. It independently downloads and verifies the latest
-upstream checksum, API digest, and database, produces deterministic gzip, uploads
-a missing content-addressed mirror asset without overwrite, and reads it back
-through the public bootstrap URL. Only after that verification succeeds may it
-open a uniquely named PR changing `GEOIP_SOURCE.txt`; merge that PR before
-creating the application release tag. There is no scheduled GeoIP freshness job.
+The `Prepare Release` workflow is the normal release entrypoint. Before any tag
+exists, it independently downloads and verifies the latest upstream checksum,
+API digest, and database, produces deterministic gzip, uploads a missing
+content-addressed mirror asset without overwrite, and reads it back through the
+public bootstrap URL. When the source record changes, it verifies the temporary
+branch, creates and rebase-merges a PR changing only `GEOIP_SOURCE.txt`, reruns CI
+on the exact merged `main`, and only then creates the application tag and starts
+`release.yml`. `Maintenance > geoip-refresh` retains the same mirror boundary as a
+manual recovery entrypoint. There is no scheduled GeoIP freshness job.
 An expired Asset ID in the previous upstream provenance therefore cannot block
 the manual refresh. The trust boundary disables redirects on authenticated API
 calls; mirror readback permits only GitHub's HTTPS download/CDN hosts and strips
@@ -94,7 +96,9 @@ before the numeric-ID PATCH, and again after the public-state poll before the OS
 recovery backup is discarded. These trust boundaries are recorded in
 [ADR-005](decisions/005-content-addressed-geoip-mirror.md), and the release-only
 refresh policy is recorded in
-[ADR-011](decisions/011-release-gated-geoip-refresh.md).
+[ADR-011](decisions/011-release-gated-geoip-refresh.md), superseded for release
+orchestration by
+[ADR-012](decisions/012-automatic-release-preparation.md).
 
 `scripts/verify-core-assets.sh` checks fixed SHA256 hashes, macOS decompressed
 executable equivalence, and bundled GeoIP databases. The same checks run in CI

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -56,8 +56,10 @@ This guide keeps local development, GitHub automation, and releases aligned.
 - Keep pull-request and branch checks in `ci.yml`.
 - Keep tag-triggered publishing in `release.yml`.
 - Add manual operator tasks to `maintenance.yml`; prefer a new task over another
-  workflow file. GeoIP refresh is deliberately manual and release-gated, so it
-  must not gain a `schedule` trigger.
+  workflow file. `prepare-release.yml` is intentionally separate because it owns
+  the write permissions, global concurrency lock, exact-main verification, tag
+  creation, and handoff to `release.yml`. GeoIP must not regain a `schedule`
+  trigger; `Maintenance > geoip-refresh` remains only a manual recovery path.
 - Split a workflow only when it needs an incompatible trigger, permission boundary,
   or concurrency lock.
 - Pin every third-party action to a full commit SHA. Dependency Review on pull requests
@@ -142,12 +144,9 @@ and run both platform suites for shared desktop changes.
 
 ## Release Checklist
 
-1. Manually run `Maintenance` with `geoip-refresh`, review and merge the generated
-   source-record PR, and wait for the resulting `main` CI to pass. Do this before
-   creating the application release tag.
-2. Confirm `main` CI is green.
-3. Review `CHANGELOG.md` and move relevant entries from `Unreleased` to the target version.
-4. Verify the pinned assets and prove that GeoIP still matches upstream `latest`:
+1. Update the application version on `main`. Review `CHANGELOG.md` and move
+   relevant entries from `Unreleased` to the target version.
+2. Verify the pinned assets and prove that GeoIP still matches upstream `latest`:
 
    ```bash
    make assets
@@ -159,18 +158,22 @@ and run both platform suites for shared desktop changes.
    downloaded content. A `latest` rollover during verification is a failure, not
    permission to accept either snapshot.
 
-5. Verify the free Android self-signed keystore secrets are available. Desktop
+3. Verify the free Android self-signed keystore secrets are available. Desktop
    releases always use the documented free path: macOS ad-hoc without
    notarization and Windows without Authenticode. Do not add Apple/Microsoft
    certificate secrets or paid-signing branches. See `docs/RELEASE_SIGNING.md`.
-6. Create and push a version tag:
-
-   ```bash
-   git tag -a vX.Y.Z -m "SSRVPN vX.Y.Z"
-   git push origin vX.Y.Z
-   ```
-
-7. Watch the `Release` workflow. New releases fail before platform builds if the
+4. Start GitHub Actions `Prepare Release` with the matching new `vX.Y.Z` tag. It
+   automatically refreshes GeoIP, verifies the temporary branch, creates and
+   rebase-merges the source-record PR, reruns CI on the exact merged `main`,
+   creates the annotated tag, and dispatches `Release`. Do not create the tag
+   manually first.
+5. Confirm both preparation CI runs are green and watch the automatic handoff
+   to the `Release` workflow. The protected branch still requires the existing six
+   GitHub Actions checks; the orchestrator does not bypass or impersonate them.
+   If automated preparation is unavailable, use `Maintenance > geoip-refresh` as
+   the manual fallback, merge its PR, wait for `main` CI, and only then create the
+   application tag.
+6. New releases fail before platform builds if the
    reviewed GeoIP pointer is no longer current; the workflow never rewrites a tag.
    An existing-release retry bypasses this live check only after the exact tag,
    completed asset states, IDs, digests, commit, and provenance all validate.
@@ -180,9 +183,9 @@ and run both platform suites for shared desktop changes.
    ID while allowing only the expected draft-to-public state transition. The asset
    identity is rechecked after OSS promotion and after the public-state poll before
    the recovery backup is discarded.
-8. Download artifacts, verify checksums, and optionally run `scripts/check-release-assets.sh vX.Y.Z`.
-9. Confirm the Windows build log includes the native registry-sandbox proxy recovery test and the real `SSRVPN_Setup.exe` install/uninstall smoke test, not only packaging and static checks.
-10. Smoke test at least one install/run path per platform before announcing.
+7. Download artifacts, verify checksums, and optionally run `scripts/check-release-assets.sh vX.Y.Z`.
+8. Confirm the Windows build log includes the native registry-sandbox proxy recovery test and the real `SSRVPN_Setup.exe` install/uninstall smoke test, not only packaging and static checks.
+9. Smoke test at least one install/run path per platform before announcing.
 
 ## Online/Offline Consistency
 

--- a/docs/OWNER_GUIDE.zh-CN.md
+++ b/docs/OWNER_GUIDE.zh-CN.md
@@ -57,7 +57,7 @@ make verify
 3. 修改代码和文档。
 4. 跑测试和必要构建。
 5. 提交到 GitHub。
-6. 需要发布时打 tag，让 GitHub Actions 生成三端产物。
+6. 需要发布时运行 GitHub Actions 的 `Prepare Release`，让它在全部检查通过后自动打 tag 并生成三端产物。
 
 ## 什么文件不要手动动
 
@@ -85,14 +85,12 @@ GitHub Release workflow 必须继续使用同一套签名 secrets。本地可以
 
 ## 当前发布方式
 
-发布版本时使用与当前源码版本一致的标签，例如：
+发布版本时，在 GitHub Actions 打开 `Prepare Release`，输入与当前源码版本一致且尚不存在的
+标签，例如 `vX.Y.Z`。它会自动刷新 GeoIP、运行临时分支和合并后 `main` 的完整检查、合并
+来源记录、创建标签并启动正式构建，不要提前手工创建 tag。只有自动编排不可用时，才按发布
+检查清单使用 `Maintenance > geoip-refresh` 和手工标签回退流程。
 
-```bash
-git tag -a vX.Y.Z -m "SSRVPN vX.Y.Z"
-git push origin vX.Y.Z
-```
-
-推送 `v*` 标签后，GitHub 会自动构建：
+准备流程完成后，GitHub 会自动构建：
 
 - Android APK
 - macOS DMG

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@
 - [ADR-009：macOS Release 权限最小化](decisions/009-macos-release-entitlement-minimization.md)
 - [ADR-010：以行为证据控制高风险职责拆分](decisions/010-risk-controlled-maintainability-boundaries.md)
 - [ADR-011：只在正式发版前刷新并强制验证 GeoIP](decisions/011-release-gated-geoip-refresh.md)
+- [ADR-012：自动准备可复现的正式版本](decisions/012-automatic-release-preparation.md)
 
 ## 文档维护规则
 

--- a/docs/RELEASE_CHECKLIST.zh-CN.md
+++ b/docs/RELEASE_CHECKLIST.zh-CN.md
@@ -4,9 +4,8 @@
 
 ## 发布前
 
-1. 在 GitHub Actions 手动运行 `Maintenance`，任务选择 `geoip-refresh`。审查并合并它创建的
-   `GEOIP_SOURCE.txt` 更新 PR，等待合并后的 `main` CI 全绿；完成前不得创建或推送应用版本
-   tag。GeoIP 不再定时自动检查。
+1. 不再单独运行 `Maintenance > geoip-refresh`。先完成版本号和 changelog 修改并合入 `main`；
+   后续 `Prepare Release` 会在创建 tag 前自动刷新 GeoIP。GeoIP 不再定时自动检查。
 2. 确认版本号一致：
 
    ```bash
@@ -31,9 +30,10 @@
    scripts/verify-core-assets.sh
    python3 scripts/sync-geoip-metadb.py --check
    ```
-   正式 Release workflow 会在三端构建前重复这项最新性门禁；失败时必须重新运行手动刷新、
-   合并新 PR 后再创建新的 release tag，禁止在 Release 中动态改写已有 tag 的输入。门禁会在
-   内容校验完成后再次确认上游 Release 和资产身份；校验期间 `latest` 发生滚动也必须失败。
+   `Prepare Release` 会在无 tag 状态下刷新来源记录；正式 Release workflow 会在三端构建前
+   重复只读最新性门禁。若此时上游已滚动，必须回到 `main` 更新版本并使用新的 tag 重新运行
+   准备流程，禁止删除、移动旧 tag 或在 Release 中动态改写已有 tag 的输入。门禁会在内容校验
+   完成后再次确认上游 Release 和资产身份；校验期间 `latest` 发生滚动也必须失败。
    只有精确 tag 下的 Release/资产 ID、上传完成状态、摘要、commit 与 provenance 全部一致的
    已有发布恢复重试，才允许复用原 tag 快照；授权阶段固定的 Release ID 与全资产规范身份会在
    发布 job 再次验证。构建期间 Release 消失、变残或被替换时必须失败，禁止删除后新建；缺失、
@@ -97,28 +97,27 @@ reg query "HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings" /v 
 
 ## 发布
 
-1. 切换到已通过必需 CI 的 `main`，更新远程引用，并确认工作树干净、本地 `HEAD`
-   与当前 `origin/main` 完全一致：
-
-   ```bash
-   git switch main
-   git fetch origin
-   test -z "$(git status --porcelain)"
-   test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
-   ```
-
-2. 在该提交上创建 annotated tag，再复核 tag 目标就是当前已测试的 `main`：
-
-   ```bash
-   git tag -a vX.Y.Z -m "SSRVPN vX.Y.Z"
-   test "$(git rev-list -n 1 vX.Y.Z)" = "$(git rev-parse HEAD)"
-   git push origin vX.Y.Z
-   ```
-
-3. 等待 GitHub Actions 的 `Release` workflow 完成。
+1. 运行 `Prepare Release`。GeoIP 有变化时，它先把只修改 `GEOIP_SOURCE.txt` 的临时分支交给
+   六项必需 CI；全绿后创建并 rebase 合并 PR。随后对合并后的精确 `main` 提交再次调度六项
+   CI，在 tag 前再次只读确认 GeoIP 仍是上游最新，并确认 `main` 在验证期间没有前移。
+2. 只有上述步骤全部通过且远端不存在同名 tag/Release 时，编排才创建 annotated tag，并通过
+   `workflow_dispatch` 显式启动该 tag 上的 `Release`。CI、合并、分支树一致性或 GitHub API
+   状态任一不明确都会失败关闭；失败分支在尚未创建 PR 时自动删除，已经创建的 PR 保留诊断。
+3. 等待 `Prepare Release` 所跟踪的 `Release` workflow 完成。
    工作流会先创建 Draft Release、上传并验证 OSS 不可变目录，然后备份并推广
    OSS 固定下载通道，最后公开 GitHub Release。GitHub 未能明确转为正式 Release
    时不得人工推进；按失败日志确认自动恢复结果或使用保留的恢复 Artifact。
+
+### 手动恢复入口
+
+只有 `Prepare Release` 本身不可用时，才手动运行 `Maintenance > geoip-refresh`，合并其 PR 并
+等待 `main` CI 全绿，再按传统方式创建 annotated tag。手工推送的新 tag 仍会触发 `Release`
+的只读 GeoIP 最新性门禁，不能绕过来源记录和版本转换校验。
+
+若 `Prepare Release` 已成功推送 tag，但 `Release` 调度失败或等待超时，不得删除、移动 tag，
+也不得用同名 tag 重跑准备流程。先确认没有重复的 Release run，再在 GitHub Actions 选择该
+精确 tag 手动运行 `Release`，或执行 `gh workflow run release.yml --ref vX.Y.Z`；既有 Release
+重试仍必须通过精确 tag、commit、资产和 provenance 身份校验。
 
 ## 发布后
 

--- a/docs/decisions/005-content-addressed-geoip-mirror.md
+++ b/docs/decisions/005-content-addressed-geoip-mirror.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-已接受；每日自动刷新策略已由 [ADR-011](011-release-gated-geoip-refresh.md) 取代
+已接受；每日自动刷新策略已由 [ADR-011](011-release-gated-geoip-refresh.md) 取代，正式发版编排由 [ADR-012](012-automatic-release-preparation.md) 补充
 
 ## 日期
 
@@ -37,8 +37,8 @@ freshness 任务把未经校验的上游内容直接带入发布构建。
    路径，限制下载大小、协议和超时，并同时验证 gzip SHA-256 与有界解压后的原始 SHA-256。
    镜像回读只允许 `github.com`、`release-assets.githubusercontent.com` 和
    `objects.githubusercontent.com` 的 HTTPS 链路，拒绝降级到 HTTP 或跳转到其他主机。
-5. `Maintenance` 的手动 `geoip-refresh` 是唯一会根据上游 `latest` 写入候选来源记录并上传
-   镜像的自动化边界。它按以下顺序执行：
+5. `Prepare Release` 与 `Maintenance` 的手动 `geoip-refresh` 是仅有的、复用同一验证链并会
+   根据上游 `latest` 写入候选来源记录和上传镜像的自动化边界。它们按以下顺序执行：
    上游 checksum/API digest/实际内容校验 → deterministic gzip → 缺失时上传内容寻址镜像
    → 从公共镜像 URL 回读并验证双 SHA-256 → 创建只修改来源记录的 PR。旧来源记录中的
    upstream URL 即使已返回 404，也不得在这条自愈链路开始前被 bootstrap 访问。
@@ -67,8 +67,8 @@ freshness 任务把未经校验的上游内容直接带入发布构建。
 ## 结果
 
 - 全新 runner 可以仅凭已提交来源记录重建三端 GeoIP 资产。
-- 每次发版前的手动更新仍保留完整上游出处，且镜像存在并能从真实 bootstrap URL 回读后
-  才进入代码审查。
+- 每次发版前的自动准备仍保留完整上游出处，且镜像存在并能从真实 bootstrap URL 回读后
+  才进入受保护分支 CI 和代码审查；手动 Maintenance 仅作为恢复入口。
 - 支持 prerelease 成为必须长期保留的运维资源；仓库所有者需保护其 tag 和已引用资产，
   并确保它永远不成为应用 `latest`。
 - GitHub Release 仍由仓库管理员控制，并非不可篡改账本；内容寻址名称和双哈希让错误替换
@@ -111,3 +111,4 @@ Asset ID 会随上游每日 Release 替换被删除，已经证明不能提供�
 - [GeoIP 来源记录](../GEOIP_SOURCE.txt)
 - [发布检查清单](../RELEASE_CHECKLIST.zh-CN.md)
 - [ADR-011：只在正式发版前刷新并强制验证 GeoIP](011-release-gated-geoip-refresh.md)
+- [ADR-012：自动准备可复现的正式版本](012-automatic-release-preparation.md)

--- a/docs/decisions/011-release-gated-geoip-refresh.md
+++ b/docs/decisions/011-release-gated-geoip-refresh.md
@@ -2,7 +2,7 @@
 
 ## 状态
 
-已接受；取代 ADR-005 中的每日自动刷新策略，不改变其内容寻址镜像和双哈希信任边界
+已由 [ADR-012](012-automatic-release-preparation.md) 取代其中的人工发版编排；取消每日刷新、内容寻址镜像、双哈希和 Release 只读门禁继续有效
 
 ## 日期
 
@@ -82,5 +82,6 @@ Release 构建阶段直接写入上游 `latest` 实现，因为应用 tag、提�
 ## 相关文档
 
 - [ADR-005：使用 SSRVPN 自控的内容寻址 GeoIP 镜像](005-content-addressed-geoip-mirror.md)
+- [ADR-012：自动准备可复现的正式版本](012-automatic-release-preparation.md)
 - [核心资产来源](../CORE_ASSETS.md)
 - [发布检查清单](../RELEASE_CHECKLIST.zh-CN.md)

--- a/docs/decisions/012-automatic-release-preparation.md
+++ b/docs/decisions/012-automatic-release-preparation.md
@@ -1,0 +1,103 @@
+# ADR-012：自动准备可复现的正式版本
+
+## 状态
+
+已接受；取代 ADR-011 中“维护者必须手动刷新、合并并创建 tag”的发版编排，不改变其
+取消日程刷新、内容寻址镜像、双哈希、只读最新性门禁和精确 Release 重试边界
+
+## 日期
+
+2026-08-03
+
+## 背景
+
+ADR-011 把 GeoIP 更新收敛到正式发版前，消除了每日 PR 噪声，但要求维护者依次运行
+Maintenance、合并来源记录、等待 CI、创建 tag 和观察 Release。步骤本身可验证，却容易因
+顺序遗漏而让 Release 在已创建 tag 后才报告 GeoIP 过期。
+
+不能简单让 `release.yml` 在 tag 已存在后下载并打包上游 `latest`：同一 tag 在不同日期重跑
+可能得到不同字节，提交中的 `GEOIP_SOURCE.txt` 也无法重建安装包。自动化必须发生在 tag
+创建前，并让最终 tag 指向包含精确来源记录、已经完整验证的 `main` 提交。
+
+仓库 `main` 启用了严格必需检查、PR、线性历史和禁止管理员绕过；`GITHUB_TOKEN` 的普通
+push 不会递归启动新 workflow，但 GitHub 明确允许它创建 `workflow_dispatch`。因此发版准备
+可以显式调度已有 CI，而不削弱分支保护或引入长期 PAT。
+
+## 决策
+
+1. 新增仅手动触发的 `Prepare Release` workflow。输入必须是与当前应用版本一致、远端尚不
+   存在 tag 或 Release 的 `vX.Y.Z`；同一时间只允许一个准备流程。
+2. 工作流从精确 `origin/main` 开始，先执行版本同步和版本转换校验，再运行现有 GeoIP
+   同步、内容寻址镜像上传与公共回读验证。任何 API、摘要、重定向、镜像或工作树状态不明确
+   都失败关闭。
+3. GeoIP 有变化时，只提交 `docs/GEOIP_SOURCE.txt` 到本次运行专属临时分支。编排先通过
+   `workflow_dispatch` 在该提交上运行现有六项必需 CI；全绿且 `main` 未前移后才创建 PR，
+   并按受保护分支规则 rebase 合并。分支 CI 失败且 PR 尚未创建时，精确删除本次临时分支；
+   已创建 PR 的失败状态保留供诊断。
+4. 合并后必须确认远端 `main` 等于 GitHub 报告的合并提交，且 Git tree 与已验证分支完全
+   一致。无论 GeoIP 是否变化，都在精确最终 `main` 上再次显式调度完整 CI；CI 结束后
+   再次以只读方式确认 GeoIP 仍是上游 `latest`，并在 tag 创建前最后复核 `main`；GeoIP
+   滚动或 `main` 前移都会中止流程。
+5. 只有精确 `main` CI 成功且再次确认同名 tag/Release 不存在，才创建 annotated tag 并推送。
+   因 `GITHUB_TOKEN` push 不递归触发工作流，编排使用 GitHub 当前 REST API 的
+   `workflow_dispatch` 响应取得精确 run ID 和 URL，显式启动 tag 上的 `release.yml` 并等待
+   结果。tag 推送是不可逆边界；若此后的调度、等待或 Release 失败，保留原 tag，并对该精确
+   tag 手动重试 `Release`，不得删除或移动 tag。Release 环境原有人工批准、三端构建、OSS
+   回滚和发布后验证保持不变。
+6. `release.yml` 继续保留只读 GeoIP 最新性门禁。手工 tag、竞态期间的上游滚动或绕过
+   `Prepare Release` 的旧流程仍会在平台构建前失败；精确已有 Release 重试继续使用
+   ADR-011 定义的不可变身份校验。
+7. `Maintenance > geoip-refresh` 保留为手动恢复入口，不再是正常发版的必需步骤，也不获得
+   schedule 触发器。
+
+## 结果
+
+- 正常发版只需在版本和 changelog 已合入 `main` 后运行一次 `Prepare Release`。
+- GeoIP 更新仍有独立提交、PR、双哈希和不可变镜像，tag 不包含运行时生成的隐式输入。
+- 分支 CI 与最终 `main` CI 都必须成功；任何创建 tag 前发现的竞态、已有 tag/Release 或外部
+  状态歧义都会停在新 tag 创建前。tag 推送后的故障保留不可变 tag，转入精确 Release 重试。
+- 自动准备会增加一次 CI；GeoIP 发生变化时会运行两次 CI。这是保护精确合并提交和分支规则
+  的有意成本，不以减少验证换取速度。
+- Release 启动后仍可能等待 `release` environment 批准；该批准保护正式发布凭据，不由准备
+  workflow 绕过。
+
+## 未采用的方案
+
+### 在 Release 构建中直接下载 latest
+
+同一 tag 会随时间改变构建输入，破坏来源记录和重跑可复现性。
+
+### 由工作流直接推送 main
+
+会绕过当前严格 PR、必需检查和线性历史规则；即使只修改来源记录也不接受。
+
+### 使用长期 PAT 自动触发 PR CI
+
+仓库已有 `workflow_dispatch`，可使用最小权限的短期 `GITHUB_TOKEN` 显式调度精确 ref；新增
+长期秘密会扩大泄漏和轮换负担。
+
+### 在 CI 前创建 tag，失败后删除
+
+受保护的 `v*` tag 不允许改写或删除；先创建再回滚不符合不可变发布入口。
+
+## 验证守卫
+
+- `scripts/test_prepare_release_workflow.py` 以伪 GitHub API 和伪 Git 远端验证有变化、无变化、
+  分支/最终 CI 失败和 tag 后调度失败，并检查 PR、双 CI、tag、Release 调度与不可逆边界。
+- `scripts/test_geoip_workflow.py` 继续覆盖上游身份、确定性 gzip、镜像回读、重定向和竞态。
+- `scripts/test_verify_release_transition.py` 继续禁止 `release.yml` 动态改写 GeoIP，并保护 tag、
+  provenance、OSS 和精确 Release 重试边界。
+- `actionlint`、ShellCheck 和 `scripts/test-release-tooling.sh` 是合并前最低门禁。
+
+## 官方依据
+
+- [GitHub：从工作流触发工作流](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow)
+- [GitHub：Create a workflow dispatch event](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event)
+- [GitHub：受保护分支](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+
+## 相关文档
+
+- [ADR-005：使用 SSRVPN 自控的内容寻址 GeoIP 镜像](005-content-addressed-geoip-mirror.md)
+- [ADR-011：只在正式发版前刷新并强制验证 GeoIP](011-release-gated-geoip-refresh.md)
+- [核心资产来源](../CORE_ASSETS.md)
+- [发布检查清单](../RELEASE_CHECKLIST.zh-CN.md)

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+tag=${1:?Usage: prepare-release.sh <new-release-tag>}
+repo=${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}
+run_id=${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}
+run_attempt=${GITHUB_RUN_ATTEMPT:-1}
+output_file=${GITHUB_OUTPUT:-}
+summary_file=${GITHUB_STEP_SUMMARY:-}
+branch=""
+branch_pushed=false
+pr_number=""
+merged=false
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+write_output() {
+  local name=$1
+  local value=$2
+  if [ -n "$output_file" ]; then
+    printf '%s=%s\n' "$name" "$value" >> "$output_file"
+  fi
+}
+
+append_summary() {
+  if [ -n "$summary_file" ]; then
+    printf '%s\n' "$1" >> "$summary_file"
+  fi
+}
+
+cleanup_failed_branch() {
+  local status=$?
+  trap - EXIT
+  if [ "$status" -ne 0 ] && [ "$branch_pushed" = true ] && \
+    [ -z "$pr_number" ] && [ "$merged" = false ]; then
+    git push origin --delete "$branch" >/dev/null 2>&1 || \
+      echo "::warning::Could not delete failed preparation branch $branch" >&2
+  fi
+  exit "$status"
+}
+trap cleanup_failed_branch EXIT
+
+# GitHub documents that workflow_dispatch always creates a run when invoked
+# with GITHUB_TOKEN. The current REST response includes the exact run ID/URL.
+# https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow
+# https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event
+dispatch_workflow() {
+  local workflow=$1
+  local ref=$2
+  local response
+
+  response="$(gh api --method POST \
+    -H "X-GitHub-Api-Version: 2026-03-10" \
+    "repos/$repo/actions/workflows/$workflow/dispatches" \
+    -f "ref=$ref")"
+  python3 - "$workflow" "$response" <<'PY'
+import json
+import sys
+
+workflow = sys.argv[1]
+try:
+    payload = json.loads(sys.argv[2])
+except json.JSONDecodeError as error:
+    raise SystemExit(f"{workflow} dispatch returned invalid JSON: {error}")
+run_id = payload.get("workflow_run_id")
+run_url = payload.get("html_url")
+if isinstance(run_id, bool) or not isinstance(run_id, int) or run_id <= 0:
+    raise SystemExit(f"{workflow} dispatch returned no valid workflow_run_id")
+if not isinstance(run_url, str) or not run_url.startswith("https://github.com/"):
+    raise SystemExit(f"{workflow} dispatch returned no valid html_url")
+print(f"{run_id}\t{run_url}")
+PY
+}
+
+wait_for_workflow() {
+  local watched_run_id=$1
+  gh run watch "$watched_run_id" --exit-status --interval 20
+}
+
+require_tag_absent() {
+  local tag_status=0
+  local release_error
+  release_error="$(mktemp)"
+
+  git ls-remote --exit-code --tags origin "refs/tags/$tag" \
+    >/dev/null 2>&1 || tag_status=$?
+  if [ "$tag_status" -eq 0 ]; then
+    rm -f "$release_error"
+    fail "Release tag already exists: $tag"
+  fi
+  if [ "$tag_status" -ne 2 ]; then
+    rm -f "$release_error"
+    fail "Could not determine whether release tag $tag exists"
+  fi
+
+  if gh api "repos/$repo/releases/tags/$tag" >/dev/null 2>"$release_error"; then
+    rm -f "$release_error"
+    fail "GitHub Release already exists: $tag"
+  fi
+  if ! grep -Fq "HTTP 404" "$release_error"; then
+    sed 's/^/GitHub API: /' "$release_error" >&2
+    rm -f "$release_error"
+    fail "Could not determine whether GitHub Release $tag exists"
+  fi
+  rm -f "$release_error"
+}
+
+if [[ ! "$tag" =~ ^v[0-9]+(\.[0-9]+){1,3}$ ]]; then
+  fail "Invalid release tag: $tag"
+fi
+if [[ ! "$run_id" =~ ^[1-9][0-9]*$ ]] || \
+  [[ ! "$run_attempt" =~ ^[1-9][0-9]*$ ]]; then
+  fail "GitHub run identity is invalid"
+fi
+
+git fetch --no-tags origin main:refs/remotes/origin/main
+git fetch --tags origin
+source_sha="$(git rev-parse --verify 'HEAD^{commit}')"
+main_sha="$(git rev-parse --verify 'origin/main^{commit}')"
+if [ "$source_sha" != "$main_sha" ]; then
+  fail "Prepare Release must start from the current main tip"
+fi
+
+bash scripts/check-version-sync.sh
+app_version="$(awk -F"'" '/appVersion = / { print $2; exit }' \
+  packages/ssrvpn_shared/lib/constants/app_constants.dart)"
+if [ "${tag#v}" != "$app_version" ]; then
+  fail "Release tag $tag does not match app version $app_version"
+fi
+
+current_full="$(awk '/^version:/ { print $2; exit }' SSRVPN_Android/pubspec.yaml)"
+current_code=${current_full##*+}
+previous_tag="$(git tag --list 'v*' --sort=-v:refname |
+  grep -E '^v[0-9]+(\.[0-9]+){1,3}$' |
+  grep -vx "$tag" | head -1 || true)"
+if [ -n "$previous_tag" ]; then
+  previous_full="$(git show "$previous_tag:SSRVPN_Android/pubspec.yaml" |
+    awk '/^version:/ { print $2; exit }')"
+  previous_code=${previous_full##*+}
+  python3 scripts/verify-release-transition.py \
+    --target "${tag#v}" \
+    --current-version "${previous_tag#v}" \
+    --target-build-code "$current_code" \
+    --current-build-code "$previous_code"
+fi
+
+require_tag_absent
+
+python3 scripts/sync-geoip-metadb.py
+python3 scripts/ensure-geoip-mirror.py --upload
+bash scripts/verify-core-assets.sh
+
+unexpected="$(git diff --name-only -- . ':!docs/GEOIP_SOURCE.txt')"
+if [ -n "$unexpected" ]; then
+  printf 'Unexpected tracked files changed:\n%s\n' "$unexpected" >&2
+  exit 1
+fi
+untracked="$(git ls-files --others --exclude-standard)"
+if [ -n "$untracked" ]; then
+  printf 'Unexpected untracked files created:\n%s\n' "$untracked" >&2
+  exit 1
+fi
+
+geoip_changed=false
+branch_ci_url=""
+pr_url=""
+if ! git diff --quiet -- docs/GEOIP_SOURCE.txt; then
+  geoip_changed=true
+  branch="automation/release-${tag#v}-geoip-${run_id}-${run_attempt}"
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git switch -c "$branch"
+  git add -- docs/GEOIP_SOURCE.txt
+  git commit -m "chore(assets): refresh GeoIP for $tag"
+  branch_sha="$(git rev-parse --verify 'HEAD^{commit}')"
+  git push origin "HEAD:refs/heads/$branch"
+  branch_pushed=true
+
+  IFS=$'\t' read -r branch_ci_run_id branch_ci_url \
+    < <(dispatch_workflow "ci.yml" "$branch")
+  wait_for_workflow "$branch_ci_run_id"
+
+  git fetch --no-tags origin main:refs/remotes/origin/main
+  if [ "$(git rev-parse --verify 'origin/main^{commit}')" != "$main_sha" ]; then
+    fail "main advanced while the GeoIP branch was being verified; retry safely"
+  fi
+
+  pr_url="$(gh pr create \
+    --base main \
+    --head "$branch" \
+    --title "chore(assets): refresh GeoIP for $tag" \
+    --body "Automated pre-release GeoIP refresh for $tag. The exact upstream source, deterministic gzip digest, and immutable SSRVPN mirror are pinned before the release tag is created.")"
+  pr_number=${pr_url##*/}
+  if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
+    fail "Could not determine the GeoIP pull request number"
+  fi
+  gh pr merge "$pr_number" --rebase --delete-branch
+  merged=true
+
+  merge_state="$(gh pr view "$pr_number" --json state --jq .state)"
+  main_sha="$(gh pr view "$pr_number" --json mergeCommit --jq .mergeCommit.oid)"
+  if [ "$merge_state" != MERGED ] || \
+    [[ ! "$main_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    fail "GeoIP pull request did not produce a valid merged commit"
+  fi
+
+  git fetch --no-tags origin main:refs/remotes/origin/main
+  if [ "$(git rev-parse --verify 'origin/main^{commit}')" != "$main_sha" ]; then
+    fail "Merged GeoIP commit is not the current main tip"
+  fi
+  if [ "$(git rev-parse "$branch_sha^{tree}")" != \
+    "$(git rev-parse "$main_sha^{tree}")" ]; then
+    fail "Merged GeoIP tree differs from the verified branch tree"
+  fi
+fi
+
+IFS=$'\t' read -r main_ci_run_id main_ci_url \
+  < <(dispatch_workflow "ci.yml" main)
+wait_for_workflow "$main_ci_run_id"
+
+git fetch --no-tags origin main:refs/remotes/origin/main
+if [ "$(git rev-parse --verify 'origin/main^{commit}')" != "$main_sha" ]; then
+  fail "main advanced after verification; refusing to create $tag"
+fi
+
+# Exact-main CI can run long enough for upstream latest to roll. Recheck the
+# reviewed pointer before crossing the immutable tag boundary; release.yml keeps
+# the same read-only gate as defense in depth.
+python3 scripts/sync-geoip-metadb.py --check
+require_tag_absent
+
+git fetch --no-tags origin main:refs/remotes/origin/main
+if [ "$(git rev-parse --verify 'origin/main^{commit}')" != "$main_sha" ]; then
+  fail "main advanced before tag creation; retry safely"
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git tag -a "$tag" "$main_sha" -m "Release ${tag#v}"
+git push origin "refs/tags/$tag"
+
+IFS=$'\t' read -r release_run_id release_run_url \
+  < <(dispatch_workflow "release.yml" "$tag")
+write_output geoip_changed "$geoip_changed"
+write_output branch_ci_url "$branch_ci_url"
+write_output geoip_pr_url "$pr_url"
+write_output main_ci_url "$main_ci_url"
+write_output release_run_url "$release_run_url"
+
+append_summary "## Release preparation for $tag"
+append_summary "- GeoIP changed: $geoip_changed"
+if [ -n "$pr_url" ]; then
+  append_summary "- GeoIP pull request: $pr_url"
+  append_summary "- Branch CI: $branch_ci_url"
+fi
+append_summary "- Exact-main CI: $main_ci_url"
+append_summary "- Release workflow: $release_run_url"
+
+wait_for_workflow "$release_run_id"

--- a/scripts/test-release-tooling.sh
+++ b/scripts/test-release-tooling.sh
@@ -17,6 +17,7 @@ python3 -m unittest \
   scripts/test_generate_release_provenance.py \
   scripts/test_macos_dmg_layout.py \
   scripts/test_promote_oss_public_channel.py \
+  scripts/test_prepare_release_workflow.py \
   scripts/test_quality_hygiene_entrypoint.py \
   scripts/test_release_tooling_entrypoint.py \
   scripts/test_reuse_github_release_assets.py \

--- a/scripts/test_prepare_release_workflow.py
+++ b/scripts/test_prepare_release_workflow.py
@@ -1,0 +1,410 @@
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "prepare-release.yml"
+PREPARER = ROOT / "scripts" / "prepare-release.sh"
+
+
+class PrepareReleaseWorkflowTest(unittest.TestCase):
+    BASE_SHA = "a" * 40
+    BRANCH_SHA = "b" * 40
+    MERGED_SHA = "c" * 40
+
+    def _write_executable(self, path: Path, content: str) -> None:
+        path.write_text(textwrap.dedent(content), encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def _run_preparer(
+        self,
+        *,
+        geoip_changed: bool,
+        fail_branch_ci: bool = False,
+        fail_main_ci: bool = False,
+        fail_release_dispatch: bool = False,
+    ) -> tuple[subprocess.CompletedProcess[str], str, str, str]:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            scripts = root / "scripts"
+            fake_bin = root / "fake-bin"
+            docs = root / "docs"
+            shared = root / "packages" / "ssrvpn_shared" / "lib" / "constants"
+            android = root / "SSRVPN_Android"
+            for directory in (scripts, fake_bin, docs, shared, android):
+                directory.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(PREPARER, scripts / PREPARER.name)
+            (docs / "GEOIP_SOURCE.txt").write_text(
+                "Release tag: 2026-08-02\n", encoding="utf-8"
+            )
+            (shared / "app_constants.dart").write_text(
+                "static const String appVersion = '4.0.2';\n",
+                encoding="utf-8",
+            )
+            (android / "pubspec.yaml").write_text(
+                "version: 4.0.2+4002\n", encoding="utf-8"
+            )
+
+            command_log = root / "commands.log"
+            current_sha = root / "current-sha"
+            main_sha = root / "main-sha"
+            output = root / "github-output"
+            summary = root / "summary"
+            current_sha.write_text(self.BASE_SHA, encoding="utf-8")
+            main_sha.write_text(self.BASE_SHA, encoding="utf-8")
+
+            self._write_executable(
+                fake_bin / "python3",
+                r"""
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [ "${1:-}" = - ]; then
+                  exec "$REAL_PYTHON" "$@"
+                fi
+                printf 'python3 %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+                if [ "${1:-}" = scripts/sync-geoip-metadb.py ] &&
+                  [ "$FAKE_GEOIP_CHANGED" = true ]; then
+                  printf 'Upstream SHA256: refreshed\n' >> docs/GEOIP_SOURCE.txt
+                fi
+                exit 0
+                """,
+            )
+            self._write_executable(
+                fake_bin / "bash",
+                r"""
+                #!/usr/bin/env bash
+                set -euo pipefail
+                case "${1:-}" in
+                  scripts/check-version-sync.sh|scripts/verify-core-assets.sh)
+                    printf 'bash %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+                    exit 0
+                    ;;
+                esac
+                exec /bin/bash "$@"
+                """,
+            )
+            self._write_executable(
+                fake_bin / "git",
+                r"""
+                #!/usr/bin/env bash
+                set -euo pipefail
+                printf 'git %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+                command=${1:-}
+                shift || true
+                case "$command" in
+                  fetch|config|switch|add)
+                    exit 0
+                    ;;
+                  rev-parse)
+                    if [ "${1:-}" = --verify ]; then shift; fi
+                    expression=${1:-}
+                    case "$expression" in
+                      HEAD*commit*) cat "$FAKE_CURRENT_SHA" ;;
+                      origin/main*commit*) cat "$FAKE_MAIN_SHA" ;;
+                      *tree*) printf '%s\n' "$FAKE_TREE_SHA" ;;
+                      *) exit 2 ;;
+                    esac
+                    ;;
+                  tag)
+                    if [ "${1:-}" = --list ]; then
+                      printf 'v4.0.1\n'
+                    fi
+                    ;;
+                  show)
+                    printf 'version: 4.0.1+4001\n'
+                    ;;
+                  ls-remote)
+                    exit 2
+                    ;;
+                  diff)
+                    if [ "${1:-}" = --quiet ]; then
+                      if [ "$FAKE_GEOIP_CHANGED" = true ]; then exit 1; fi
+                      exit 0
+                    fi
+                    exit 0
+                    ;;
+                  ls-files)
+                    exit 0
+                    ;;
+                  commit)
+                    printf '%s' "$FAKE_BRANCH_SHA" > "$FAKE_CURRENT_SHA"
+                    ;;
+                  push)
+                    exit 0
+                    ;;
+                  *)
+                    printf 'unexpected fake git command: %s %s\n' "$command" "$*" >&2
+                    exit 2
+                    ;;
+                esac
+                """,
+            )
+            self._write_executable(
+                fake_bin / "gh",
+                r"""
+                #!/usr/bin/env bash
+                set -euo pipefail
+                printf 'gh %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+                command=${1:-}
+                shift || true
+                case "$command" in
+                  api)
+                    if [[ "$*" == *'/releases/tags/'* ]]; then
+                      printf 'gh: Not Found (HTTP 404)\n' >&2
+                      exit 1
+                    fi
+                    if [[ "$*" == *'/workflows/ci.yml/dispatches'* ]]; then
+                      if [[ "$*" == *'ref=main'* ]]; then
+                        printf '{"workflow_run_id":102,"html_url":"https://github.com/Elegying/SSRVPN/actions/runs/102"}\n'
+                      else
+                        printf '{"workflow_run_id":101,"html_url":"https://github.com/Elegying/SSRVPN/actions/runs/101"}\n'
+                      fi
+                      exit 0
+                    fi
+                    if [[ "$*" == *'/workflows/release.yml/dispatches'* ]]; then
+                      if [ "$FAKE_FAIL_RELEASE_DISPATCH" = true ]; then
+                        exit 1
+                      fi
+                      printf '{"workflow_run_id":103,"html_url":"https://github.com/Elegying/SSRVPN/actions/runs/103"}\n'
+                      exit 0
+                    fi
+                    exit 2
+                    ;;
+                  run)
+                    if [ "${1:-}" = watch ] && [ "${2:-}" = 101 ] &&
+                      [ "$FAKE_FAIL_BRANCH_CI" = true ]; then
+                      exit 1
+                    fi
+                    if [ "${1:-}" = watch ] && [ "${2:-}" = 102 ] &&
+                      [ "$FAKE_FAIL_MAIN_CI" = true ]; then
+                      exit 1
+                    fi
+                    exit 0
+                    ;;
+                  pr)
+                    subcommand=${1:-}
+                    shift || true
+                    case "$subcommand" in
+                      create)
+                        printf 'https://github.com/Elegying/SSRVPN/pull/84\n'
+                        ;;
+                      merge)
+                        printf '%s' "$FAKE_MERGED_SHA" > "$FAKE_MAIN_SHA"
+                        ;;
+                      view)
+                        if [[ "$*" == *'.mergeCommit.oid'* ]]; then
+                          printf '%s\n' "$FAKE_MERGED_SHA"
+                        else
+                          printf 'MERGED\n'
+                        fi
+                        ;;
+                      *) exit 2 ;;
+                    esac
+                    ;;
+                  *) exit 2 ;;
+                esac
+                """,
+            )
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PATH": f"{fake_bin}{os.pathsep}{environment['PATH']}",
+                    "REAL_PYTHON": sys.executable,
+                    "FAKE_COMMAND_LOG": str(command_log),
+                    "FAKE_CURRENT_SHA": str(current_sha),
+                    "FAKE_MAIN_SHA": str(main_sha),
+                    "FAKE_BASE_SHA": self.BASE_SHA,
+                    "FAKE_BRANCH_SHA": self.BRANCH_SHA,
+                    "FAKE_MERGED_SHA": self.MERGED_SHA,
+                    "FAKE_TREE_SHA": "d" * 40,
+                    "FAKE_GEOIP_CHANGED": str(geoip_changed).lower(),
+                    "FAKE_FAIL_BRANCH_CI": str(fail_branch_ci).lower(),
+                    "FAKE_FAIL_MAIN_CI": str(fail_main_ci).lower(),
+                    "FAKE_FAIL_RELEASE_DISPATCH": str(
+                        fail_release_dispatch
+                    ).lower(),
+                    "GITHUB_REPOSITORY": "Elegying/SSRVPN",
+                    "GITHUB_RUN_ID": "9001",
+                    "GITHUB_RUN_ATTEMPT": "1",
+                    "GITHUB_OUTPUT": str(output),
+                    "GITHUB_STEP_SUMMARY": str(summary),
+                }
+            )
+            result = subprocess.run(
+                ["/bin/bash", str(scripts / PREPARER.name), "v4.0.2"],
+                cwd=root,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            return (
+                result,
+                command_log.read_text(encoding="utf-8"),
+                output.read_text(encoding="utf-8") if output.exists() else "",
+                summary.read_text(encoding="utf-8") if summary.exists() else "",
+            )
+
+    def test_workflow_is_manual_serialized_and_least_privilege(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("name: Prepare Release", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("tag:", workflow)
+        self.assertIn("type: string", workflow)
+        self.assertNotIn("\n  push:\n", workflow)
+        self.assertNotIn("\n  schedule:\n", workflow)
+        self.assertIn("group: ssrvpn-release-preparation", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertIn("actions: write", workflow)
+        self.assertIn("contents: write", workflow)
+        self.assertIn("pull-requests: write", workflow)
+        self.assertNotIn("packages: write", workflow)
+        self.assertIn("GH_TOKEN: ${{ github.token }}", workflow)
+        self.assertIn("GITHUB_TOKEN: ${{ github.token }}", workflow)
+        self.assertIn("ref: main", workflow)
+        self.assertIn("fetch-depth: 0", workflow)
+        self.assertIn("RELEASE_TAG: ${{ inputs.tag }}", workflow)
+        self.assertIn('bash scripts/prepare-release.sh "$RELEASE_TAG"', workflow)
+        self.assertNotIn(
+            'bash scripts/prepare-release.sh "${{ inputs.tag }}"', workflow
+        )
+
+    def test_preparer_tags_only_after_geoip_and_exact_main_ci(self) -> None:
+        preparer = PREPARER.read_text(encoding="utf-8")
+
+        sync = preparer.index("python3 scripts/sync-geoip-metadb.py")
+        mirror = preparer.index("python3 scripts/ensure-geoip-mirror.py --upload")
+        verify = preparer.index("bash scripts/verify-core-assets.sh")
+        branch_ci = preparer.index('dispatch_workflow "ci.yml" "$branch"')
+        create_pr = preparer.index("gh pr create")
+        merge_pr = preparer.index("gh pr merge")
+        main_ci = preparer.index('dispatch_workflow "ci.yml" main')
+        final_freshness = preparer.index(
+            "python3 scripts/sync-geoip-metadb.py --check"
+        )
+        create_tag = preparer.index('git tag -a "$tag"')
+        push_tag = preparer.index('git push origin "refs/tags/$tag"')
+        release = preparer.index('dispatch_workflow "release.yml" "$tag"')
+
+        self.assertLess(sync, mirror)
+        self.assertLess(mirror, verify)
+        self.assertLess(verify, branch_ci)
+        self.assertLess(branch_ci, create_pr)
+        self.assertLess(create_pr, merge_pr)
+        self.assertLess(merge_pr, main_ci)
+        self.assertLess(main_ci, final_freshness)
+        self.assertLess(final_freshness, create_tag)
+        self.assertLess(create_tag, push_tag)
+        self.assertLess(push_tag, release)
+        self.assertIn('wait_for_workflow "$release_run_id"', preparer)
+        self.assertIn("git add -- docs/GEOIP_SOURCE.txt", preparer)
+        self.assertNotIn("git add .", preparer)
+        self.assertNotIn("git push --force", preparer)
+        self.assertNotIn("--admin", preparer)
+
+    def test_existing_tag_or_release_blocks_before_geoip_mutation(self) -> None:
+        preparer = PREPARER.read_text(encoding="utf-8")
+
+        remote_tag_guard = preparer.index("refs/tags/$tag")
+        release_guard = preparer.index('releases/tags/$tag')
+        sync = preparer.index("python3 scripts/sync-geoip-metadb.py")
+        self.assertLess(remote_tag_guard, sync)
+        self.assertLess(release_guard, sync)
+
+    def test_release_workflow_retains_read_only_freshness_defense(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("Require the latest GeoIP snapshot", workflow)
+        self.assertIn("python3 scripts/sync-geoip-metadb.py --check", workflow)
+        self.assertNotRegex(
+            workflow,
+            r"(?m)^\s*python3 scripts/sync-geoip-metadb\.py\s*$",
+        )
+
+    def test_changed_geoip_runs_both_ci_gates_before_release(self) -> None:
+        result, commands, output, summary = self._run_preparer(
+            geoip_changed=True
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        branch_dispatch = commands.index("workflows/ci.yml/dispatches")
+        create_pr = commands.index("gh pr create")
+        merge_pr = commands.index("gh pr merge")
+        main_dispatch = commands.index(
+            "workflows/ci.yml/dispatches", branch_dispatch + 1
+        )
+        tag_push = commands.index("git push origin refs/tags/v4.0.2")
+        release_dispatch = commands.index("workflows/release.yml/dispatches")
+        self.assertLess(branch_dispatch, create_pr)
+        self.assertLess(create_pr, merge_pr)
+        self.assertLess(merge_pr, main_dispatch)
+        self.assertLess(main_dispatch, tag_push)
+        self.assertLess(tag_push, release_dispatch)
+        self.assertIn("geoip_changed=true", output)
+        self.assertIn("geoip_pr_url=https://github.com/Elegying/SSRVPN/pull/84", output)
+        self.assertIn("Release workflow:", summary)
+
+    def test_branch_ci_failure_deletes_branch_without_pr_or_tag(self) -> None:
+        result, commands, output, _ = self._run_preparer(
+            geoip_changed=True,
+            fail_branch_ci=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("git push origin --delete automation/release-4.0.2", commands)
+        self.assertNotIn("gh pr create", commands)
+        self.assertNotIn("git push origin refs/tags/v4.0.2", commands)
+        self.assertNotIn("workflows/release.yml/dispatches", commands)
+        self.assertEqual(output, "")
+
+    def test_current_geoip_skips_pr_but_rechecks_main_before_release(self) -> None:
+        result, commands, output, _ = self._run_preparer(geoip_changed=False)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("gh pr create", commands)
+        self.assertNotIn("HEAD:refs/heads/automation/", commands)
+        main_dispatch = commands.index("workflows/ci.yml/dispatches")
+        tag_push = commands.index("git push origin refs/tags/v4.0.2")
+        release_dispatch = commands.index("workflows/release.yml/dispatches")
+        self.assertLess(main_dispatch, tag_push)
+        self.assertLess(tag_push, release_dispatch)
+        self.assertIn("geoip_changed=false", output)
+
+    def test_exact_main_ci_failure_prevents_tag_and_release(self) -> None:
+        result, commands, output, _ = self._run_preparer(
+            geoip_changed=False,
+            fail_main_ci=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("gh run watch 102", commands)
+        self.assertNotIn("git push origin refs/tags/v4.0.2", commands)
+        self.assertNotIn("workflows/release.yml/dispatches", commands)
+        self.assertEqual(output, "")
+
+    def test_release_dispatch_failure_keeps_the_immutable_tag(self) -> None:
+        result, commands, output, _ = self._run_preparer(
+            geoip_changed=False,
+            fail_release_dispatch=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("git push origin refs/tags/v4.0.2", commands)
+        self.assertIn("workflows/release.yml/dispatches", commands)
+        self.assertNotIn("git push origin --delete", commands)
+        self.assertEqual(output, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a manual, globally serialized `Prepare Release` workflow as the normal release entrypoint
- refresh and pin GeoIP before any tag, verify the temporary branch, merge its source-record PR through branch protection, then rerun CI on the exact final `main`
- recheck GeoIP and `main` immediately before creating the immutable tag, then explicitly dispatch and watch the existing `Release` workflow
- keep `Maintenance > geoip-refresh` as a manual recovery path and retain the read-only Release freshness gate
- update the owner guide, release checklist, core-asset docs, changelog, README, and ADR history

## Safety boundaries

- no application version bump, tag, or GitHub Release is created by this PR
- workflow input is passed through a quoted environment variable
- only `docs/GEOIP_SOURCE.txt` can be committed by the future preparation run
- all external/API uncertainty fails closed
- branch CI failure occurs before PR/tag creation; exact-main CI failure occurs before tag creation
- after tag creation, failures preserve the immutable tag for exact Release retry
- no force push, administrator bypass, scheduled GeoIP job, or long-lived PAT

## Validation

- `make verify`
- `bash scripts/test-release-tooling.sh` (276 tests)
- targeted release/GeoIP tests (54 tests)
- `actionlint .github/workflows/*.yml`
- `shellcheck scripts/prepare-release.sh scripts/test-release-tooling.sh`
- `bash scripts/check-doc-consistency.sh`
- `bash scripts/check-secrets.sh`
- `git diff --check`
