### PR TITLE
fix(macos): scope stable network service identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.2] - 2026-08-04
+
+### 修复
+
+- macOS 系统代理的稳定服务标识只从当前网络集合读取，避免偏好数据库中的残留或虚拟服务与 `networksetup` 可管理服务不一致时误报“无法确认 macOS 网络服务稳定标识”并阻止连接。
+
 ### 改进
 
 - 正式发版新增一键 `Prepare Release` 编排：自动刷新并固定 GeoIP，临时分支 CI 与合并后精确 `main` CI 均通过后才创建不可变标签并启动既有 Release；任一前置检查失败都会停在标签之前，标签后的发布失败则保留原标签供安全重试。

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 4.0.1+4001
+version: 4.0.2+4002
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/macos/Runner/AppDelegate.swift
+++ b/SSRVPN_MacOS/macos/Runner/AppDelegate.swift
@@ -244,7 +244,10 @@ class AppDelegate: FlutterAppDelegate {
         "com.ssrvpn.network-service-identities" as CFString,
         nil
       ),
-      let rawServices = SCNetworkServiceCopyAll(preferences)
+      // `networksetup` manages the current location's services. Reading every
+      // preference service also returns orphaned entries that it cannot name.
+      let currentSet = SCNetworkSetCopyCurrent(preferences),
+      let rawServices = SCNetworkSetCopyServices(currentSet)
     else {
       return nil
     }

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 4.0.1+4001
+version: 4.0.2+4002
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 4.0.1+4001
+version: 4.0.2+4002
 resolution: workspace
 
 environment:

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -71,7 +71,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '4.0.1';
+  static const String appVersion = '4.0.2';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/scripts/check-macos-core-privileges.sh
+++ b/scripts/check-macos-core-privileges.sh
@@ -418,6 +418,30 @@ print("macOS TUN DNS transaction guards passed.")
 PY
 
 python3 - <<'PY'
+from pathlib import Path
+
+path = Path("SSRVPN_MacOS/macos/Runner/AppDelegate.swift")
+source = path.read_text(encoding="utf-8")
+identity_start = source.index("func currentNetworkServiceIdentities()")
+identity_end = source.index(
+    "private func resetCommittedApplicationTermination", identity_start
+)
+identity_body = source[identity_start:identity_end]
+
+for required in ("SCNetworkSetCopyCurrent", "SCNetworkSetCopyServices"):
+    if required not in identity_body:
+        raise SystemExit(
+            f"{path}: stable identities must come from the current network set"
+        )
+if "SCNetworkServiceCopyAll" in identity_body:
+    raise SystemExit(
+        f"{path}: all preference services include orphaned entries that networksetup cannot manage"
+    )
+
+print("macOS network-service identity scope guards passed.")
+PY
+
+python3 - <<'PY'
 from hashlib import sha256
 from pathlib import Path
 import re


### PR DESCRIPTION
## What changed

- read stable macOS network-service identities from the current network set
- guard against reintroducing all-preference service enumeration
- prepare version 4.0.2 with synchronized build code 4002

## Root cause

`SCNetworkServiceCopyAll` includes orphaned or virtual preference services that `networksetup` cannot manage. The proxy transaction required that broader list to exactly match the current manageable service names, so affected Macs failed closed with “无法确认 macOS 网络服务稳定标识” before any proxy mutation.

## Impact

System proxy mode can connect on Macs with stale or out-of-set network service records while preserving stable-ID replacement protection.

## Validation

- version transition 4.0.1+4001 → 4.0.2+4002
- targeted current-network-set regression guard
- `git diff --check`
- full GitHub Actions matrix will validate Dart, Android, macOS Swift/XCTest, and Windows