### PR TITLE
fix(ci): bootstrap core assets before release verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 修复
 
 - macOS 系统代理的稳定服务标识只从当前网络集合读取，避免偏好数据库中的残留或虚拟服务与 `networksetup` 可管理服务不一致时误报“无法确认 macOS 网络服务稳定标识”并阻止连接。
+- 一键发布准备会先引导固定核心资产，再刷新 GeoIP 并执行完整性校验，避免干净 runner 因缺少未入库平台二进制而在创建标签前失败。
 
 ### 改进
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -152,6 +152,7 @@ fi
 
 require_tag_absent
 
+bash scripts/bootstrap-core-assets.sh
 python3 scripts/sync-geoip-metadb.py
 python3 scripts/ensure-geoip-mirror.py --upload
 bash scripts/verify-core-assets.sh

--- a/scripts/test_prepare_release_workflow.py
+++ b/scripts/test_prepare_release_workflow.py
@@ -82,7 +82,7 @@ class PrepareReleaseWorkflowTest(unittest.TestCase):
                 #!/usr/bin/env bash
                 set -euo pipefail
                 case "${1:-}" in
-                  scripts/check-version-sync.sh|scripts/verify-core-assets.sh)
+                  scripts/check-version-sync.sh|scripts/bootstrap-core-assets.sh|scripts/verify-core-assets.sh)
                     printf 'bash %s\n' "$*" >> "$FAKE_COMMAND_LOG"
                     exit 0
                     ;;
@@ -281,6 +281,7 @@ class PrepareReleaseWorkflowTest(unittest.TestCase):
     def test_preparer_tags_only_after_geoip_and_exact_main_ci(self) -> None:
         preparer = PREPARER.read_text(encoding="utf-8")
 
+        bootstrap = preparer.index("bash scripts/bootstrap-core-assets.sh")
         sync = preparer.index("python3 scripts/sync-geoip-metadb.py")
         mirror = preparer.index("python3 scripts/ensure-geoip-mirror.py --upload")
         verify = preparer.index("bash scripts/verify-core-assets.sh")
@@ -295,6 +296,7 @@ class PrepareReleaseWorkflowTest(unittest.TestCase):
         push_tag = preparer.index('git push origin "refs/tags/$tag"')
         release = preparer.index('dispatch_workflow "release.yml" "$tag"')
 
+        self.assertLess(bootstrap, sync)
         self.assertLess(sync, mirror)
         self.assertLess(mirror, verify)
         self.assertLess(verify, branch_ci)


### PR DESCRIPTION
## What changed

- bootstrap pinned core assets before GeoIP refresh and full asset verification
- assert the release preparation order in the workflow regression test
- document the release orchestration fix in v4.0.2

## Root cause

The new `Prepare Release` entrypoint ran `verify-core-assets.sh` on a clean runner before downloading ignored platform binaries. The first v4.0.2 preparation therefore failed closed on the missing Android `libgojni.so`, before creating any tag.

## Validation

- targeted release ordering tests
- `git diff --check`
- failed run: https://github.com/Elegying/SSRVPN/actions/runs/30873383785