### PR TITLE
test(windows): allow PowerShell cold starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - macOS 系统代理的稳定服务标识只从当前网络集合读取，避免偏好数据库中的残留或虚拟服务与 `networksetup` 可管理服务不一致时误报“无法确认 macOS 网络服务稳定标识”并阻止连接。
 - 一键发布准备会先引导固定核心资产，再刷新 GeoIP 并执行完整性校验，避免干净 runner 因缺少未入库平台二进制而在创建标签前失败。
 - GeoIP 更新分支改为先创建 PR，再等待分支保护实际认可的 PR 必需检查，避免预先手动调度的分支 CI 全绿后仍因“检查尚未注册”而无法合并。
+- Windows PowerShell 5.1 UTF-8 真实集成测试放宽冷启动预算，避免繁忙 runner 将正确的编码结果误判为超时失败；生产代理命令的有界超时保持不变。
 
 ### 改进
 

--- a/SSRVPN_Windows/test/windows_powershell_encoding_test.dart
+++ b/SSRVPN_Windows/test/windows_powershell_encoding_test.dart
@@ -17,7 +17,9 @@ void main() {
           '-Command',
           windowsPowerShellUtf8Script("Write-Output '中文代理恢复成功'"),
         ],
-        timeout: const Duration(seconds: 10),
+        // This verifies encoding, not cold-start performance. Windows
+        // PowerShell 5.1 can take over 10 seconds to start on a loaded runner.
+        timeout: const Duration(seconds: 30),
       );
 
       expect(result.exitCode, 0);


### PR DESCRIPTION
## What changed

- increase the Windows PowerShell 5.1 encoding integration-test timeout from 10 to 30 seconds
- keep production command timeouts unchanged

## Root cause

The test validates UTF-8 output but also included the legacy PowerShell cold start in a 10-second budget. Two isolated exact-main release gates returned timeout exit code 124, while the same test passed in other runs. Loaded Windows runners can exceed 10 seconds before producing the immediate output.

## Validation

- repeated failure isolated to `windows_powershell_encoding_test.dart`
- expected behavior remains exit code 0 and exact Chinese UTF-8 output
- full GitHub Actions matrix will run the real Windows integration test