### PR TITLE
fix: bound Android state reconciliation

### DIFF
--- a/SSRVPN_Android/lib/services/clash_service_native_bridge.dart
+++ b/SSRVPN_Android/lib/services/clash_service_native_bridge.dart
@@ -5,9 +5,10 @@ const _nativeStateRetryDelays = <Duration>[
   Duration(milliseconds: 300),
 ];
 
-// Align deferred reconciliation with the native liveness cadence. A failed
-// platform-channel read must not create a tight, indefinite polling loop.
+// Align deferred reconciliation with the native liveness cadence while keeping
+// a persistent platform-channel failure bounded.
 const _deferredNativeStateRetryDelay = Duration(seconds: 3);
+const _maxDeferredNativeStateRetryAttempts = 3;
 
 class AndroidProxySwitchResult {
   const AndroidProxySwitchResult({
@@ -190,6 +191,7 @@ extension AndroidNativeBridge on ClashService {
   void _scheduleDeferredNativeStateSync(
     int nativeStateEpoch, {
     required bool Function() isStillCurrent,
+    int attempt = 1,
   }) {
     _nativeStateReconciliationTimer?.cancel();
     _nativeStateReconciliationTimer = Timer(
@@ -202,14 +204,31 @@ extension AndroidNativeBridge on ClashService {
           source: '原生状态低频复核',
           isStillCurrent: isStillCurrent,
         );
-        if (!synchronized && isStillCurrent()) {
-          _scheduleDeferredNativeStateSync(
-            nativeStateEpoch,
-            isStillCurrent: isStillCurrent,
-          );
+        if (synchronized || !isStillCurrent()) return;
+        if (attempt >= _maxDeferredNativeStateRetryAttempts) {
+          _failClosedNativeStateReconciliation();
+          return;
         }
+        _scheduleDeferredNativeStateSync(
+          nativeStateEpoch,
+          isStillCurrent: isStillCurrent,
+          attempt: attempt + 1,
+        );
       },
     );
+  }
+
+  void _failClosedNativeStateReconciliation() {
+    _nativeSessionProtocolAvailable = false;
+    _nativeConnectionTransitioning = false;
+    _nativeSessionGeneration = null;
+    _runningConfigPath = null;
+    stopStatusMonitor();
+    if (!isRunning && !connectionDesired) return;
+    _markNativeConnectionLost();
+    const message = '无法确认 Android VPN 运行状态，已标记为断开，请重新连接';
+    log(message);
+    _notifyNativeRuntimeNotice(message);
   }
 
   void _applyNativeRunningFallback({required String source}) {

--- a/SSRVPN_Android/test/clash_service_test.dart
+++ b/SSRVPN_Android/test/clash_service_test.dart
@@ -421,7 +421,7 @@ void main() {
     expect(service.connectionDesired, isTrue);
   });
 
-  test('terminal state retry is bounded when every query fails', () async {
+  test('persistent terminal state failure eventually fails closed', () async {
     const channel = MethodChannel('com.ssrvpn/native');
     final messenger =
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
@@ -442,6 +442,15 @@ void main() {
     expect(stateReads, 3);
     expect(service.isRunning, isTrue);
     expect(service.connectionDesired, isTrue);
+
+    await Future<void>.delayed(const Duration(milliseconds: 9500));
+
+    expect(stateReads, 6);
+    expect(service.isRunning, isFalse);
+    expect(service.connectionDesired, isFalse);
+
+    await Future<void>.delayed(const Duration(milliseconds: 3200));
+    expect(stateReads, 6);
   });
 
   test(

--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -1,8 +1,8 @@
 # 项目健康状态
 
-最近审查：2026-08-01<br>
-当前应用版本：`v4.0.1`；公开发布状态与产物以 [GitHub Release](https://github.com/Elegying/SSRVPN/releases/latest) 为准。<br>
-审查基线：PR [#79](https://github.com/Elegying/SSRVPN/pull/79) 完成全仓审查与整改，PR [#74](https://github.com/Elegying/SSRVPN/pull/74)、[#80](https://github.com/Elegying/SSRVPN/pull/80) 和 [#81](https://github.com/Elegying/SSRVPN/pull/81) 完成依赖、资产与文档维护；上一轮受保护 `main` 基线为提交 `06921cb` 的 [CI run 30702971551](https://github.com/Elegying/SSRVPN/actions/runs/30702971551)。本轮可维护性结论以本文所在提交的完整本地门禁、对应 Pull Request 检查和合并后 `main` CI 共同为准。
+最近审查：2026-08-08<br>
+当前应用版本：`v4.0.3`；公开发布状态与产物以 [GitHub Release](https://github.com/Elegying/SSRVPN/releases/latest) 为准。<br>
+审查基线：公开版本 `v4.0.3`、提交 `bcca48a` 与 [CI run 30887916321](https://github.com/Elegying/SSRVPN/actions/runs/30887916321) 的三端构建及发布产物已核对；本文所在提交继续以完整本地门禁、对应 Pull Request 检查和合并后 `main` CI 共同作为当前结论。
 
 ## 综合结论与评分
 
@@ -14,13 +14,15 @@
 | 安全与隐私 | 92 | 凭据分平台保护、日志脱敏、最小化 macOS Release 权限、秘密扫描和依赖审查 |
 | 架构与可维护性 | 90 | 更新、macOS 原生支持和 Windows 代理模型形成可检查边界；高风险事务保留原顺序并受增长护栏保护 |
 | 测试与 CI | 93 | 四套覆盖率、三端原生门禁、发布故障注入、目标平台构建与安装烟雾 |
-| 文档与项目治理 | 92 | 41 份受版本控制 Markdown 自动校验，ADR、贡献、Issue/PR 和发布边界对齐 |
+| 文档与项目治理 | 92 | 43 份受版本控制 Markdown 自动校验，ADR、贡献、Issue/PR 和发布边界对齐 |
 | 性能与可观测性 | 85 | 有界诊断与离线关键路径基线已具备；真机启动/连接阶段数据仍可扩展 |
 
 评分依据是当前源码、测试、构建配置、文档、GitHub 安全设置和本轮实测，不把测试数量、覆盖率或文件变短单独当作质量。当前没有发现已知 P0-P1；剩余风险主要是目标平台人工证据、上游 Android 工具链迁移以及仍需真实 OS 故障注入才能继续拆分的生命周期事务。
 
 ## 本轮完成的优化
 
+- Android 状态收敛：原生运行状态连续读取失败时只执行三轮有界复核；仍无法确认则清除会话并标记断开，避免无限轮询和界面长期停留在错误的已连接状态。
+- 版本治理：`check-version-sync.sh` 同时校验本健康文档的当前应用版本，版本升级后若忘记更新审查基线会直接阻止门禁通过。
 - 可维护性边界：共享更新服务的稳定 façade 从 1534 行收敛为 513 行，下载/取消和校验后发布/恢复分别进入独立 part；公开调用入口、持久化格式、错误语义和发布顺序不变。
 - macOS 原生边界：`AppDelegate.swift` 从 2273 行降至 1999 行；核心身份/PID/有界输出与原生 owned-process 值对象进入 `CoreProcessSupport.swift`，安全单实例租约和窗口恢复进入 `ApplicationLifecycleSupport.swift`；代理状态快照和退出租约状态恢复为委托私有实现，Xcode RunnerTests 连续真实编译运行通过。
 - Windows 代理边界：系统代理事务入口从 1530 行降至 1432 行；私有快照、取消、恢复动作和原生日志模型迁入同一 Dart library 的 101 行 part，锁、PowerShell 调用、恢复判定和写入顺序未移动，47 项代理专项测试通过。
@@ -32,12 +34,12 @@
 - Windows 原生恢复：增加真实 C++ 注册表恢复测试，使用进程级 `RegOverridePredefKey` 沙箱验证有效日志精确恢复、损坏日志失败关闭；GitHub Windows runner 已实际编译运行。
 - 重复代码：启动器与窗口宿主的当前用户 SID 查询收敛为同一原生实现，保持既有用户边界。
 - 供应链：Pull Request 增加固定提交的 GitHub Dependency Review，中等及以上新增已知漏洞阻止合并；Dependency Graph、漏洞告警、私有漏洞报告和 SPDX SBOM 作为仓库基线。
-- 文档治理：文档门禁从手工 29 份扩展为自动枚举全部 41 份受版本控制 Markdown；历史 CHANGELOG 只检查链接，40 份当前文档还检查已知陈旧结论与危险发布命令。
+- 文档治理：文档门禁从手工 29 份扩展为自动枚举全部 43 份受版本控制 Markdown；历史 CHANGELOG 只检查链接，42 份当前文档还检查已知陈旧结论与危险发布命令。
 - 仓库入口：README、安全/贡献/维护/测试/路线图/排障、ADR、Issue 与 PR 模板已经对齐当前 4.x 行为和验证入口。
 
 ## 当前验证证据
 
-2026-08-01 在 macOS 26.5.2、Flutter 3.44.1 的当前提交执行：
+2026-08-08 在 macOS 26.5.2、Flutter 3.44.1 的当前提交执行：
 
 ```bash
 make verify
@@ -45,13 +47,13 @@ make verify
 
 结果：
 
-- 文档 41/41 本地链接检查、40/40 当前状态检查通过；317 个 Dart 文件格式与全部 ShellCheck 通过。
+- 文档 43/43 本地链接检查、42/42 当前状态检查通过；317 个 Dart 文件格式与全部 ShellCheck 通过。
 - 核心资产、版本、包指南、产品表面、结构边界、桌面安全存储、秘密扫描、免费分发和发布资产守卫通过。
-- 发布工具 248/248；macOS TUN/DNS 行为 25/25；workspace analyze 0 issue。
-- Shared 469 项通过，覆盖率 `82.49%`（`5186/6287`），门槛 65%。
-- Android Flutter 218 项通过，覆盖率 `63.89%`（`2091/3273`），门槛 30%；Gradle/JUnit 构建成功。
-- macOS Flutter 243 项通过，覆盖率 `65.54%`（`3285/5012`）；生命周期 `76.91%`（`623/810`），系统代理 `88.36%`（`387/438`）；RunnerTests 通过。
-- Windows Flutter 209 项通过，8 项仅限 Windows 主机的测试在 macOS 条件跳过；平台覆盖率 `48.47%`（`2716/5604`），生命周期 `20.68%`（`134/648`）。
+- 发布工具 276/276；macOS TUN/DNS 行为 25/25；workspace analyze 0 issue。
+- Shared 全套测试通过，覆盖率 `82.44%`（`5183/6287`），门槛 65%。
+- Android Flutter 219 项通过，覆盖率 `64.13%`（`2115/3298`），门槛 30%；Gradle/JUnit 构建成功。
+- macOS Flutter 247 项通过，覆盖率 `65.64%`（`3297/5023`）；生命周期 `76.91%`（`623/810`），系统代理 `88.32%`（`378/428`）；RunnerTests 通过。
+- Windows Flutter 210 项通过，8 项仅限 Windows 主机的测试在 macOS 条件跳过；平台覆盖率 `48.62%`（`2729/5613`），生命周期 `20.68%`（`134/648`）。
 - 关键路径 smoke：解析、合并与配置生成结构校验通过；耗时只作同环境观察值，不作为跨机器硬阈值。
 - 上一轮 PR #79、#74、#80、#81 的依赖审查、全历史秘密扫描、核心资产、Workspace、Android、macOS、Windows 共 7 项均通过；`main` CI 再次通过全部适用门禁。Windows runner 还实际完成 C++ 代理恢复测试、PowerShell 5.1 检查、安装器构建、安装/卸载及安装后立即升级 smoke；本轮 Windows 专属结论仍须由对应 PR 与合并后 CI 重新确认。
 
@@ -62,7 +64,7 @@ make verify
 - 自动化不能替代 TalkBack、VoiceOver、Narrator 的完整人工流程，也不能覆盖所有第三方网络、节点和系统升级组合。
 - Android 仍有 `android.builtInKotlin=false`、`android.newDsl=false` 与 KGP 兼容告警。当前 Flutter 插件链仍依赖这些边界；应等待上游支持后以 APK 与原生测试迁移，不为消除告警提前破坏构建。
 - 高认知复杂度继续集中在 Android VPN Service、macOS 核心/系统代理编排、Windows 生命周期和安装恢复。结构护栏只防止继续膨胀；后续必须先增加目标平台行为证据，再按 ADR-010 小步拆分。
-- `https://ssrvpn.vip/` 在本轮实时检查返回 Cloudflare 521。GitHub 仓库 Website 字段不应指向失效入口，恢复官网前需先修复源站并重新验证 HTTPS。
+- 官网可用性和下载链路需要独立实时核验；历史网络快照不作为当前状态结论，也不由本次客户端代码修复代替。
 
 ## 已固定的产品边界
 
@@ -77,7 +79,7 @@ make verify
 ## 下一阶段最高优先级
 
 1. 在真实 Android、macOS、Windows 上完成生命周期、无障碍与网络恢复矩阵，记录系统版本和脱敏证据。
-2. 修复 `ssrvpn.vip` 源站 521，确认 HTTPS 和下载入口后再恢复 GitHub Website 链接。
+2. 定期从公开网络和真实浏览器复核官网 HTTPS、下载入口与固定别名到版本化产物的一致性。
 3. 在新增行为时继续提高 Windows 生命周期覆盖率，不把当前 20% 门槛当成完成目标。
 4. 等待 Flutter/插件链完整支持 AGP 10 内置 Kotlin 与新 DSL 后，分步移除兼容开关。
 5. 修改 Android VPN Service、macOS 核心/系统代理或 Windows 恢复热点时，先补故障注入证据，再按 ADR-010 做单职责切片；不以行数下降作为完成标准。

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -54,4 +54,13 @@ if ! grep -Eq "^## \\[$version_pattern\\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHAN
   exit 1
 fi
 
+health_version="$(
+  awk -F '\140' '/^当前应用版本：/ { version=$2; sub(/^v/, "", version); print version; exit }' \
+    docs/PROJECT_HEALTH.md
+)"
+if [ "$health_version" != "$base_version" ]; then
+  echo "version check failed: docs/PROJECT_HEALTH.md is v${health_version:-unknown}, expected v$base_version" >&2
+  exit 1
+fi
+
 echo "Version sync check passed: $workspace_version"


### PR DESCRIPTION
## Summary

- bound Android native-state reconciliation after persistent platform-channel failures
- fail closed to a disconnected state instead of leaving stale connected UI and polling forever
- add a regression test for retry exhaustion and a version-sync guard for `docs/PROJECT_HEALTH.md`
- refresh project-health evidence from the complete local verification run

## Root cause

The low-frequency Android reconciliation callback recursively scheduled itself whenever every native state read failed. A persistent channel failure therefore had no terminal state and could keep both polling and presenting a stale connected state indefinitely.

## Verification

- `make verify`
- Android targeted service suite: 53 tests passed
- Android full Flutter suite: 219 tests passed, 64.13% coverage
- Shared: 82.44%; macOS: 65.64%; Windows: 48.62%
- version, documentation, Dart formatting, ShellCheck, analyzer, native tests, secret scan, release-tooling fault injection all passed

## Release scope

No release is included: no version bump, tag, GitHub Release, artifact publication, or release workflow dispatch.
