### PR TITLE
fix: restore Google Play delivery downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.4] - 2026-08-08
+
+### 修复
+
+- Google Play 应用分包使用的 `xn--ngstr-lra8j.com` 配送域名现在会在国内域名与 GeoIP 直连规则之前使用代理 DNS 和代理路由，避免国内缓存地址无法直连时下载停在末段并提示“无法安装”。
+- Android 原生 VPN 状态连续读取失败时只执行三轮有界复核；仍无法确认则清除会话并标记断开，避免无限轮询和界面长期停留在错误的已连接状态。
+
+### 测试
+
+- 新增 Google Play 配送域名的 DNS、规则顺序和国内直连回退回归，三端继续通过共享配置生成器使用同一结果。
+
+### 兼容性边界
+
+- 本版本没有修改 HTTP 订阅、75 个 Android 国内应用直连名单、三端 IPv4-only 策略、两页产品表面、macOS 免费 ad-hoc 分发或 Windows 未签名安装器单一分发策略。
+
 ## [4.0.3] - 2026-08-04
 
 ### 修复

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 4.0.3+4003
+version: 4.0.4+4004
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 4.0.3+4003
+version: 4.0.4+4004
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 4.0.3+4003
+version: 4.0.4+4004
 resolution: workspace
 
 environment:

--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -1,7 +1,7 @@
 # 项目健康状态
 
 最近审查：2026-08-08<br>
-当前应用版本：`v4.0.3`；公开发布状态与产物以 [GitHub Release](https://github.com/Elegying/SSRVPN/releases/latest) 为准。<br>
+当前应用版本：`v4.0.4`；公开发布状态与产物以 [GitHub Release](https://github.com/Elegying/SSRVPN/releases/latest) 为准。<br>
 审查基线：公开版本 `v4.0.3`、提交 `bcca48a` 与 [CI run 30887916321](https://github.com/Elegying/SSRVPN/actions/runs/30887916321) 的三端构建及发布产物已核对；本文所在提交继续以完整本地门禁、对应 Pull Request 检查和合并后 `main` CI 共同作为当前结论。
 
 ## 综合结论与评分
@@ -21,6 +21,7 @@
 
 ## 本轮完成的优化
 
+- Google Play 安装恢复：分包配送域名在国内域名和 GeoIP 直连规则之前固定使用代理 DNS 与代理路由，避免中国缓存地址无法直连时下载在末段失败；共享生成器保证三端规则一致。
 - Android 状态收敛：原生运行状态连续读取失败时只执行三轮有界复核；仍无法确认则清除会话并标记断开，避免无限轮询和界面长期停留在错误的已连接状态。
 - 版本治理：`check-version-sync.sh` 同时校验本健康文档的当前应用版本，版本升级后若忘记更新审查基线会直接阻止门禁通过。
 - 可维护性边界：共享更新服务的稳定 façade 从 1534 行收敛为 513 行，下载/取消和校验后发布/恢复分别进入独立 part；公开调用入口、持久化格式、错误语义和发布顺序不变。

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -76,7 +76,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '4.0.3';
+  static const String appVersion = '4.0.4';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -56,11 +56,16 @@ class AppConstants {
     'https://8.8.8.8/dns-query#PROXY',
   ];
 
-  static const List<String> openAiDomainSuffixes = [
+  /// International domains that must be resolved and routed through PROXY
+  /// before domestic domain or GeoIP rules can match them.
+  static const List<String> defaultProxyDomainSuffixes = [
     'chatgpt.com',
     'openai.com',
     'oaistatic.com',
     'oaiusercontent.com',
+    // Google Play delivery hosts use subdomains of this IDN/Punycode suffix.
+    // Some domestic resolvers return CN cache IPs that are unreachable directly.
+    'xn--ngstr-lra8j.com',
   ];
 
   // ── 文件路径 ──
@@ -132,13 +137,6 @@ class AppConstants {
     'IP-CIDR,172.16.0.0/12,DIRECT,no-resolve',
     'IP-CIDR,192.168.0.0/16,DIRECT,no-resolve',
     'IP-CIDR,100.64.0.0/10,DIRECT,no-resolve',
-  ];
-
-  static const List<String> openAiProxyRules = [
-    'DOMAIN-SUFFIX,chatgpt.com,PROXY',
-    'DOMAIN-SUFFIX,openai.com,PROXY',
-    'DOMAIN-SUFFIX,oaistatic.com,PROXY',
-    'DOMAIN-SUFFIX,oaiusercontent.com,PROXY',
   ];
 
   static const List<String> defaultRuleProviderDirectRules = [

--- a/packages/ssrvpn_shared/lib/services/clash_config_generator.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_config_generator.dart
@@ -183,7 +183,7 @@ class ClashConfigGenerator {
       for (final domain in forceProxyDomainSuffixes) {
         nameserverPolicies['+.$domain'] = AppConstants.trustedProxyNameservers;
       }
-      for (final domain in AppConstants.openAiDomainSuffixes) {
+      for (final domain in AppConstants.defaultProxyDomainSuffixes) {
         nameserverPolicies.putIfAbsent(
           '+.$domain',
           () => AppConstants.trustedProxyNameservers,
@@ -290,7 +290,11 @@ class ClashConfigGenerator {
             (rule) => rule.isNotEmpty,
           ),
     );
-    orderedRules.addAll(AppConstants.openAiProxyRules);
+    orderedRules.addAll(
+      AppConstants.defaultProxyDomainSuffixes.map(
+        (domain) => 'DOMAIN-SUFFIX,$domain,PROXY',
+      ),
+    );
     orderedRules.addAll(AppConstants.defaultRuleProviderDirectRules);
     orderedRules.addAll(AppConstants.defaultDirectRules);
     orderedRules.add(AppConstants.defaultGeoIpDirectRule);

--- a/packages/ssrvpn_shared/test/clash_config_generator_test.dart
+++ b/packages/ssrvpn_shared/test/clash_config_generator_test.dart
@@ -302,6 +302,46 @@ proxies:
     });
 
     test(
+      'Google Play delivery never falls through to domestic DNS or routing',
+      () {
+        const yaml = '''
+proxies:
+  - name: "Test Node"
+    type: ss
+    server: node.example.com
+    port: 443
+    cipher: aes-256-gcm
+    password: "test123"
+''';
+
+        final parsed = loadYaml(
+          ClashConfigGenerator.generateConfig(yaml, AppSettings()),
+        ) as YamlMap;
+        final dns = parsed['dns'] as YamlMap;
+        final policy = dns['nameserver-policy'] as YamlMap;
+        final policyKeys = policy.keys.cast<String>().toList();
+        final rules = (parsed['rules'] as YamlList).cast<String>();
+        final proxyRuleIndex =
+            rules.indexOf('DOMAIN-SUFFIX,xn--ngstr-lra8j.com,PROXY');
+
+        expect(
+          (policy['+.xn--ngstr-lra8j.com'] as YamlList).cast<String>(),
+          everyElement(contains('#PROXY')),
+        );
+        expect(
+          policyKeys.indexOf('+.xn--ngstr-lra8j.com'),
+          lessThan(policyKeys.indexOf('rule-set:ssrvpn-geosite-cn')),
+        );
+        expect(proxyRuleIndex, isNonNegative);
+        expect(
+          proxyRuleIndex,
+          lessThan(rules.indexOf('RULE-SET,ssrvpn-geosite-cn,DIRECT')),
+        );
+        expect(proxyRuleIndex, lessThan(rules.indexOf('GEOIP,CN,DIRECT')));
+      },
+    );
+
+    test(
       'force-proxy domains override domestic DNS and routing without duplicates',
       () {
         const yaml = '''


### PR DESCRIPTION
## Summary

- route Google Play delivery hosts under `xn--ngstr-lra8j.com` through proxy DNS and `PROXY` before domestic domain and GeoIP direct rules
- generate built-in international proxy DNS/routing entries from one canonical suffix list
- add a regression covering DNS resolver selection, `nameserver-policy` order, and routing order
- prepare the synchronized `v4.0.4+4004` patch release

## Root cause

On a rooted Android 16 device, Google Play's Telegram split download repeatedly stopped near completion. Finsky reported `CANNOT_CONNECT` / Cronet `ERR_CONNECTION_CLOSED`, while SSRVPN routed the observed Play delivery hosts to Chinese cache IPs through `GEOIP,CN,DIRECT`; those direct connections timed out.

## Verification

- RED: the new Google Play delivery regression failed on the previous implementation because the proxy DNS policy was absent
- GREEN: focused shared generator tests pass
- `make verify` passes on the final `v4.0.4` tree
  - release tooling: 276/276
  - workspace analyze: 0 issues
  - Android Flutter/native tests and coverage gate
  - macOS Flutter/Xcode tests and coverage gates
  - Windows Flutter tests and coverage gates (Windows-host-only cases remain CI-gated)
- fresh-context adversarial review found no P1 blocker; its P2 policy-order test gap was added and reverified

## Compatibility boundaries

No change to HTTP subscriptions, the 75 Android domestic-app bypass list, IPv4-only runtime policy, the two-page product surface, macOS ad-hoc distribution, or the Windows installer-only release channel.
