### PR TITLE
fix(android): verify VPN data plane before connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.6] - 2026-08-14
+
+### 修复
+
+- Android VPN 改用与成熟客户端一致的虚拟 TUN 地址、虚拟 DNS 和非阻塞文件描述符契约，SSRVPN 自身也不再整包绕过 VPN；Mihomo 出站连接继续逐 socket 使用系统 `protect()`，避免部分 Android 设备显示已连接但浏览器没有实际流量。
+- Android 原生服务只有在普通应用流量通过 TUN 真实取得 HTTP 204 后才发布“已连接”；探测会在 Google、YouTube 与 Cloudflare 三个有界端点间轮换，全部失败时清理 VPN 并提示切换节点或重试。
+
+### 测试
+
+- 新增 Android TUN 地址、虚拟 DNS、应用排除与数据面启动门禁原生回归，覆盖重定向/非 204 拒绝、跨提供方重试和三次失败关闭。
+- 完整发布门禁继续覆盖共享配置、Android Flutter 与 Kotlin 原生测试、macOS/Windows 回归、发布工具、秘密扫描、静态分析和覆盖率阈值。
+
+### 兼容性边界
+
+- 本版本不修改强制代理网站输入与规则顺序、75 个 Android 国内应用直连名单、HTTP 订阅、IPv6 防泄漏、两页产品表面、macOS 免费 ad-hoc 分发或 Windows 未签名安装器单一分发策略。
+
 ## [4.0.5] - 2026-08-08
 
 ### 修复

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
@@ -424,7 +424,6 @@ class SsrvpnVpnService : VpnService() {
         requestId: String?,
         recoveryAttempt: Int
     ) {
-        val packageName = packageName
         try {
             ensureStartCurrent(startToken)
             Log.d(TAG, "Initializing protect pipe...")
@@ -447,12 +446,11 @@ class SsrvpnVpnService : VpnService() {
             builder.setSession("SSRVPN")
             // IPv4 公网路由保留局域网直连；IPv6 全量进入 VPN，避免泄漏。
             VpnRouteInstaller.configure(builder)
-            builder.addDnsServer("223.5.5.5")
-            builder.addDnsServer("8.8.8.8")
             builder.setMtu(1500)
-            builder.setBlocking(true)
-            // 排除自身、无线调试服务和明确的国内服务应用。
-            val bypassedDomesticApps = VpnAppExclusionInstaller.install(builder, packageName)
+            // Keep Android's documented default non-blocking TUN contract.
+            builder.setBlocking(false)
+            // Keep this app inside TUN; protect Mihomo outbound sockets individually.
+            val bypassedDomesticApps = VpnAppExclusionInstaller.install(builder)
             Log.i(TAG, "Bypassing ${bypassedDomesticApps.size} installed domestic apps")
 
             vpnFd = builder.establish()
@@ -505,6 +503,14 @@ class SsrvpnVpnService : VpnService() {
                     ensureStartCurrent(startToken)
                     Log.d(TAG, "Core started!")
                     applyProxySelection(apiPort, apiSecret, selectedNodeName)
+                    val dataPlaneHealthy =
+                        VpnDataPlaneProbe.isStartupHealthy(protectThread) {
+                            ensureStartCurrent(startToken)
+                        }
+                    if (!dataPlaneHealthy) {
+                        return rejectCoreStart(requestId, "VPN 数据通道不可用，请切换节点或重试", recoveryAttempt)
+                    }
+                    ensureStartCurrent(startToken)
                     val published = startGeneration.runIfCurrent(startToken) {
                         runtimeDiagnostics.claimTunDescriptor(tunFd)
                         NativeConnectionSession.publishRunning(configPath)

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnAppExclusionInstaller.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnAppExclusionInstaller.kt
@@ -9,15 +9,16 @@ internal object VpnAppExclusionInstaller {
         "com.google.android.adb"
     )
 
-    fun install(
-        builder: VpnService.Builder,
-        vpnPackageName: String
-    ): List<String> {
-        builder.addDisallowedApplication(vpnPackageName)
+    fun install(builder: VpnService.Builder): List<String> =
+        install { packageName -> addIfInstalled(builder, packageName) }
+
+    internal fun install(addDisallowedApplication: (String) -> Boolean): List<String> {
         val bypassedDomesticApps = DomesticAppBypassPolicy.applyInstalled { packageName ->
-            addIfInstalled(builder, packageName)
+            addDisallowedApplication(packageName)
         }
-        adbPackages.forEach { addIfInstalled(builder, it) }
+        adbPackages.forEach { packageName ->
+            addDisallowedApplication(packageName)
+        }
         return bypassedDomesticApps
     }
 

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnDataPlaneProbe.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnDataPlaneProbe.kt
@@ -1,0 +1,67 @@
+package com.ssrvpn.android
+
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Verifies the same Android VPN data path used by browsers and other apps.
+ *
+ * The SSRVPN package must remain inside the VPN for this probe to be
+ * meaningful. Native Mihomo outbound sockets are kept outside the VPN one by
+ * one through VpnService.protect(), rather than bypassing this whole package.
+ */
+internal object VpnDataPlaneProbe {
+    private val endpoints = listOf(
+        "https://www.gstatic.com/generate_204",
+        "https://www.youtube.com/generate_204",
+        "https://cp.cloudflare.com/generate_204"
+    )
+    private const val maxBoundedAttempts = 3
+    private const val requestTimeoutMillis = 2_000
+
+    fun isStartupHealthy(protectThread: Thread?, beforeAttempt: () -> Unit): Boolean =
+        isReachable(retryDelayMillis = 200, beforeAttempt = beforeAttempt) &&
+            VpnRuntimeHealth.hasProtectMonitor(protectThread)
+
+    fun isReachable(
+        endpoints: List<String> = this.endpoints,
+        maxAttempts: Int = maxBoundedAttempts,
+        retryDelayMillis: Long = 0,
+        beforeAttempt: () -> Unit = {},
+        fetchStatus: (String) -> Int? = ::fetchHttpStatus
+    ): Boolean {
+        if (endpoints.isEmpty()) return false
+        val attempts = maxAttempts.coerceIn(1, maxBoundedAttempts)
+        repeat(attempts) { index ->
+            beforeAttempt()
+            val endpoint = endpoints[index % endpoints.size]
+            if (fetchStatus(endpoint) == HttpURLConnection.HTTP_NO_CONTENT) {
+                return true
+            }
+            if (index + 1 < attempts && retryDelayMillis > 0) {
+                Thread.sleep(retryDelayMillis)
+            }
+        }
+        return false
+    }
+
+    private fun fetchHttpStatus(endpoint: String): Int? {
+        val connection = try {
+            URL(endpoint).openConnection() as HttpURLConnection
+        } catch (_: Exception) {
+            return null
+        }
+        return try {
+            connection.connectTimeout = requestTimeoutMillis
+            connection.readTimeout = requestTimeoutMillis
+            connection.instanceFollowRedirects = false
+            connection.useCaches = false
+            connection.setRequestProperty("Cache-Control", "no-cache")
+            connection.responseCode
+        } catch (_: Exception) {
+            null
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnRouteInstaller.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnRouteInstaller.kt
@@ -3,16 +3,26 @@ package com.ssrvpn.android
 import android.net.VpnService
 
 internal object VpnRouteInstaller {
+    private const val clientAddress = "172.19.0.1"
+    private const val clientPrefixLength = 30
+    private const val dnsAddress = "172.19.0.2"
+
     fun configure(builder: VpnService.Builder) {
-        configure(builder::addAddress, builder::addRoute)
+        configure(builder::addAddress, builder::addRoute, builder::addDnsServer)
     }
 
     internal fun configure(
         addAddress: (String, Int) -> Unit,
-        addRoute: (String, Int) -> Unit
+        addRoute: (String, Int) -> Unit,
+        addDnsServer: (String) -> Unit
     ) {
-        addAddress("198.18.0.1", 32)
+        // Keep the interface and its synthetic DNS peer on a dedicated subnet.
+        // The explicit /32 DNS route is required because 172.16.0.0/12 is
+        // otherwise intentionally left outside the VPN for LAN compatibility.
+        addAddress(clientAddress, clientPrefixLength)
         addAddress(VpnIpv6Config.address, VpnIpv6Config.addressPrefixLength)
+        addDnsServer(dnsAddress)
+        addRoute(dnsAddress, 32)
         for (route in PublicIpv4Routes.routes) {
             addRoute(route.address, route.prefixLength)
         }

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnAppExclusionInstallerTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnAppExclusionInstallerTest.kt
@@ -1,0 +1,28 @@
+package com.ssrvpn.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VpnAppExclusionInstallerTest {
+    @Test
+    fun `vpn app stays inside tunnel while domestic and adb apps remain bypassed`() {
+        val installed = setOf(
+            "com.ssrvpn.android",
+            "com.ss.android.ugc.aweme",
+            "com.tencent.mm",
+            "com.android.adb"
+        )
+        val attempted = mutableListOf<String>()
+
+        VpnAppExclusionInstaller.install { packageName ->
+            attempted += packageName
+            packageName in installed
+        }
+
+        assertFalse(attempted.contains("com.ssrvpn.android"))
+        assertTrue(attempted.contains("com.ss.android.ugc.aweme"))
+        assertTrue(attempted.contains("com.tencent.mm"))
+        assertTrue(attempted.contains("com.android.adb"))
+    }
+}

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnDataPlaneProbeTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnDataPlaneProbeTest.kt
@@ -1,0 +1,67 @@
+package com.ssrvpn.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VpnDataPlaneProbeTest {
+    @Test
+    fun `accepts only a real generate 204 response`() {
+        assertTrue(VpnDataPlaneProbe.isReachable(fetchStatus = { 204 }))
+        assertFalse(VpnDataPlaneProbe.isReachable(fetchStatus = { 200 }))
+        assertFalse(VpnDataPlaneProbe.isReachable(fetchStatus = { 302 }))
+    }
+
+    @Test
+    fun `rotates independent endpoints and succeeds when a later path works`() {
+        val attempted = mutableListOf<String>()
+
+        val reachable = VpnDataPlaneProbe.isReachable(
+            endpoints = listOf("first", "second"),
+            maxAttempts = 3,
+            fetchStatus = { endpoint ->
+                attempted += endpoint
+                if (attempted.size == 3) 204 else null
+            }
+        )
+
+        assertTrue(reachable)
+        assertEquals(listOf("first", "second", "first"), attempted)
+    }
+
+    @Test
+    fun `fails closed after all bounded attempts`() {
+        var attempts = 0
+
+        val reachable = VpnDataPlaneProbe.isReachable(
+            maxAttempts = 9,
+            fetchStatus = {
+                attempts++
+                null
+            }
+        )
+
+        assertFalse(reachable)
+        assertEquals(3, attempts)
+    }
+
+    @Test
+    fun `default attempts span independent providers`() {
+        val attempted = mutableListOf<String>()
+
+        VpnDataPlaneProbe.isReachable(fetchStatus = { endpoint ->
+            attempted += endpoint
+            null
+        })
+
+        assertEquals(
+            listOf(
+                "https://www.gstatic.com/generate_204",
+                "https://www.youtube.com/generate_204",
+                "https://cp.cloudflare.com/generate_204"
+            ),
+            attempted
+        )
+    }
+}

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnIpv6ConfigTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnIpv6ConfigTest.kt
@@ -17,16 +17,20 @@ class VpnIpv6ConfigTest {
     fun `route installer applies both addresses public IPv4 and IPv6 default`() {
         val addresses = mutableListOf<Pair<String, Int>>()
         val routes = mutableListOf<Pair<String, Int>>()
+        val dnsServers = mutableListOf<String>()
 
         VpnRouteInstaller.configure(
             addAddress = { address, prefix -> addresses += address to prefix },
-            addRoute = { address, prefix -> routes += address to prefix }
+            addRoute = { address, prefix -> routes += address to prefix },
+            addDnsServer = dnsServers::add
         )
 
         assertEquals(
-            listOf("198.18.0.1" to 32, "fdfe:dcba:9876::1" to 126),
+            listOf("172.19.0.1" to 30, "fdfe:dcba:9876::1" to 126),
             addresses
         )
+        assertEquals(listOf("172.19.0.2"), dnsServers)
+        assertTrue(routes.contains("172.19.0.2" to 32))
         assertTrue(routes.contains("102.0.0.0" to 7))
         assertTrue(routes.contains("::" to 0))
     }

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 4.0.5+4005
+version: 4.0.6+4006
 resolution: workspace
 
 environment:

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 4.0.5+4005
+version: 4.0.6+4006
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 4.0.5+4005
+version: 4.0.6+4006
 resolution: workspace
 
 environment:

--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -1,7 +1,7 @@
 # 项目健康状态
 
 最近审查：2026-08-08<br>
-当前应用版本：`v4.0.5`；公开发布状态与产物以 [GitHub Release](https://github.com/Elegying/SSRVPN/releases/latest) 为准。<br>
+当前应用版本：`v4.0.6`；公开发布状态与产物以 [GitHub Release](https://github.com/Elegying/SSRVPN/releases/latest) 为准。<br>
 审查基线：公开版本 `v4.0.3`、提交 `bcca48a` 与 [CI run 30887916321](https://github.com/Elegying/SSRVPN/actions/runs/30887916321) 的三端构建及发布产物已核对；本文所在提交继续以完整本地门禁、对应 Pull Request 检查和合并后 `main` CI 共同作为当前结论。
 
 ## 综合结论与评分

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -77,7 +77,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '4.0.5';
+  static const String appVersion = '4.0.6';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/scripts/check-android-native-bridge-guards.sh
+++ b/scripts/check-android-native-bridge-guards.sh
@@ -25,6 +25,8 @@ HOME_PARTS=(
 )
 PUBLIC_ROUTES="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/PublicIpv4Routes.kt"
 VPN_ROUTE_INSTALLER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnRouteInstaller.kt"
+VPN_APP_EXCLUSION_INSTALLER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnAppExclusionInstaller.kt"
+VPN_DATA_PLANE_PROBE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnDataPlaneProbe.kt"
 NOTIFICATION_SUPPORT="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnNotificationSupport.kt"
 NOTIFICATION_GATE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NotificationGenerationGate.kt"
 CORE_LIVENESS_MONITOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreLivenessMonitor.kt"
@@ -96,6 +98,15 @@ require_route_text() {
   local needle="$1"
   if ! grep -Fq "$needle" "$VPN_ROUTE_INSTALLER"; then
     echo "Android VPN route guard check failed: missing '$needle'" >&2
+    exit 1
+  fi
+}
+
+require_file_text() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "Android native file guard failed in $file: missing '$needle'" >&2
     exit 1
   fi
 }
@@ -643,11 +654,31 @@ grep -Fq '<string name="disconnect_recovery_status">' "$ANDROID_STRINGS" || {
 }
 require_text "VpnRouteInstaller.configure(builder)"
 require_route_text "PublicIpv4Routes.routes"
-require_route_text "configure(builder::addAddress, builder::addRoute)"
-require_route_text 'addAddress("198.18.0.1", 32)'
+require_route_text "configure(builder::addAddress, builder::addRoute, builder::addDnsServer)"
+require_route_text 'private const val clientAddress = "172.19.0.1"'
+require_route_text 'private const val clientPrefixLength = 30'
+require_route_text 'private const val dnsAddress = "172.19.0.2"'
+require_route_text 'addDnsServer(dnsAddress)'
+require_route_text 'addRoute(dnsAddress, 32)'
 require_route_text "VpnIpv6Config.address"
 require_route_text "addRoute(route.address, route.prefixLength)"
 require_route_text "VpnIpv6Config.defaultRoute"
+require_text "builder.setBlocking(false)"
+require_text "VpnAppExclusionInstaller.install(builder)"
+require_text "VpnDataPlaneProbe.isStartupHealthy("
+require_text '"VPN 数据通道不可用，请切换节点或重试"'
+require_file_text "$VPN_DATA_PLANE_PROBE" '"https://www.gstatic.com/generate_204"'
+require_file_text "$VPN_DATA_PLANE_PROBE" '"https://www.youtube.com/generate_204"'
+require_file_text "$VPN_DATA_PLANE_PROBE" '"https://cp.cloudflare.com/generate_204"'
+require_file_text "$VPN_DATA_PLANE_PROBE" "HttpURLConnection.HTTP_NO_CONTENT"
+require_file_text "$VPN_APP_EXCLUSION_INSTALLER" "fun install(builder: VpnService.Builder)"
+require_file_text "$VPN_APP_EXCLUSION_INSTALLER" "DomesticAppBypassPolicy.applyInstalled"
+require_file_text "$VPN_APP_EXCLUSION_INSTALLER" "adbPackages.forEach"
+if grep -Fq "vpnPackageName" "$VPN_APP_EXCLUSION_INSTALLER" ||
+  grep -Fq "VpnAppExclusionInstaller.install(builder, packageName)" "$SERVICE"; then
+  echo "Android VPN app exclusion guard failed: SSRVPN must stay inside its own TUN" >&2
+  exit 1
+fi
 require_text "VpnNotificationSupport.createChannel(this, CHANNEL_ID)"
 require_text "NativeConnectionSnapshotStore.read(this)"
 require_text "notificationUpdatePolicy.publishIfChanged(it)"
@@ -876,7 +907,7 @@ from pathlib import Path
 service = Path(sys.argv[1])
 support = Path(sys.argv[2])
 line_count = len(service.read_text(encoding="utf-8").splitlines())
-if line_count > 915:
+if line_count > 920:
     raise SystemExit(f"{service}: VPN service grew to {line_count} lines")
 if "fun formatBytes(bytes: Long)" not in support.read_text(encoding="utf-8"):
     raise SystemExit(f"{support}: missing notification byte formatter")


### PR DESCRIPTION
## Summary

- align Android TUN address, virtual DNS, and non-blocking fd handling with the working VpnService model
- keep SSRVPN inside its own VPN so startup verification exercises the real browser data path while Mihomo sockets remain individually protected
- require a bounded real HTTP 204 data-plane result before publishing connected state
- preserve force-proxy rules, domestic app bypass, LAN exclusions, and IPv6 leak prevention
- prepare v4.0.6+4006

## Verification

- make verify
- Android native Gradle unit tests
- Android force-proxy/settings regression tests
- Android native bridge guards
- local flutter build apk --debug
- local findings-first code review and fresh-context adversarial scenario review: no blocking findings

## Evidence boundary

No ADB device is attached to this workstation, so Samsung Android 16 / One UI 8.5 real-device acceptance remains a post-build field check; this PR does not claim that device test.