### PR TITLE
fix(windows): harden TUN teardown and release wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows 安装器在内置更新交接后只给旧客户端 3 秒正常退出，未释放启动器即进入带 PID、路径、会话和创建时间复核的强制清理；安装过程会结束当前会话中的全部 SSRVPN、Mihomo，以及常见 Clash、sing-box、Xray、V2Ray、Shadowsocks、Hysteria、TUIC、NaiveProxy、Trojan、OpenVPN、WireGuard、Tailscale 和 ZeroTier 进程，不再因便携副本、其他 Mihomo 或旧启动器残留而在覆盖前直接报错。
 - Windows 安装器现在请求管理员权限后再执行残留进程清理，解决普通权限安装器无法读取已提升 SSRVPN/Mihomo 的映像路径而报 `IDENTITY_UNVERIFIED`；安装目录仍保持当前用户的 LocalAppData。不可读取的可选第三方代理进程会被记录并跳过，不再阻断已验证 SSRVPN 实例的升级。
 - Windows 连接提交前会再次核对刚取得的系统代理端点；Mihomo 启动就绪失败不再统一误报“电脑性能不足”，而是保留控制 API、TUN listener 或代理所有权的实际诊断原因。
+- Windows TUN 残留清理总预算由 15 秒放宽到 30 秒，仍要求连续两次确认网卡、地址和路由均已消失；慢速 PowerShell 网络模块即使出现一次完整探测超时，也不会过早阻断连接或升级。
 - Windows 代理所有权日志现在区分“代理被关闭、地址被清空、地址被其他程序修改”；原生代理恢复单测不再向真实 WinINet 会话广播全局代理刷新，避免开发机或 CI 自托管机上正在使用的代理客户端被测试意外断开。
+- 一键发版在自动创建 GeoIP PR 后会直接等待受保护的 PR 检查，并为 GitHub 要求的维护者批准保留 30 分钟；不再重复调度无法附着到 PR 的分支 CI，也不会在一分钟内误判“检查未注册”。
 
 ## [4.0.6] - 2026-08-14
 

--- a/SSRVPN_Windows/lib/services/windows_tun_runtime_probe.dart
+++ b/SSRVPN_Windows/lib/services/windows_tun_runtime_probe.dart
@@ -59,6 +59,7 @@ const _tunRouteDestinations = <String>[
 // observations still fit, while avoiding a permanent fail-closed loop caused
 // solely by the previous 3-second cold-start ceiling.
 const _windowsNetworkCmdletTimeout = Duration(seconds: 6);
+const windowsTunTeardownTimeout = Duration(seconds: 30);
 
 class WindowsTunTeardownGate {
   final _interfaces = <WindowsTunInterfaceIdentity>{};
@@ -111,7 +112,7 @@ class WindowsTunTeardownGate {
 
 Future<bool> waitForWindowsTunTeardown({
   required Future<WindowsTunResidualProbeResult> Function() probe,
-  Duration timeout = const Duration(seconds: 15),
+  Duration timeout = windowsTunTeardownTimeout,
   Duration pollInterval = const Duration(milliseconds: 100),
   Future<void> Function(Duration duration)? wait,
 }) async {

--- a/SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart
+++ b/SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart
@@ -98,6 +98,11 @@ void main() {
     expect(calls, 1);
   });
 
+  test('production teardown budget tolerates a full transient probe timeout',
+      () {
+    expect(windowsTunTeardownTimeout, const Duration(seconds: 30));
+  });
+
   test('TUN teardown gate retains captured identities until gone', () {
     final gate = WindowsTunTeardownGate()..markPending(const [identity7]);
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -85,9 +85,16 @@ wait_for_workflow() {
 
 wait_for_pull_request_checks() {
   local pull_request=$1
+  local checks_url=$2
   local check_count=""
+  local warned=false
 
-  for _ in {1..30}; do
+  # Pull-request workflows created by GITHUB_TOKEN can remain in
+  # action_required until a maintainer approves them. Keep the release
+  # transaction open long enough for that approval instead of failing after
+  # one minute. We still require the repository's protected checks and never
+  # bypass branch protection.
+  for _ in {1..90}; do
     check_count="$(gh pr checks "$pull_request" \
       --required --json name --jq 'length' 2>/dev/null || true)"
     if [[ "$check_count" =~ ^[1-9][0-9]*$ ]]; then
@@ -95,9 +102,13 @@ wait_for_pull_request_checks() {
         --required --watch --fail-fast --interval 20
       return
     fi
-    sleep 2
+    if [ "$warned" = false ]; then
+      echo "::warning::Approve the pending GitHub Actions workflow for pull request $pull_request, then this release will continue automatically: $checks_url" >&2
+      warned=true
+    fi
+    sleep 20
   done
-  fail "Required checks did not register for pull request $pull_request"
+  fail "Required checks were not approved and registered for pull request $pull_request within 30 minutes: $checks_url"
 }
 
 require_tag_absent() {
@@ -209,13 +220,11 @@ if ! git diff --quiet -- docs/GEOIP_SOURCE.txt; then
   if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
     fail "Could not determine the GeoIP pull request number"
   fi
-  # Pull requests created with GITHUB_TOKEN do not trigger another workflow
-  # run. Dispatch CI explicitly for the exact automation branch, then require
-  # the resulting checks to be attached to the pull request before merging.
-  IFS=$'\t' read -r branch_ci_run_id branch_ci_url \
-    < <(dispatch_workflow "ci.yml" "$branch")
-  wait_for_workflow "$branch_ci_run_id"
-  wait_for_pull_request_checks "$pr_number"
+  # GitHub holds pull-request workflows created by GITHUB_TOKEN for maintainer
+  # approval. A separately dispatched branch run does not attach its checks to
+  # the pull request, so wait for the protected PR checks themselves.
+  branch_ci_url="$pr_url/checks"
+  wait_for_pull_request_checks "$pr_number" "$branch_ci_url"
 
   git fetch --no-tags origin main:refs/remotes/origin/main
   if [ "$(git rev-parse --verify 'origin/main^{commit}')" != "$main_sha" ]; then
@@ -279,7 +288,7 @@ append_summary "## Release preparation for $tag"
 append_summary "- GeoIP changed: $geoip_changed"
 if [ -n "$pr_url" ]; then
   append_summary "- GeoIP pull request: $pr_url"
-  append_summary "- Branch CI: $branch_ci_url"
+  append_summary "- Protected PR checks: $branch_ci_url"
 fi
 append_summary "- Exact-main CI: $main_ci_url"
 append_summary "- Release workflow: $release_run_url"

--- a/scripts/test_prepare_release_workflow.py
+++ b/scripts/test_prepare_release_workflow.py
@@ -293,10 +293,8 @@ class PrepareReleaseWorkflowTest(unittest.TestCase):
         mirror = preparer.index("python3 scripts/ensure-geoip-mirror.py --upload")
         verify = preparer.index("bash scripts/verify-core-assets.sh")
         create_pr = preparer.index("gh pr create")
-        branch_dispatch = preparer.index('dispatch_workflow "ci.yml" "$branch"')
-        branch_ci = preparer.index('wait_for_workflow "$branch_ci_run_id"')
         branch_checks = preparer.index(
-            'wait_for_pull_request_checks "$pr_number"'
+            'wait_for_pull_request_checks "$pr_number" "$branch_ci_url"'
         )
         merge_pr = preparer.index("gh pr merge")
         main_ci = preparer.index('dispatch_workflow "ci.yml" main')
@@ -310,10 +308,8 @@ class PrepareReleaseWorkflowTest(unittest.TestCase):
         self.assertLess(bootstrap, sync)
         self.assertLess(sync, mirror)
         self.assertLess(mirror, verify)
-        self.assertLess(verify, branch_dispatch)
-        self.assertLess(create_pr, branch_dispatch)
-        self.assertLess(branch_dispatch, branch_ci)
-        self.assertLess(branch_ci, branch_checks)
+        self.assertLess(verify, create_pr)
+        self.assertLess(create_pr, branch_checks)
         self.assertLess(branch_checks, merge_pr)
         self.assertLess(merge_pr, main_ci)
         self.assertLess(main_ci, final_freshness)
@@ -325,6 +321,9 @@ class PrepareReleaseWorkflowTest(unittest.TestCase):
         self.assertNotIn("git add .", preparer)
         self.assertNotIn("git push --force", preparer)
         self.assertNotIn("--admin", preparer)
+        self.assertNotIn('dispatch_workflow "ci.yml" "$branch"', preparer)
+        self.assertIn("within 30 minutes", preparer)
+        self.assertIn("Approve the pending GitHub Actions workflow", preparer)
 
     def test_existing_tag_or_release_blocks_before_geoip_mutation(self) -> None:
         preparer = PREPARER.read_text(encoding="utf-8")
@@ -354,18 +353,12 @@ class PrepareReleaseWorkflowTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         create_pr = commands.index("gh pr create")
-        branch_dispatch = commands.index(
-            "ref=automation/release-4.0.2-geoip-9001-1"
-        )
-        branch_ci = commands.index("gh run watch 101")
         branch_checks = commands.index("gh pr checks 84")
         merge_pr = commands.index("gh pr merge")
         main_dispatch = commands.index("ref=main")
         tag_push = commands.index("git push origin refs/tags/v4.0.2")
         release_dispatch = commands.index("workflows/release.yml/dispatches")
-        self.assertLess(create_pr, branch_dispatch)
-        self.assertLess(branch_dispatch, branch_ci)
-        self.assertLess(branch_ci, branch_checks)
+        self.assertLess(create_pr, branch_checks)
         self.assertLess(branch_checks, merge_pr)
         self.assertLess(merge_pr, main_dispatch)
         self.assertLess(main_dispatch, tag_push)
@@ -382,8 +375,9 @@ class PrepareReleaseWorkflowTest(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("gh pr create", commands)
-        self.assertIn("ref=automation/release-4.0.2-geoip-9001-1", commands)
-        self.assertIn("gh run watch 101", commands)
+        self.assertIn("gh pr checks 84", commands)
+        self.assertNotIn("ref=automation/release-4.0.2-geoip-9001-1", commands)
+        self.assertNotIn("gh run watch 101", commands)
         self.assertNotIn("git push origin --delete", commands)
         self.assertNotIn("git push origin refs/tags/v4.0.2", commands)
         self.assertNotIn("workflows/release.yml/dispatches", commands)


### PR DESCRIPTION
## Summary
- extend Windows TUN teardown verification to 30 seconds so one slow PowerShell network probe cannot prematurely block reconnect or upgrade
- wait up to 30 minutes for protected checks on GITHUB_TOKEN-created GeoIP PRs that require maintainer approval
- remove the duplicate branch workflow dispatch whose checks cannot attach to the pull request

## Verification
- Windows `flutter analyze`
- Windows full Flutter suite: 219 passed
- TUN runtime probe suite: 22 passed
- release tooling suite: 279 passed
- Prepare Release workflow tests: 9 passed
- documentation consistency checks passed

Note: local ShellCheck was unavailable in WSL; the repository CI job provides that gate.