### PR TITLE
fix(android): prevent immediate disconnect after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.10] - 2026-08-17
+
+### 修复
+
+- Android 原生 VPN 已确认并持有运行配置后，Flutter 不再用第二次文件系统查询覆盖原生会话事实，避免部分设备把有效配置误判为不存在并在连接成功后立即自动断开。
+- Android socket protect 监控保留原生管道所有权、改用可主动关闭的独立读取副本；停止时关闭阻塞读取并等待线程退出，避免清理超时和恢复页强制结束进程。
+
+### 测试边界
+
+- 新增原生配置证明与阻塞 protect 监控退出回归；通过 Android Kotlin 单测、Flutter 服务层回归、静态分析和原生桥接门禁，并在正式签名构建发布前执行 Android 真机持续连接与实际数据通道验收。
+
 ## [4.0.9] - 2026-08-16
 
 ### 修复

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt
@@ -322,6 +322,14 @@ class MainActivity : FlutterActivity() {
         }
         callback = callback@{ success, message, capturedState ->
             if (!completed.compareAndSet(false, true)) return@callback
+            Log.d(
+                "MainActivity",
+                "VPN start result: success=$success " +
+                    "running=${capturedState?.get("running")} " +
+                    "transitioning=${capturedState?.get("transitioning")} " +
+                    "configTrusted=${capturedState?.get("protectedConfigTrusted")} " +
+                    "hasGeneration=${capturedState?.get("sessionGeneration") != null}"
+            )
             vpnPermissionRequestPending = false
             mainHandler.removeCallbacks(timeoutRunnable)
             if (startTimeoutRunnable === timeoutRunnable) {

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSession.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeConnectionSession.kt
@@ -192,6 +192,7 @@ internal object NativeConnectionSession {
             "running" to running,
             "transitioning" to isTransitioning(),
             "protectedConfigPath" to protectedConfigPath(running),
+            "protectedConfigTrusted" to (protectedConfigPath(running) != null),
             "sessionGeneration" to sessionGeneration.takeIf { running }
         )
 

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
@@ -117,7 +117,7 @@ class SsrvpnVpnService : VpnService() {
         }
     }
     private var vpnFd: ParcelFileDescriptor? = null
-    private var protectThread: Thread? = null
+    private var protectMonitor: VpnProtectMonitor.Monitor? = null
     @Volatile
     private var serviceStartThread: Thread? = null
     private val notificationHandler = Handler(Looper.getMainLooper())
@@ -474,12 +474,12 @@ class SsrvpnVpnService : VpnService() {
             Log.d(TAG, "Initializing protect pipe...")
             val protectReadFd = bridge.Bridge.initProtect()
             Log.d(TAG, "Protect pipe fd=$protectReadFd")
-            protectThread = VpnProtectMonitor.start(
+            protectMonitor = VpnProtectMonitor.start(
                 protectReadFd,
                 protectSocket = { socketFd -> protect(socketFd) },
                 reportResult = { protected -> bridge.Bridge.setProtectResult(protected) }
             )
-            if (!VpnRuntimeHealth.hasProtectMonitor(protectThread)) {
+            if (!VpnRuntimeHealth.hasProtectMonitor(protectMonitor?.thread)) {
                 return rejectCoreStart(requestId, "VPN 网络保护服务启动失败，请重新连接", recoveryAttempt)
             }
             Log.d(TAG, "Protect monitor started")
@@ -516,7 +516,7 @@ class SsrvpnVpnService : VpnService() {
                 )
                 if (healthy) Log.d(TAG, "Mihomo API /version is healthy")
 
-                if (healthy && !VpnRuntimeHealth.hasProtectMonitor(protectThread)) {
+                if (healthy && !VpnRuntimeHealth.hasProtectMonitor(protectMonitor?.thread)) {
                     return rejectCoreStart(
                         requestId,
                         "VPN 网络保护服务异常，请重新连接",
@@ -529,7 +529,7 @@ class SsrvpnVpnService : VpnService() {
                     Log.d(TAG, "Core started!")
                     applyProxySelection(apiPort, apiSecret, selectedNodeName)
                     val dataPlaneHealthy =
-                        VpnDataPlaneProbe.isStartupHealthy(protectThread) {
+                        VpnDataPlaneProbe.isStartupHealthy(protectMonitor?.thread) {
                             ensureStartCurrent(startToken)
                         }
                     if (!dataPlaneHealthy) {
@@ -649,7 +649,7 @@ class SsrvpnVpnService : VpnService() {
                     { isRunning },
                     { isBridgeRunningWithTimeout() != false },
                     isProtectMonitorRunning = {
-                        VpnRuntimeHealth.hasProtectMonitor(protectThread)
+                        VpnRuntimeHealth.hasProtectMonitor(protectMonitor?.thread)
                     },
                     isApiHealthy = { VpnRuntimeHealth.isApiHealthy(request.apiPort, request.apiSecret) },
                     isApiPortReachable = { CorePortReleaseVerifier.isPortListening(request.apiPort) }
@@ -769,7 +769,7 @@ class SsrvpnVpnService : VpnService() {
     internal fun runtimeDiagnosticsSnapshot(): NativeRuntimeDiagnostics =
         runtimeDiagnostics.snapshot(
             isRunning, isCoreOperationBusy(),
-            VpnRuntimeHealth.hasProtectMonitor(protectThread),
+            VpnRuntimeHealth.hasProtectMonitor(protectMonitor?.thread),
             isBridgeRunningWithTimeout()
         )
     private fun applyProxySelection(apiPort: Int, apiSecret: String, nodeName: String?) =
@@ -838,13 +838,13 @@ class SsrvpnVpnService : VpnService() {
     private fun stopAllOnWorker(): Boolean {
         Log.d(TAG, "Stopping...")
         stopNotificationUpdates()
-        val protectMonitor = protectThread
-        protectMonitor?.interrupt()
-        protectThread = null
+        val activeProtectMonitor = protectMonitor
+        activeProtectMonitor?.stop()
+        protectMonitor = null
         val pendingStartStopped = waitForPendingStart()
         val bridgeStopped = pendingStartStopped && stopBridgeWithTimeout()
         if (bridgeStopped) runtimeDiagnostics.releaseTunDescriptor()
-        val protectMonitorStopped = waitForProtectMonitor(protectMonitor)
+        val protectMonitorStopped = waitForProtectMonitor(activeProtectMonitor?.thread)
         val stopDecision = CoreStopDecision.afterBridgeCheck(
             pendingStartStopped,
             bridgeStopped && protectMonitorStopped,

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnProtectMonitor.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnProtectMonitor.kt
@@ -2,35 +2,55 @@ package com.ssrvpn.android
 
 import android.os.ParcelFileDescriptor
 import android.util.Log
-import java.io.FileInputStream
 import java.io.InputStream
 
 internal object VpnProtectMonitor {
     private const val TAG = "VpnProtectMonitor"
 
+    internal class Monitor(
+        val thread: Thread,
+        private val input: InputStream
+    ) {
+        fun stop() {
+            try {
+                input.close()
+            } catch (_: Exception) {}
+            thread.interrupt()
+        }
+    }
+
     fun start(
         protectReadFd: Long,
         protectSocket: (Int) -> Boolean,
         reportResult: (Boolean) -> Unit
-    ): Thread? {
+    ): Monitor? {
         if (protectReadFd <= 0L) return null
+        // Bridge retains the raw descriptor until Bridge.stop(). Read from a
+        // duplicate so native cleanup cannot invalidate Java's monitor mid-run.
+        val input = ParcelFileDescriptor.AutoCloseInputStream(
+            ParcelFileDescriptor.fromFd(protectReadFd.toInt())
+        )
+        return start(input, protectSocket, reportResult)
+    }
 
-        return Thread({
+    internal fun start(
+        input: InputStream,
+        protectSocket: (Int) -> Boolean,
+        reportResult: (Boolean) -> Unit
+    ): Monitor {
+        val thread = Thread({
             try {
-                ParcelFileDescriptor.fromFd(protectReadFd.toInt()).use { descriptor ->
-                    FileInputStream(descriptor.fileDescriptor).use { input ->
-                        val buffer = ByteArray(4)
-                        while (!Thread.currentThread().isInterrupted) {
-                            val socketFd = readSocketFd(input) ?: run {
-                                Log.d(TAG, "Protect pipe closed")
-                                return@Thread
-                            }
-                            val protected = protectSocket(socketFd)
-                            Log.d(TAG, "protect($socketFd) = $protected")
-                            if (!reportResultSafely(protected, reportResult)) {
-                                Log.e(TAG, "Native protect result reporter is unavailable")
-                                return@Thread
-                            }
+                input.use {
+                    while (!Thread.currentThread().isInterrupted) {
+                        val socketFd = readSocketFd(it) ?: run {
+                            Log.d(TAG, "Protect pipe closed")
+                            return@Thread
+                        }
+                        val protected = protectSocket(socketFd)
+                        Log.d(TAG, "protect($socketFd) = $protected")
+                        if (!reportResultSafely(protected, reportResult)) {
+                            Log.e(TAG, "Native protect result reporter is unavailable")
+                            return@Thread
                         }
                     }
                 }
@@ -43,6 +63,7 @@ internal object VpnProtectMonitor {
             isDaemon = true
             start()
         }
+        return Monitor(thread, input)
     }
 
     internal fun reportResultSafely(

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeConnectionSessionTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeConnectionSessionTest.kt
@@ -19,6 +19,7 @@ class NativeConnectionSessionTest {
         assertTrue(running["running"] as Boolean)
         assertEquals(runningToken, running["sessionGeneration"])
         assertEquals("/data/config-active.yaml", running["protectedConfigPath"])
+        assertTrue(running["protectedConfigTrusted"] as Boolean)
 
         NativeConnectionSession.beginStopping()
         val stopping = NativeConnectionSession.snapshotConsistently(gate) { false }

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnProtectMonitorTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnProtectMonitorTest.kt
@@ -1,9 +1,13 @@
 package com.ssrvpn.android
 
 import java.io.InputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VpnProtectMonitorTest {
@@ -34,5 +38,39 @@ class VpnProtectMonitorTest {
         }
 
         assertFalse(reported)
+    }
+
+    @Test
+    fun `stop closes the pipe reader and joins a blocked monitor`() {
+        val readStarted = CountDownLatch(1)
+        val inputClosed = AtomicBoolean(false)
+        val input = object : InputStream() {
+            @Volatile private var closed = false
+
+            override fun read(): Int = -1
+
+            override fun read(target: ByteArray, offset: Int, length: Int): Int {
+                readStarted.countDown()
+                while (!closed) Thread.sleep(1)
+                return -1
+            }
+
+            override fun close() {
+                inputClosed.set(true)
+                closed = true
+            }
+        }
+        val monitor = VpnProtectMonitor.start(
+            input,
+            protectSocket = { true },
+            reportResult = {}
+        )
+        assertTrue(readStarted.await(1, TimeUnit.SECONDS))
+
+        monitor.stop()
+        monitor.thread.join(1_000)
+
+        assertTrue(inputClosed.get())
+        assertFalse(monitor.thread.isAlive)
     }
 }

--- a/SSRVPN_Android/lib/services/clash_service_native_bridge.dart
+++ b/SSRVPN_Android/lib/services/clash_service_native_bridge.dart
@@ -619,6 +619,11 @@ extension AndroidNativeBridge on ClashService {
       log('原生 VPN 返回了无效的受保护配置路径类型');
       return null;
     }
+    final rawPathTrusted = value['protectedConfigTrusted'];
+    if (rawPathTrusted != null && rawPathTrusted is! bool) {
+      log('原生 VPN 返回了无效的受保护配置证明');
+      return null;
+    }
     final rawPath = rawPathValue as String?;
     if (rawPath == null || rawPath.isEmpty) {
       return (
@@ -633,9 +638,10 @@ extension AndroidNativeBridge on ClashService {
     final supportedName = name == 'config.yaml' ||
         (name.startsWith('config-') && name.endsWith('.yaml'));
     if (!supportedName ||
-        file.parent.path != Directory(configDir).absolute.path ||
-        await FileSystemEntity.type(file.path, followLinks: false) !=
-            FileSystemEntityType.file) {
+        (rawPathTrusted != true &&
+            (file.parent.path != Directory(configDir).absolute.path ||
+                await FileSystemEntity.type(file.path, followLinks: false) !=
+                    FileSystemEntityType.file))) {
       log('原生 VPN 返回了无效的受保护配置路径');
       return (
         running: running,

--- a/SSRVPN_Android/pubspec.yaml
+++ b/SSRVPN_Android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_android
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 4.0.9+4009
+version: 4.0.10+4010
 resolution: workspace
 
 environment:

--- a/SSRVPN_Android/test/clash_service_test.dart
+++ b/SSRVPN_Android/test/clash_service_test.dart
@@ -1237,6 +1237,59 @@ void main() {
     expect(service.lastStartError, contains('受保护配置'));
   });
 
+  test('native-attested config survives Android data-directory aliases',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    const channel = MethodChannel('com.ssrvpn/native');
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final dir = await Directory.systemTemp.createTemp(
+      'ssrvpn_native_attested_config_',
+    );
+    final requestedConfig =
+        File('${dir.path}${Platform.pathSeparator}config.yaml');
+    await requestedConfig.writeAsString('proxies: []');
+    // Android may report the same app data directory through /data/user/0
+    // while Flutter resolves it through the /data/data compatibility alias.
+    // Native has already canonicalized and validated this path before start.
+    final nativeConfigPath =
+        '${dir.parent.path}${Platform.pathSeparator}config-native.yaml';
+    var stopCalls = 0;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      switch (call.method) {
+        case 'startCoreWithVpn':
+        case 'getConnectionState':
+          return <String, Object?>{
+            'running': true,
+            'transitioning': false,
+            'protectedConfigPath': nativeConfigPath,
+            'protectedConfigTrusted': true,
+            'sessionGeneration': 52,
+          };
+        case 'syncSettings':
+          return 'snapshot-generation';
+        case 'stopCore':
+          stopCalls += 1;
+          return true;
+        case 'notifyVpnStateChanged':
+          return true;
+      }
+      return null;
+    });
+    addTearDown(() async {
+      messenger.setMockMethodCallHandler(channel, null);
+      await dir.delete(recursive: true);
+    });
+
+    final service = ClashService()
+      ..setPaths(configDir: dir.path, configPath: requestedConfig.path)
+      ..updateSettings(AppSettings());
+
+    expect(await service.start(nodeName: 'A'), isTrue);
+    expect(stopCalls, 0);
+    expect(service.isRunning, isTrue);
+  });
+
   test('failed malformed-state rollback preserves native running truth',
       () async {
     SharedPreferences.setMockInitialValues({});

--- a/SSRVPN_MacOS/pubspec.yaml
+++ b/SSRVPN_MacOS/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_macos
 description: SSRVPN - 安全稳定的VPN客户端
 publish_to: 'none'
-version: 4.0.9+4009
+version: 4.0.10+4010
 resolution: workspace
 
 environment:

--- a/SSRVPN_Windows/pubspec.yaml
+++ b/SSRVPN_Windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ssrvpn_windows
 description: SSRVPN - 安全稳定的VPN客户端 (Windows 安装版)
 publish_to: 'none'
-version: 4.0.9+4009
+version: 4.0.10+4010
 resolution: workspace
 
 environment:

--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -1,7 +1,7 @@
 # 项目健康状态
 
 最近审查：2026-08-16<br>
-当前应用版本：`v4.0.9`；公开发布状态与产物以 [GitHub Release](https://github.com/Elegying/SSRVPN/releases/latest) 为准。<br>
+当前应用版本：`v4.0.10`；公开发布状态与产物以 [GitHub Release](https://github.com/Elegying/SSRVPN/releases/latest) 为准。<br>
 审查基线：公开版本 `v4.0.3`、提交 `bcca48a` 与 [CI run 30887916321](https://github.com/Elegying/SSRVPN/actions/runs/30887916321) 的三端构建及发布产物已核对；本文所在提交继续以完整本地门禁、对应 Pull Request 检查和合并后 `main` CI 共同作为当前结论。
 
 ## 综合结论与评分

--- a/packages/ssrvpn_shared/lib/constants/app_constants.dart
+++ b/packages/ssrvpn_shared/lib/constants/app_constants.dart
@@ -85,7 +85,7 @@ class AppConstants {
 
   // ── 版本信息 ──
   static const String appName = 'SSRVPN';
-  static const String appVersion = '4.0.9';
+  static const String appVersion = '4.0.10';
   static const String appUserAgent = '$appName/$appVersion';
   static const String appDescription = 'Cross-platform VPN client';
 

--- a/scripts/check-android-native-bridge-guards.sh
+++ b/scripts/check-android-native-bridge-guards.sh
@@ -27,6 +27,7 @@ PUBLIC_ROUTES="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/andro
 VPN_ROUTE_INSTALLER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnRouteInstaller.kt"
 VPN_APP_EXCLUSION_INSTALLER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnAppExclusionInstaller.kt"
 VPN_DATA_PLANE_PROBE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnDataPlaneProbe.kt"
+VPN_PROTECT_MONITOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnProtectMonitor.kt"
 NOTIFICATION_SUPPORT="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnNotificationSupport.kt"
 NOTIFICATION_GATE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NotificationGenerationGate.kt"
 CORE_LIVENESS_MONITOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreLivenessMonitor.kt"
@@ -111,6 +112,12 @@ require_file_text() {
     exit 1
   fi
 }
+
+require_file_text "$VPN_PROTECT_MONITOR" "ParcelFileDescriptor.fromFd("
+if grep -Fq "ParcelFileDescriptor.adoptFd(" "$VPN_PROTECT_MONITOR"; then
+  echo "Android protect monitor must duplicate the native-owned pipe descriptor" >&2
+  exit 1
+fi
 
 require_count() {
   local needle="$1"


### PR DESCRIPTION
## Summary
- trust the Android native session attestation across `/data/user/0` and `/data/data` aliases
- retain independent ownership for the socket-protect monitor reader and unblock teardown
- bump all clients to v4.0.10 and add regression coverage

## Verification
- `make verify`
- signed Android release APK installed as 4.0.10 (4010)
- Android 17 physical device: connection remains active, browser traffic to `www.gstatic.com` traverses TUN and the selected proxy, with no automatic `stopCore`, fatal exception, or SIGKILL