### PR TITLE
test: let Windows TUN cleanup budget complete

### DIFF
--- a/SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart
+++ b/SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart
@@ -481,6 +481,7 @@ void main() {
       );
     },
     skip: Platform.isWindows ? false : 'Windows network cmdlets are required',
+    timeout: const Timeout(Duration(seconds: 45)),
   );
 
   test('runtime probe rejects a missing or duplicate TUN address', () {


### PR DESCRIPTION
## 根因

精确 main CI run 32056560187 的 Windows 任务中，真实 Windows TUN 清理验收使用生产 30 秒预算，同时继承测试框架默认 30 秒整项上限。Runner 的 PowerShell 探针稍慢时，测试框架在 30.000 秒先终止用例，清理函数无法返回最终结果。同一代码的 PR run 32055040140 已通过，说明这是测试上限竞态而非产品回归。

## 最小修复

只把该真实 Windows 测试的外层测试上限设为 45 秒；生产清理预算仍保持 30 秒，客户端行为、路由、安装器和发布规则均不变。若生产函数在 30 秒内返回 false，测试仍会正常失败。

## 本地验证

- Dart format 通过
- windows_tun_runtime_probe_test.dart：20 项通过，2 项仅 Windows 主机测试按平台跳过
- git diff --check 通过

正式合并仍以 Windows runner 上该真实探针通过为准。