### PR TITLE
docs: remove version note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ Android、macOS、Windows 三端一致的连接体验：导入订阅，选择节
 
 </div>
 
-> [!NOTE]
-> **当前稳定版：[v4.0.13](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.13)（2026-08-20）**
-> 已增强三端订阅兼容重试与安全校验，修复 Windows 诊断复制和连接中节点切换，完善桌面键盘/长节点名体验，并将 Android arm64 核心升级为可审查源码构建与 16 KiB ELF 对齐。
-
 ## SSRVPN 是什么
 
 SSRVPN 是面向 Android、macOS 和 Windows 的开源 Mihomo 客户端。它把常用功能收敛为清晰的“主页 + 订阅”两页流程，适合希望快速导入订阅或节点、查看延迟并稳定连接的用户。


### PR DESCRIPTION
## Summary
- remove the temporary current-version note from the README header
- keep the version badge, product previews, downloads, and release assets unchanged

## Validation
- git diff --check origin/main...HEAD
- reviewed as a documentation-only four-line deletion

## Release impact
- documentation-only; no client version or binary asset changes