### PR TITLE
fix: decouple OSS publishing from app updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,26 +550,22 @@ jobs:
           python3 - <<'PY'
           import os
           import re
-          from pathlib import Path
 
-          source = Path(
-              "packages/ssrvpn_shared/lib/services/update_checker.dart"
-          ).read_text(encoding="utf-8")
-          match = re.search(
-              r"primaryManifestUrl\s*=\s*Uri\.parse\(\s*['\"]([^'\"]+)['\"]",
-              source,
-          )
-          if match is None:
-              raise SystemExit("cannot find the client's primary update manifest URL")
-          configured_url = (
-              f"https://{os.environ['OSS_BUCKET']}.{os.environ['OSS_ENDPOINT']}/"
-              f"{os.environ['OSS_PREFIX']}/latest.json"
-          )
-          if configured_url != match.group(1):
-              raise SystemExit(
-                  "OSS workflow variables do not match the client's primary "
-                  "update manifest URL"
-              )
+          endpoint = os.environ["OSS_ENDPOINT"]
+          bucket = os.environ["OSS_BUCKET"]
+          prefix = os.environ["OSS_PREFIX"]
+
+          if not re.fullmatch(r"[A-Za-z0-9.-]+", endpoint):
+              raise SystemExit("OSS_ENDPOINT must be a hostname without a scheme or path")
+          if not re.fullmatch(r"[a-z0-9][a-z0-9-]{1,61}[a-z0-9]", bucket):
+              raise SystemExit("OSS_BUCKET is not a valid bucket name")
+          if (
+              not re.fullmatch(r"[A-Za-z0-9._/-]+", prefix)
+              or prefix.startswith("/")
+              or prefix.endswith("/")
+              or ".." in prefix.split("/")
+          ):
+              raise SystemExit("OSS_PREFIX must be a normalized relative object prefix")
           PY
 
       - name: Reuse an existing GitHub release on retry

--- a/scripts/test_verify_release_transition.py
+++ b/scripts/test_verify_release_transition.py
@@ -114,15 +114,13 @@ class VerifyReleaseTransitionTest(unittest.TestCase):
         github_release = workflow.index("Create GitHub Draft Release")
         self.assertLess(validate, github_release)
         validation_step = workflow[validate:github_release]
-        self.assertIn(
-            "packages/ssrvpn_shared/lib/services/update_checker.dart",
-            validation_step,
-        )
-        self.assertIn("primaryManifestUrl", validation_step)
-        self.assertIn("os.environ['OSS_BUCKET']", validation_step)
-        self.assertIn("os.environ['OSS_ENDPOINT']", validation_step)
-        self.assertIn("os.environ['OSS_PREFIX']", validation_step)
-        self.assertIn("configured_url != match.group(1)", validation_step)
+        self.assertNotIn("update_checker.dart", validation_step)
+        self.assertNotIn("primaryManifestUrl", validation_step)
+        self.assertIn('os.environ["OSS_BUCKET"]', validation_step)
+        self.assertIn('os.environ["OSS_ENDPOINT"]', validation_step)
+        self.assertIn('os.environ["OSS_PREFIX"]', validation_step)
+        self.assertIn("must be a hostname without a scheme or path", validation_step)
+        self.assertIn("must be a normalized relative object prefix", validation_step)
         retry_reuse = workflow.index("Reuse an existing GitHub release on retry")
         self.assertLess(validate, retry_reuse)
         self.assertLess(retry_reuse, github_release)


### PR DESCRIPTION
## Summary
- keep release artifact mirroring to OSS
- validate OSS publication settings independently of the app update source
- remove the obsolete requirement for an OSS manifest URL in client code

## Verification
- bash scripts/test-release-tooling.sh (296 tests passed)
- git diff --check