### PR TITLE
fix: harden connection health and diagnostics

### DIFF
--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreLivenessMonitor.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreLivenessMonitor.kt
@@ -1,5 +1,10 @@
 package com.ssrvpn.android
 
+internal data class CoreLivenessOutcome(
+    val unexpectedExit: Boolean,
+    val recoveryAttempt: Int
+)
+
 internal object CoreLivenessMonitor {
     private const val MAX_CONSECUTIVE_API_FAILURES = 3
     private const val POLL_INTERVAL_MILLIS = 3_000L
@@ -8,21 +13,34 @@ internal object CoreLivenessMonitor {
         startToken: Long,
         currentGeneration: () -> Long,
         isRunning: () -> Boolean,
-        isBridgeRunning: () -> Boolean,
+        recoveryAttempt: Int = 0,
+        isBridgeRunning: () -> Boolean?,
         isProtectMonitorRunning: () -> Boolean = { true },
         isApiHealthy: () -> Boolean = { true },
         isApiPortReachable: () -> Boolean = { true },
+        monotonicMillis: () -> Long = { System.nanoTime() / 1_000_000L },
         sleep: (Long) -> Unit = Thread::sleep
-    ): Boolean {
+    ): CoreLivenessOutcome {
+        val recoveryBudget = CoreRecoveryBudget(recoveryAttempt)
         var consecutiveApiFailures = 0
         while (startToken == currentGeneration() && isRunning()) {
             val bridgeRunning = isBridgeRunning()
-            if (startToken != currentGeneration()) return false
-            if (!bridgeRunning) break
-            if (!isProtectMonitorRunning()) break
-            if (startToken != currentGeneration() || !isRunning()) return false
+            if (startToken != currentGeneration()) {
+                return CoreLivenessOutcome(false, recoveryBudget.attempt)
+            }
+            if (bridgeRunning == false) break
+            val protectMonitorRunning = isProtectMonitorRunning()
+            if (!protectMonitorRunning) break
+            if (startToken != currentGeneration() || !isRunning()) {
+                return CoreLivenessOutcome(false, recoveryBudget.attempt)
+            }
 
-            if (isApiHealthy()) {
+            val apiHealthy = isApiHealthy()
+            recoveryBudget.observeHealth(
+                bridgeRunning == true && protectMonitorRunning && apiHealthy,
+                monotonicMillis()
+            )
+            if (apiHealthy) {
                 consecutiveApiFailures = 0
             } else {
                 consecutiveApiFailures++
@@ -35,9 +53,14 @@ internal object CoreLivenessMonitor {
                     if (consecutiveApiFailures >= MAX_CONSECUTIVE_API_FAILURES + 1) break
                 }
             }
-            if (startToken != currentGeneration() || !isRunning()) return false
+            if (startToken != currentGeneration() || !isRunning()) {
+                return CoreLivenessOutcome(false, recoveryBudget.attempt)
+            }
             sleep(POLL_INTERVAL_MILLIS)
         }
-        return startToken == currentGeneration() && isRunning()
+        return CoreLivenessOutcome(
+            startToken == currentGeneration() && isRunning(),
+            recoveryBudget.attempt
+        )
     }
 }

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreRecoveryCoordinator.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreRecoveryCoordinator.kt
@@ -1,0 +1,170 @@
+package com.ssrvpn.android
+
+import android.os.Handler
+import android.util.Log
+import java.util.concurrent.atomic.AtomicLong
+
+/** Single source of truth for every bounded native VPN startup stage. */
+internal object VpnStartBudget {
+    const val BRIDGE_MS = 45_000L
+    const val CANCEL_GRACE_MS = 1_000L
+    const val API_HEALTH_MS = 20_000L
+    const val API_POLL_MS = 250L
+    // MihomoProxySelection performs at most four local API requests, each
+    // with independent 1.5s connect/read timeouts.
+    const val PROXY_SELECTION_MS = 12_000L
+    private const val COORDINATION_GRACE_MS = 5_000L
+    const val RESULT_MS = BRIDGE_MS + API_HEALTH_MS + PROXY_SELECTION_MS +
+        VpnDataPlaneProbe.MAX_STARTUP_DURATION_MILLIS + COORDINATION_GRACE_MS
+}
+
+/** Coordinates bounded core recovery without owning the VPN service lifecycle. */
+internal object CoreRecoveryCoordinator {
+    private const val TAG = "SsrvpnVpn"
+    // A recreated Service must not accept an older recovery Intent in the same process.
+    private val recoveryGeneration = AtomicLong(0)
+
+    fun cancelPendingRecovery() {
+        recoveryGeneration.incrementAndGet()
+    }
+
+    fun shouldAcceptRestart(
+        service: SsrvpnVpnService,
+        attempt: Int,
+        intentToken: Long?
+    ): Boolean = CoreRecoveryPolicy.shouldAcceptRestart(
+        attempt,
+        intentToken,
+        recoveryGeneration.get(),
+        service.hasManualStopRequest()
+    )
+
+    fun recoverFromUnexpectedCoreExit(
+        service: SsrvpnVpnService,
+        request: CoreRecoveryRequest
+    ) {
+        val nextAttempt = nextAttemptAfterUnexpectedExit(request.attempt)
+        if (nextAttempt == null) {
+            Log.e(TAG, "Core recovery limit reached")
+            stopWithFailure(service)
+            return
+        }
+        if (service.hasManualStopRequest()) return
+
+        val recoveryToken = recoveryGeneration.incrementAndGet()
+        if (!NativeVpnSessionCoordinator.reserveRecovery(request.configPath)) return
+        publishRecovering(service, nextAttempt, recoveryToken)
+
+        service.stopForRecovery {
+            if (!shouldRestart(service, nextAttempt, recoveryToken)) {
+                if (service.hasPendingProcessTermination()) {
+                    service.showCoreRecoveryFailedNotification()
+                }
+                return@stopForRecovery
+            }
+            launchRecovery(
+                service,
+                nextAttempt,
+                recoveryToken,
+                "Unable to restart VPN core"
+            )
+        }
+    }
+
+    fun nextAttemptAfterUnexpectedExit(currentAttempt: Int): Int? =
+        CoreRecoveryPolicy.nextAttempt(currentAttempt)
+
+    fun stopAfterStartFailure(
+        service: SsrvpnVpnService,
+        handler: Handler,
+        recoveryAttempt: Int
+    ) {
+        val nextAttempt = CoreRecoveryPolicy.retryAfterStartFailure(recoveryAttempt)
+        if (nextAttempt == null) {
+            if (recoveryAttempt > 0) stopWithFailure(service) else service.stopAll()
+            return
+        }
+        retryRecoveryAfterStartFailure(service, handler, nextAttempt)
+    }
+
+    private fun retryRecoveryAfterStartFailure(
+        service: SsrvpnVpnService,
+        handler: Handler,
+        nextAttempt: Int
+    ) {
+        if (service.hasManualStopRequest() || service.hasPendingProcessTermination()) {
+            stopWithFailure(service)
+            return
+        }
+
+        val recoveryToken = recoveryGeneration.incrementAndGet()
+        publishRecovering(service, nextAttempt, recoveryToken)
+
+        service.stopForRecovery {
+            val restart = Runnable {
+                if (!shouldRestart(service, nextAttempt, recoveryToken)) return@Runnable
+                launchRecovery(
+                    service,
+                    nextAttempt,
+                    recoveryToken,
+                    "Unable to perform final VPN recovery attempt"
+                )
+            }
+            handler.postDelayed(
+                restart,
+                CoreRecoveryPolicy.retryDelayMillis(nextAttempt)
+            )
+        }
+    }
+
+    private fun publishRecovering(
+        service: SsrvpnVpnService,
+        attempt: Int,
+        recoveryToken: Long
+    ) = service.publishCoreRecovery(attempt) {
+        CoreRecoveryPolicy.shouldPublishRecovery(
+            recoveryToken,
+            recoveryGeneration.get(),
+            service.hasManualStopRequest(),
+            service.hasPendingProcessTermination()
+        )
+    }
+
+    private fun shouldRestart(
+        service: SsrvpnVpnService,
+        attempt: Int,
+        recoveryToken: Long
+    ): Boolean = CoreRecoveryPolicy.shouldAcceptRestart(
+        attempt,
+        recoveryToken,
+        recoveryGeneration.get(),
+        service.hasManualStopRequest()
+    ) && !service.hasPendingProcessTermination()
+
+    private fun launchRecovery(
+        service: SsrvpnVpnService,
+        attempt: Int,
+        recoveryToken: Long,
+        failureLog: String
+    ) {
+        try {
+            val restartIntent = SsrvpnVpnService.createStartIntent(
+                service,
+                recoveryAttempt = attempt,
+                recoveryToken = recoveryToken
+            )
+            // Recovery keeps this same Service in foreground, so deliver the
+            // next command without attempting a new background FGS launch.
+            service.startService(restartIntent)
+        } catch (error: Exception) {
+            Log.e(TAG, failureLog, error)
+            NativeVpnSessionCoordinator.clearRecovery()
+            service.showCoreRecoveryFailedNotification()
+            service.stopSelf()
+        }
+    }
+
+    private fun stopWithFailure(service: SsrvpnVpnService) {
+        service.stopAll { service.showCoreRecoveryFailedNotification() }
+    }
+}

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreRecoveryPolicy.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreRecoveryPolicy.kt
@@ -8,11 +8,46 @@ internal data class CoreRecoveryRequest(
     val attempt: Int
 )
 
+internal class CoreRecoveryBudget(
+    initialAttempt: Int,
+    private val stableHealthMillis: Long = 120_000L
+) {
+    var attempt: Int = initialAttempt
+        private set
+    private var healthySinceMillis: Long? = null
+
+    fun observeHealth(isHealthy: Boolean?, monotonicMillis: Long) {
+        if (attempt == 0) return
+        if (isHealthy != true) {
+            healthySinceMillis = null
+            return
+        }
+        val healthySince = healthySinceMillis
+        if (healthySince == null) {
+            healthySinceMillis = monotonicMillis
+            return
+        }
+        if (monotonicMillis - healthySince >= stableHealthMillis) attempt = 0
+    }
+}
+
 internal object CoreRecoveryPolicy {
     private const val MAX_ATTEMPTS = 2
+    private const val START_FAILURE_RETRY_DELAY_MILLIS = 1_000L
 
     fun nextAttempt(currentAttempt: Int): Int? =
         (currentAttempt + 1).takeIf { it <= MAX_ATTEMPTS }
+
+    /**
+     * A normal user start has no silent retry. The first automatic recovery
+     * start may fail transiently while native resources are still settling,
+     * so it receives exactly one delayed final attempt.
+     */
+    fun retryAfterStartFailure(currentAttempt: Int): Int? =
+        if (currentAttempt > 0) nextAttempt(currentAttempt) else null
+
+    fun retryDelayMillis(attempt: Int): Long =
+        if (attempt in 1..MAX_ATTEMPTS) START_FAILURE_RETRY_DELAY_MILLIS else 0L
 
     fun recoveringMessage(attempt: Int): String =
         "核心异常，正在自动恢复（$attempt/$MAX_ATTEMPTS）"

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/MainActivity.kt
@@ -285,7 +285,7 @@ class MainActivity : FlutterActivity() {
         val apiSecret = args?.get("apiSecret") as? String ?: ""
         val nodeName = args?.get("nodeName") as? String
         if (configDir == null || configPath == null) {
-            result.error("INVALID_ARGS", "Missing required arguments", null)
+            result.error("INVALID_ARGS", "连接参数不完整，请重试", null)
             return
         }
 
@@ -319,7 +319,11 @@ class MainActivity : FlutterActivity() {
                 )
             }
             runOnActiveUiThread("Unable to deliver VPN start timeout") {
-                result.error("CORE_TIMEOUT", "设备性能不足，请重新连接", null)
+                result.error(
+                    "CORE_TIMEOUT",
+                    "VPN 启动超时，请重新连接；若持续失败请打开诊断与运行日志",
+                    null
+                )
             }
         }
         callback = callback@{ success, message, capturedState ->
@@ -425,7 +429,7 @@ class MainActivity : FlutterActivity() {
                         } else {
                             result.error(
                                 "STOP_INCOMPLETE",
-                                "VPN resources are still releasing",
+                                "VPN 正在释放系统资源，请稍后重试",
                                 null
                             )
                         }
@@ -433,7 +437,12 @@ class MainActivity : FlutterActivity() {
                 }
             }
         } catch (error: Exception) {
-            result.error("STOP_FAILED", error.message, null)
+            Log.e("MainActivity", "Unable to stop VPN core", error)
+            result.error(
+                "STOP_FAILED",
+                "VPN 断开失败，请重试；若持续失败请打开诊断与运行日志",
+                null
+            )
         }
     }
 
@@ -475,7 +484,8 @@ class MainActivity : FlutterActivity() {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
             result.success(true)
         } catch (error: Exception) {
-            result.error("OPEN_URL_FAILED", error.message, null)
+            Log.e("MainActivity", "Unable to open external URL", error)
+            result.error("OPEN_URL_FAILED", "无法打开链接，请稍后重试", null)
         }
     }
 
@@ -488,7 +498,12 @@ class MainActivity : FlutterActivity() {
         try {
             result.success(mapOf("status" to requestUpdateInstall(apkPath)))
         } catch (error: Exception) {
-            result.error("INSTALL_UPDATE_FAILED", error.message, null)
+            Log.e("MainActivity", "Unable to request update install", error)
+            result.error(
+                "INSTALL_UPDATE_FAILED",
+                "无法打开安装界面，请重新下载安装包后重试",
+                null
+            )
         }
     }
 
@@ -613,7 +628,10 @@ class MainActivity : FlutterActivity() {
         }
         pendingVpnServiceIntent = null
         mainHandler.removeCallbacks(timeoutRunnable)
-        mainHandler.postDelayed(timeoutRunnable, 55000L)
+        mainHandler.postDelayed(
+            timeoutRunnable,
+            VpnStartBudget.RESULT_MS
+        )
         val claimId = NativeVpnSessionCoordinator.claimPendingStart(serviceIntent)
         if (claimId == null) {
             cancelPendingActivityStart("VPN 启动状态已变化，请重试")

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
@@ -19,7 +19,6 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 
 private class StartCancelledException : Exception("VPN start cancelled")
 
@@ -71,10 +70,6 @@ class SsrvpnVpnService : VpnService() {
             context.sendBroadcast(intent)
         }
 
-        private const val BRIDGE_START_TIMEOUT_MS = 45_000L
-        private const val PENDING_START_CANCEL_GRACE_MS = 1_000L
-        private const val API_HEALTH_TIMEOUT_MS = 20_000L
-        private const val API_HEALTH_POLL_INTERVAL_MS = 250L
         private const val BRIDGE_STOP_TIMEOUT_MS = 5_000L
         private const val BRIDGE_IS_RUNNING_TIMEOUT_MS = 2_000L
         private const val PROTECT_MONITOR_STOP_TIMEOUT_MS = 1_000L
@@ -86,7 +81,6 @@ class SsrvpnVpnService : VpnService() {
         private val bridgeFdTerminationRequired = AtomicBoolean(false)
         private val processTerminationPending = AtomicBoolean(false)
         internal val startGeneration = StartGenerationGate()
-        private val recoveryGeneration = AtomicLong(0)
         private val manualStopRequested = AtomicBoolean(false)
 
         fun isCoreOperationBusy(): Boolean =
@@ -107,6 +101,7 @@ class SsrvpnVpnService : VpnService() {
     private var protectMonitor: VpnProtectMonitor.Monitor? = null
     @Volatile
     private var serviceStartThread: Thread? = null
+    private val serviceStopGate = VpnServiceStopGate()
     private val notificationHandler = Handler(Looper.getMainLooper())
     private var currentNodeName = "SSRVPN"
     private var currentApiPort = 0
@@ -198,6 +193,7 @@ class SsrvpnVpnService : VpnService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "VPN Service starting...")
         if (intent?.action == ACTION_DISCONNECT) {
+            serviceStopGate.acceptStart(startId)
             Log.d(TAG, "Received disconnect from notification")
             stopAll(recordManualStop = true)
             return START_NOT_STICKY
@@ -218,11 +214,10 @@ class SsrvpnVpnService : VpnService() {
             null
         }
 
-        if (recoveryAttempt > 0 && !CoreRecoveryPolicy.shouldAcceptRestart(
+        if (recoveryAttempt > 0 && !CoreRecoveryCoordinator.shouldAcceptRestart(
+                this,
                 recoveryAttempt,
-                recoveryToken,
-                recoveryGeneration.get(),
-                manualStopRequested.get()
+                recoveryToken
             )
         ) {
             Log.w(TAG, "Ignoring obsolete VPN recovery request")
@@ -236,6 +231,7 @@ class SsrvpnVpnService : VpnService() {
         }
 
         if (isRunning) {
+            serviceStopGate.acceptStart(startId)
             Log.d(TAG, "VPN is already running; reusing the active session")
             NativeVpnSessionCoordinator.releasePendingStart(startClaimId)
             consumeStartResult(requestId, true, "Already running",
@@ -243,6 +239,7 @@ class SsrvpnVpnService : VpnService() {
             return START_STICKY
         }
         if (stopOperation.isRunning || processTerminationPending.get()) {
+            serviceStopGate.includeRejectedStart(startId)
             Log.w(TAG, "VPN cleanup is still in progress")
             NativeVpnSessionCoordinator.releasePendingStart(startClaimId)
             consumeStartResult(requestId, false, "VPN 核心正在清理，请稍后重试")
@@ -261,6 +258,7 @@ class SsrvpnVpnService : VpnService() {
             consumeStartResult(requestId, false, "VPN 启动租约已失效")
             return finishRejectedServiceStart(startId, isRunning, false)
         }
+        serviceStopGate.acceptStart(startId)
 
         val snapshot = if (startPayloadId == null) {
             NativeConnectionSnapshotStore.read(this)
@@ -469,7 +467,11 @@ class SsrvpnVpnService : VpnService() {
             vpnFd = builder.establish()
             if (vpnFd == null) {
                 Log.e(TAG, "VPN establish returned null!")
-                return rejectCoreStart(requestId, "VPN establish failed", recoveryAttempt)
+                return rejectCoreStart(
+                    requestId,
+                    "系统未能创建 VPN 接口，请检查 VPN 权限后重试",
+                    recoveryAttempt
+                )
             }
 
             ensureStartCurrent(startToken)
@@ -499,22 +501,26 @@ class SsrvpnVpnService : VpnService() {
                 val startErr = startBridgeWithTimeout(configDir, configPath, tunFdOwner)
                 if (startErr == null) {
                     Log.e(TAG, "Mihomo start timed out")
-                    return rejectCoreStart(requestId, "设备性能不足，请重新连接", recoveryAttempt)
+                    return rejectCoreStart(requestId, "VPN 核心启动超时，请重新连接", recoveryAttempt)
                 }
                 if (startErr.isNotEmpty()) {
                     Log.e(TAG, "Mihomo start failed: $startErr")
-                    return rejectCoreStart(requestId, "Mihomo: $startErr", recoveryAttempt)
+                    return rejectCoreStart(
+                        requestId,
+                        "VPN 核心启动失败，请重试；若持续失败请打开诊断与运行日志",
+                        recoveryAttempt
+                    )
                 }
                 ensureStartCurrent(startToken)
                 Log.d(TAG, "Mihomo started with TUN fd=$tunFd")
                 Log.d(TAG, "Waiting for API on port $apiPort...")
                 val healthDeadlineNanos =
-                    System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(API_HEALTH_TIMEOUT_MS)
+                    System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(VpnStartBudget.API_HEALTH_MS)
                 val healthy = mihomoApiWaiter.waitUntilHealthy(
                     apiPort,
                     apiSecret,
                     healthDeadlineNanos,
-                    API_HEALTH_POLL_INTERVAL_MS,
+                    VpnStartBudget.API_POLL_MS,
                     ensureCurrent = { ensureStartCurrent(startToken) }
                 )
                 if (healthy) Log.d(TAG, "Mihomo API /version is healthy")
@@ -531,12 +537,12 @@ class SsrvpnVpnService : VpnService() {
                     ensureStartCurrent(startToken)
                     Log.d(TAG, "Core started!")
                     applyProxySelection(apiPort, apiSecret, selectedNodeName)
-                    val dataPlaneHealthy =
-                        VpnDataPlaneProbe.isStartupHealthy(protectMonitor?.thread) {
+                    val dataPlaneFailure =
+                        VpnDataPlaneProbe.startupOutcome(protectMonitor?.thread) {
                             ensureStartCurrent(startToken)
-                        }
-                    if (!dataPlaneHealthy) {
-                        return rejectCoreStart(requestId, "VPN 数据通道不可用，请切换节点或重试", recoveryAttempt)
+                        }.failureMessage
+                    if (dataPlaneFailure != null) {
+                        return rejectCoreStart(requestId, dataPlaneFailure, recoveryAttempt)
                     }
                     ensureStartCurrent(startToken)
                     val published = startGeneration.runIfCurrent(startToken) {
@@ -571,7 +577,11 @@ class SsrvpnVpnService : VpnService() {
                     }
                 } else {
                     Log.e(TAG, "Health check timeout")
-                    rejectCoreStart(requestId, "设备性能不足，请重新连接", recoveryAttempt)
+                    rejectCoreStart(
+                        requestId,
+                        "VPN 核心已启动，但本地控制服务未及时就绪，请重新连接",
+                        recoveryAttempt
+                    )
                 }
             } finally {
                 tunFdOwner.close()
@@ -585,7 +595,11 @@ class SsrvpnVpnService : VpnService() {
             rejectCoreStart(requestId, "Mihomo 原生组件不可用，请重新安装应用", recoveryAttempt)
         } catch (e: Exception) {
             Log.e(TAG, "startCoreWithVpn error", e)
-            rejectCoreStart(requestId, "Error: ${e.message}", recoveryAttempt)
+            rejectCoreStart(
+                requestId,
+                "VPN 启动失败，请重试；若持续失败请打开诊断与运行日志",
+                recoveryAttempt
+            )
         }
     }
 
@@ -624,9 +638,9 @@ class SsrvpnVpnService : VpnService() {
             start()
         }
         try {
-            bridgeThread.join(BRIDGE_START_TIMEOUT_MS)
+            bridgeThread.join(VpnStartBudget.BRIDGE_MS)
             if (bridgeThread.isAlive) {
-                Log.e(TAG, "Bridge.start timed out after ${BRIDGE_START_TIMEOUT_MS}ms")
+                Log.e(TAG, "Bridge.start timed out after ${VpnStartBudget.BRIDGE_MS}ms")
                 return null
             }
         } catch (e: InterruptedException) {
@@ -645,20 +659,24 @@ class SsrvpnVpnService : VpnService() {
         try {
             // 核心意外退出：必须关闭 VPN 接口并停止前台服务，
             // 否则全局流量仍被路由进无人读取的 TUN，导致整机断网
-            if (CoreLivenessMonitor.waitForUnexpectedExit(
-                    startToken,
-                    startGeneration::current,
-                    { isRunning },
-                    { isBridgeRunningWithTimeout() != false },
-                    isProtectMonitorRunning = {
-                        VpnRuntimeHealth.hasProtectMonitor(protectMonitor?.thread)
-                    },
-                    isApiHealthy = { VpnRuntimeHealth.isApiHealthy(request.apiPort, request.apiSecret) },
-                    isApiPortReachable = { CorePortReleaseVerifier.isPortListening(request.apiPort) }
-                )
-            ) {
+            val liveness = CoreLivenessMonitor.waitForUnexpectedExit(
+                startToken = startToken,
+                currentGeneration = startGeneration::current,
+                isRunning = { isRunning },
+                recoveryAttempt = request.attempt,
+                isBridgeRunning = ::isBridgeRunningWithTimeout,
+                isProtectMonitorRunning = {
+                    VpnRuntimeHealth.hasProtectMonitor(protectMonitor?.thread)
+                },
+                isApiHealthy = { VpnRuntimeHealth.isApiHealthy(request.apiPort, request.apiSecret) },
+                isApiPortReachable = { CorePortReleaseVerifier.isPortListening(request.apiPort) }
+            )
+            if (liveness.unexpectedExit) {
                 Log.e(TAG, "Mihomo stopped unexpectedly")
-                recoverFromUnexpectedCoreExit(request)
+                CoreRecoveryCoordinator.recoverFromUnexpectedCoreExit(
+                    this,
+                    request.copy(attempt = liveness.recoveryAttempt)
+                )
             }
         } catch (e: Exception) {
             Log.e(TAG, "Monitor error", e)
@@ -672,61 +690,30 @@ class SsrvpnVpnService : VpnService() {
         }
     }
 
-    private fun recoverFromUnexpectedCoreExit(request: CoreRecoveryRequest) {
-        val nextAttempt = CoreRecoveryPolicy.nextAttempt(request.attempt)
-        if (nextAttempt == null) {
-            Log.e(TAG, "Core recovery limit reached")
-            stopAll { showCoreRecoveryFailedNotification() }
-            return
-        }
-        if (manualStopRequested.get()) return
-
-        val recoveryToken = recoveryGeneration.incrementAndGet()
-        if (!NativeVpnSessionCoordinator.reserveRecovery(request.configPath)) return
-        notificationStatusText = CoreRecoveryPolicy.recoveringMessage(nextAttempt)
+    internal fun publishCoreRecovery(
+        attempt: Int,
+        allowPublication: () -> Boolean
+    ) {
+        notificationStatusText = CoreRecoveryPolicy.recoveringMessage(attempt)
         notificationConnected = false
-        notifyCurrentState(currentNotificationState()) {
-            CoreRecoveryPolicy.shouldPublishRecovery(
-                recoveryToken,
-                recoveryGeneration.get(),
-                manualStopRequested.get(),
-                processTerminationPending.get()
-            )
-        }
-
-        stopForRecovery {
-            if (manualStopRequested.get() ||
-                recoveryToken != recoveryGeneration.get() ||
-                processTerminationPending.get()
-            ) {
-                if (processTerminationPending.get()) {
-                    showCoreRecoveryFailedNotification()
-                }
-                return@stopForRecovery
-            }
-            try {
-                val restartIntent = createStartIntent(
-                    this,
-                    recoveryAttempt = nextAttempt,
-                    recoveryToken = recoveryToken
-                )
-                ContextCompat.startForegroundService(this, restartIntent)
-            } catch (e: Exception) {
-                Log.e(TAG, "Unable to restart VPN core", e)
-                NativeVpnSessionCoordinator.clearRecovery()
-                showCoreRecoveryFailedNotification()
-                stopSelf()
-            }
-        }
+        notifyCurrentState(currentNotificationState(), allowPublication)
     }
 
+    internal fun hasManualStopRequest(): Boolean = manualStopRequested.get()
+
+    internal fun hasPendingProcessTermination(): Boolean = processTerminationPending.get()
+
     private fun stopAfterStartFailure(recoveryAttempt: Int) =
-        if (recoveryAttempt > 0) stopAll { showCoreRecoveryFailedNotification() } else stopAll()
+        CoreRecoveryCoordinator.stopAfterStartFailure(
+            this,
+            notificationHandler,
+            recoveryAttempt
+        )
 
     private fun rejectCoreStart(requestId: String?, message: String, recoveryAttempt: Int) =
         consumeStartResult(requestId, false, message).also { stopAfterStartFailure(recoveryAttempt) }
 
-    private fun showCoreRecoveryFailedNotification() {
+    internal fun showCoreRecoveryFailedNotification() {
         AndroidRuntimeGuard.run(TAG, "Unable to show core recovery failure") {
             getSystemService(NotificationManager::class.java).notify(
                 RECOVERY_FAILURE_NOTIFICATION_ID,
@@ -785,16 +772,17 @@ class SsrvpnVpnService : VpnService() {
             Log.e(TAG, "Unable to persist manual VPN disconnect")
         }
         manualStopRequested.set(true)
-        recoveryGeneration.incrementAndGet()
+        CoreRecoveryCoordinator.cancelPendingRecovery()
         stopInternal(true, preserveForegroundUi, onComplete)
     }
-    private fun stopForRecovery(onComplete: () -> Unit) =
-        stopInternal(false, false) { onComplete() }
+    internal fun stopForRecovery(onComplete: () -> Unit) =
+        stopInternal(false, true) { onComplete() }
 
     private fun stopInternal(
         stopServiceWhenDone: Boolean, preserveForegroundUi: Boolean,
         onComplete: ((Boolean) -> Unit)?
     ) {
+        val stopToken = serviceStopGate.beginOrJoinStop()
         notificationGeneration.invalidate()
         startGeneration.invalidate {
             NativeConnectionSession.beginStopping()
@@ -806,8 +794,10 @@ class SsrvpnVpnService : VpnService() {
         }
         serviceStartThread?.interrupt()
         val completion: (Boolean) -> Unit = { stoppedCleanly ->
-            if (stopServiceWhenDone || manualStopRequested.get()) {
-                stopSelf()
+            val stopStartId = serviceStopGate.finishStop(stopToken)
+            if ((stopServiceWhenDone || manualStopRequested.get()) &&
+                stopStartId != null) {
+                stopSelfResult(stopStartId)
             }
             onComplete?.invoke(stoppedCleanly)
             Unit
@@ -818,7 +808,8 @@ class SsrvpnVpnService : VpnService() {
         }
         Thread({
             StopOperationRunner.run(
-                bridgeFdTerminationRequired.get(), ::stopAllOnWorker,
+                bridgeFdTerminationRequired.get(),
+                { stopAllOnWorker(removeForeground = !preserveForegroundUi) },
                 {
                     processTerminationPending.set(true)
                     DisconnectRecoveryCoordinator.handoffIfNeeded(this, preserveForegroundUi)
@@ -837,7 +828,7 @@ class SsrvpnVpnService : VpnService() {
         }
     }
 
-    private fun stopAllOnWorker(): Boolean {
+    private fun stopAllOnWorker(removeForeground: Boolean): Boolean {
         Log.d(TAG, "Stopping...")
         stopNotificationUpdates()
         val activeProtectMonitor = protectMonitor.also { it?.stop() }
@@ -866,15 +857,17 @@ class SsrvpnVpnService : VpnService() {
         isRunning = false
         if (stopDecision.clearRunningSession) NativeConnectionSession.clearRunning()
         broadcastState(this)
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                stopForeground(STOP_FOREGROUND_REMOVE)
-            } else {
-                @Suppress("DEPRECATION")
-                stopForeground(true)
+        if (removeForeground) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                } else {
+                    @Suppress("DEPRECATION")
+                    stopForeground(true)
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "stopForeground failed: ${e.message}")
             }
-        } catch (e: Exception) {
-            Log.w(TAG, "stopForeground failed: ${e.message}")
         }
         Log.d(TAG, "Stopped")
         return bridgeFdTerminationRequired.get() || stopDecision.terminateProcess
@@ -899,7 +892,7 @@ class SsrvpnVpnService : VpnService() {
     }
 
     private fun waitForPendingStart(): Boolean {
-        val deadline = SystemClock.elapsedRealtime() + PENDING_START_CANCEL_GRACE_MS
+        val deadline = SystemClock.elapsedRealtime() + VpnStartBudget.CANCEL_GRACE_MS
         serviceStartThread?.interrupt()
         while (SystemClock.elapsedRealtime() < deadline) {
             val thread = serviceStartThread
@@ -915,7 +908,7 @@ class SsrvpnVpnService : VpnService() {
         }
         Log.e(
             TAG,
-            "Pending VPN start did not stop within ${PENDING_START_CANCEL_GRACE_MS}ms; " +
+            "Pending VPN start did not stop within ${VpnStartBudget.CANCEL_GRACE_MS}ms; " +
                 "forcing process cleanup"
         )
         return false

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnDataPlaneProbe.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnDataPlaneProbe.kt
@@ -1,7 +1,20 @@
 package com.ssrvpn.android
 
+import android.util.Log
+import java.io.IOException
 import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.net.URL
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import javax.net.ssl.SSLException
 
 /**
  * Verifies the same Android VPN data path used by browsers and other apps.
@@ -11,6 +24,7 @@ import java.net.URL
  * one through VpnService.protect(), rather than bypassing this whole package.
  */
 internal object VpnDataPlaneProbe {
+    private const val TAG = "SsrvpnVpn"
     private val endpoints = listOf(
         "https://www.gstatic.com/generate_204",
         "https://www.youtube.com/generate_204",
@@ -18,39 +32,236 @@ internal object VpnDataPlaneProbe {
     )
     private const val maxBoundedAttempts = 3
     private const val requestTimeoutMillis = 2_000
+    private const val startupRetryDelayMillis = 200L
+    private val startupProbeCompletion = AtomicReference<CountDownLatch?>()
 
-    fun isStartupHealthy(protectThread: Thread?, beforeAttempt: () -> Unit): Boolean =
-        isReachable(retryDelayMillis = 200, beforeAttempt = beforeAttempt) &&
-            VpnRuntimeHealth.hasProtectMonitor(protectThread)
+    // HttpURLConnection timeouts do not cover DNS resolution. This remains
+    // the absolute outer watchdog budget for all attempts and retry delays.
+    internal const val MAX_STARTUP_DURATION_MILLIS =
+        maxBoundedAttempts * requestTimeoutMillis * 2L +
+            (maxBoundedAttempts - 1) * startupRetryDelayMillis
+
+    internal data class AttemptDiagnostic(
+        val endpointCategory: String,
+        val attempt: Int,
+        val totalAttempts: Int,
+        val status: Int?,
+        val elapsedMillis: Long,
+        val cause: String
+    )
+
+    internal enum class StartupOutcome(
+        val logValue: String,
+        val failureMessage: String?
+    ) {
+        HEALTHY("healthy", null),
+        UNREACHABLE(
+            "unreachable",
+            "VPN 数据通道不可用，请切换节点或重试"
+        ),
+        WATCHDOG_TIMEOUT(
+            "watchdog_timeout",
+            "VPN 联网检查超时，请稍后重试；若持续出现请重启应用"
+        ),
+        PREVIOUS_PROBE_STILL_RUNNING(
+            "previous_probe_still_running",
+            "上次 VPN 联网检查仍在结束，请稍后重试；若持续出现请重启应用"
+        ),
+        PROTECT_MONITOR_UNAVAILABLE(
+            "protect_monitor_unavailable",
+            "VPN 网络保护服务异常，请重新连接"
+        )
+    }
+
+    private data class ProbeResult(
+        val reachable: Boolean,
+        val diagnostics: List<AttemptDiagnostic>
+    )
+
+    fun startupOutcome(
+        protectThread: Thread?,
+        beforeAttempt: () -> Unit
+    ): StartupOutcome {
+        val reachability = probeReachability(
+            retryDelayMillis = startupRetryDelayMillis,
+            beforeAttempt = beforeAttempt,
+            recordAttempt = ::logAttempt
+        )
+        val outcome = if (
+            reachability == StartupOutcome.HEALTHY &&
+            !VpnRuntimeHealth.hasProtectMonitor(protectThread)
+        ) {
+            StartupOutcome.PROTECT_MONITOR_UNAVAILABLE
+        } else {
+            reachability
+        }
+        Log.i(TAG, "event=vpn_data_plane_startup outcome=${outcome.logValue}")
+        return outcome
+    }
 
     fun isReachable(
         endpoints: List<String> = this.endpoints,
         maxAttempts: Int = maxBoundedAttempts,
         retryDelayMillis: Long = 0,
+        totalBudgetMillis: Long = MAX_STARTUP_DURATION_MILLIS,
         beforeAttempt: () -> Unit = {},
-        fetchStatus: (String) -> Int? = ::fetchHttpStatus
-    ): Boolean {
-        if (endpoints.isEmpty()) return false
+        fetchStatus: (String) -> Int? = ::fetchHttpStatus,
+        recordAttempt: (AttemptDiagnostic) -> Unit = {}
+    ): Boolean = probeReachability(
+        endpoints,
+        maxAttempts,
+        retryDelayMillis,
+        totalBudgetMillis,
+        beforeAttempt,
+        fetchStatus,
+        recordAttempt
+    ) == StartupOutcome.HEALTHY
+
+    internal fun probeReachability(
+        endpoints: List<String> = this.endpoints,
+        maxAttempts: Int = maxBoundedAttempts,
+        retryDelayMillis: Long = 0,
+        totalBudgetMillis: Long = MAX_STARTUP_DURATION_MILLIS,
+        beforeAttempt: () -> Unit = {},
+        fetchStatus: (String) -> Int? = ::fetchHttpStatus,
+        recordAttempt: (AttemptDiagnostic) -> Unit = {}
+    ): StartupOutcome {
+        if (endpoints.isEmpty() || totalBudgetMillis <= 0L) {
+            return StartupOutcome.UNREACHABLE
+        }
+        val deadlineNanos = System.nanoTime() +
+            TimeUnit.MILLISECONDS.toNanos(totalBudgetMillis)
+        val completion = acquireProbeSlot(deadlineNanos, beforeAttempt)
+            ?: return StartupOutcome.PREVIOUS_PROBE_STILL_RUNNING
         val attempts = maxAttempts.coerceIn(1, maxBoundedAttempts)
-        repeat(attempts) { index ->
+        val active = AtomicBoolean(true)
+        val task = FutureTask(
+            Callable {
+                runAttempts(
+                    endpoints,
+                    attempts,
+                    retryDelayMillis,
+                    active::get,
+                    beforeAttempt,
+                    fetchStatus
+                )
+            }
+        )
+        try {
+            Thread({
+                try {
+                    task.run()
+                } finally {
+                    releaseProbeSlot(completion)
+                }
+            }, "SSRVPN-data-plane-startup-probe").apply {
+                isDaemon = true
+                start()
+            }
+        } catch (error: Throwable) {
+            releaseProbeSlot(completion)
+            throw error
+        }
+        val remainingNanos = deadlineNanos - System.nanoTime()
+        if (remainingNanos <= 0L) {
+            active.set(false)
+            task.cancel(true)
+            return StartupOutcome.WATCHDOG_TIMEOUT
+        }
+        val result = try {
+            task.get(remainingNanos, TimeUnit.NANOSECONDS)
+        } catch (_: TimeoutException) {
+            active.set(false)
+            task.cancel(true)
+            return StartupOutcome.WATCHDOG_TIMEOUT
+        } catch (error: InterruptedException) {
+            active.set(false)
+            task.cancel(true)
+            Thread.currentThread().interrupt()
+            throw error
+        } catch (error: ExecutionException) {
+            throw error.cause ?: error
+        }
+        result.diagnostics.forEach { diagnostic ->
+            try {
+                recordAttempt(diagnostic)
+            } catch (_: Exception) {
+                // Diagnostics must never weaken or abort the startup gate.
+            }
+        }
+        return if (result.reachable) {
+            StartupOutcome.HEALTHY
+        } else {
+            StartupOutcome.UNREACHABLE
+        }
+    }
+
+    private fun acquireProbeSlot(
+        deadlineNanos: Long,
+        beforeAttempt: () -> Unit
+    ): CountDownLatch? {
+        while (true) {
             beforeAttempt()
+            val remainingNanos = deadlineNanos - System.nanoTime()
+            if (remainingNanos <= 0L) return null
+            val completion = CountDownLatch(1)
+            if (startupProbeCompletion.compareAndSet(null, completion)) {
+                return completion
+            }
+            val inFlight = startupProbeCompletion.get() ?: continue
+            if (!inFlight.await(remainingNanos, TimeUnit.NANOSECONDS)) return null
+        }
+    }
+
+    private fun releaseProbeSlot(completion: CountDownLatch) {
+        startupProbeCompletion.compareAndSet(completion, null)
+        completion.countDown()
+    }
+
+    private fun runAttempts(
+        endpoints: List<String>,
+        attempts: Int,
+        retryDelayMillis: Long,
+        isActive: () -> Boolean,
+        beforeAttempt: () -> Unit,
+        fetchStatus: (String) -> Int?
+    ): ProbeResult {
+        val diagnostics = mutableListOf<AttemptDiagnostic>()
+        repeat(attempts) { index ->
+            if (!isActive()) return ProbeResult(false, diagnostics)
+            beforeAttempt()
+            if (!isActive()) return ProbeResult(false, diagnostics)
             val endpoint = endpoints[index % endpoints.size]
-            if (fetchStatus(endpoint) == HttpURLConnection.HTTP_NO_CONTENT) {
-                return true
+            val startedAt = System.nanoTime()
+            var status: Int? = null
+            var failure: Exception? = null
+            try {
+                status = fetchStatus(endpoint)
+            } catch (error: Exception) {
+                failure = error
+            }
+            if (!isActive()) return ProbeResult(false, diagnostics)
+            diagnostics += AttemptDiagnostic(
+                endpointCategory = endpointCategory(endpoint),
+                attempt = index + 1,
+                totalAttempts = attempts,
+                status = status,
+                elapsedMillis = ((System.nanoTime() - startedAt) / 1_000_000L)
+                    .coerceAtLeast(0L),
+                cause = attemptCause(status, failure)
+            )
+            if (status == HttpURLConnection.HTTP_NO_CONTENT) {
+                return ProbeResult(true, diagnostics)
             }
             if (index + 1 < attempts && retryDelayMillis > 0) {
                 Thread.sleep(retryDelayMillis)
             }
         }
-        return false
+        return ProbeResult(false, diagnostics)
     }
 
     private fun fetchHttpStatus(endpoint: String): Int? {
-        val connection = try {
-            URL(endpoint).openConnection() as HttpURLConnection
-        } catch (_: Exception) {
-            return null
-        }
+        val connection = URL(endpoint).openConnection() as HttpURLConnection
         return try {
             connection.connectTimeout = requestTimeoutMillis
             connection.readTimeout = requestTimeoutMillis
@@ -58,10 +269,48 @@ internal object VpnDataPlaneProbe {
             connection.useCaches = false
             connection.setRequestProperty("Cache-Control", "no-cache")
             connection.responseCode
-        } catch (_: Exception) {
-            null
         } finally {
             connection.disconnect()
         }
+    }
+
+    private fun endpointCategory(endpoint: String): String = when {
+        endpoint.startsWith("https://www.gstatic.com/") -> "google"
+        endpoint.startsWith("https://www.youtube.com/") -> "youtube"
+        endpoint.startsWith("https://cp.cloudflare.com/") -> "cloudflare"
+        else -> "other"
+    }
+
+    private fun attemptCause(status: Int?, failure: Throwable?): String {
+        if (failure == null) {
+            return when (status) {
+                HttpURLConnection.HTTP_NO_CONTENT -> "none"
+                null -> "no_response"
+                else -> "http_status"
+            }
+        }
+        var current: Throwable? = failure
+        while (current != null) {
+            when (current) {
+                is UnknownHostException -> return "dns"
+                is SocketTimeoutException -> return "timeout"
+                is SSLException -> return "tls"
+                is IOException -> return "io"
+            }
+            current = current.cause
+        }
+        return "unexpected"
+    }
+
+    private fun logAttempt(diagnostic: AttemptDiagnostic) {
+        Log.i(
+            TAG,
+            "event=vpn_data_plane_probe " +
+                "endpoint=${diagnostic.endpointCategory} " +
+                "attempt=${diagnostic.attempt}/${diagnostic.totalAttempts} " +
+                "status=${diagnostic.status ?: "none"} " +
+                "elapsedMs=${diagnostic.elapsedMillis} " +
+                "cause=${diagnostic.cause}"
+        )
     }
 }

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnRuntimeHealth.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnRuntimeHealth.kt
@@ -14,10 +14,19 @@ internal object VpnRuntimeHealth {
     }
 
     fun isApiHealthy(port: Int, secret: String): Boolean {
+        val startedAt = System.nanoTime()
         val deadline = System.nanoTime() +
             TimeUnit.MILLISECONDS.toNanos(API_TIMEOUT_MILLIS)
         val healthy = MihomoApiHealthProbe.isHealthy(port, secret, deadline)
-        if (!healthy) Log.w(TAG, "Mihomo local API runtime health check failed")
+        if (!healthy) {
+            val elapsedMillis = ((System.nanoTime() - startedAt) / 1_000_000L)
+                .coerceAtLeast(0L)
+            Log.w(
+                TAG,
+                "event=vpn_runtime_probe endpoint=local_api status=failed " +
+                    "elapsedMs=$elapsedMillis cause=health_contract"
+            )
+        }
         return healthy
     }
 }

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnServiceStartPolicy.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnServiceStartPolicy.kt
@@ -19,6 +19,52 @@ object VpnServiceStartPolicy {
         }
 }
 
+/** Keeps asynchronous stop completions scoped to the service start they own. */
+internal class VpnServiceStopGate {
+    internal data class StopToken(
+        val acceptedGeneration: Int,
+        val stopGeneration: Int
+    )
+
+    private val lock = Any()
+    @Volatile
+    private var acceptedStartId = 0
+    private var acceptedGeneration = 0
+    private var stopGeneration = 0
+    private var activeStop: StopToken? = null
+    private var activeStopTargetStartId = 0
+
+    fun acceptStart(startId: Int) = synchronized(lock) {
+        acceptedStartId = startId
+        acceptedGeneration++
+    }
+
+    fun beginOrJoinStop(): StopToken = synchronized(lock) {
+        activeStop
+            ?.takeIf { it.acceptedGeneration == acceptedGeneration }
+            ?.let { return@synchronized it }
+        val token = StopToken(acceptedGeneration, ++stopGeneration)
+        activeStop = token
+        activeStopTargetStartId = acceptedStartId
+        token
+    }
+
+    fun includeRejectedStart(startId: Int) = synchronized(lock) {
+        if (activeStop?.acceptedGeneration == acceptedGeneration) {
+            activeStopTargetStartId = startId
+        }
+    }
+
+    fun finishStop(token: StopToken): Int? = synchronized(lock) {
+        if (activeStop != token) return@synchronized null
+        activeStop = null
+        if (token.acceptedGeneration != acceptedGeneration) {
+            return@synchronized null
+        }
+        activeStopTargetStartId.takeIf { it > 0 }
+    }
+}
+
 fun SsrvpnVpnService.finishRejectedServiceStart(
     startId: Int,
     hasActiveSession: Boolean,

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTileService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnTileService.kt
@@ -22,6 +22,8 @@ class VpnTileService : TileService() {
         private const val TAG = "VpnTile"
         const val ACTION_VPN_STATE_CHANGED = "com.ssrvpn.VPN_STATE_CHANGED"
         const val EXTRA_CONNECTED = "connected"
+        internal const val START_CALLBACK_TIMEOUT_MS =
+            VpnStartBudget.RESULT_MS
     }
 
     private var isConnected = false
@@ -154,14 +156,14 @@ class VpnTileService : TileService() {
             launchApp()
             return
         }
-        // 30 秒超时清理回调，防止泄漏
+        // 覆盖完整原生启动预算后再清理回调，避免丢失合法的慢启动结果。
         android.os.Handler(mainLooper).postDelayed({
             if (consumed.compareAndSet(false, true)) {
                 Log.w(TAG, "VPN start callback timeout, clearing")
                 NativeVpnSessionCoordinator.releasePendingStart(claim.id)
                 VpnStartResultRegistry.clear(requestId)
             }
-        }, 30_000L)
+        }, START_CALLBACK_TIMEOUT_MS)
         // 不再提前设置 isConnected = true，等回调确认后再更新磁贴状态
     }
 

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/CoreLivenessMonitorTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/CoreLivenessMonitorTest.kt
@@ -8,6 +8,33 @@ import org.junit.Test
 
 class CoreLivenessMonitorTest {
     @Test
+    fun `stable native health makes the next recovery start at attempt one`() {
+        var monotonicNow = 0L
+        var bridgeChecks = 0
+
+        val outcome = CoreLivenessMonitor.waitForUnexpectedExit(
+            startToken = 7,
+            currentGeneration = { 7 },
+            isRunning = { true },
+            recoveryAttempt = 2,
+            isBridgeRunning = { ++bridgeChecks <= 2 },
+            isProtectMonitorRunning = { true },
+            isApiHealthy = { true },
+            monotonicMillis = { monotonicNow },
+            sleep = { monotonicNow = 120_000L }
+        )
+
+        assertTrue(outcome.unexpectedExit)
+        assertEquals(0, outcome.recoveryAttempt)
+        assertEquals(
+            1,
+            CoreRecoveryCoordinator.nextAttemptAfterUnexpectedExit(
+                outcome.recoveryAttempt
+            )
+        )
+    }
+
+    @Test
     fun `reports unexpected exit while the same start is active`() {
         assertTrue(
             CoreLivenessMonitor.waitForUnexpectedExit(
@@ -15,7 +42,7 @@ class CoreLivenessMonitorTest {
                 currentGeneration = { 7 },
                 isRunning = { true },
                 isBridgeRunning = { false }
-            )
+            ).unexpectedExit
         )
     }
 
@@ -31,7 +58,7 @@ class CoreLivenessMonitorTest {
                     generation.incrementAndGet()
                     false
                 }
-            )
+            ).unexpectedExit
         )
     }
 
@@ -43,7 +70,7 @@ class CoreLivenessMonitorTest {
                 currentGeneration = { 7 },
                 isRunning = { false },
                 isBridgeRunning = { error("must not probe a stopped session") }
-            )
+            ).unexpectedExit
         )
     }
 
@@ -58,7 +85,7 @@ class CoreLivenessMonitorTest {
                 isProtectMonitorRunning = { false },
                 isApiHealthy = { error("API must not be probed after protect failure") },
                 sleep = { error("a dead protect monitor must fail immediately") }
-            )
+            ).unexpectedExit
         )
     }
 
@@ -83,7 +110,7 @@ class CoreLivenessMonitorTest {
                     false // 端口不可达 → 核心已死
                 },
                 sleep = {}
-            )
+            ).unexpectedExit
         )
         assertEquals(3, apiChecks)
         assertEquals(1, portProbes)
@@ -106,7 +133,7 @@ class CoreLivenessMonitorTest {
                 },
                 isApiPortReachable = { true }, // 僵尸端口仍可达
                 sleep = {}
-            )
+            ).unexpectedExit
         )
         // 3 次失败后探测端口（可达），再等 1 次确认后退出
         assertEquals(4, apiChecks)
@@ -127,7 +154,7 @@ class CoreLivenessMonitorTest {
                 isApiHealthy = { apiResults.removeFirst() },
                 isApiPortReachable = { true },
                 sleep = {}
-            )
+            ).unexpectedExit
         )
         assertTrue(apiResults.isEmpty())
     }
@@ -149,7 +176,7 @@ class CoreLivenessMonitorTest {
                     sleeps++
                     if (sleeps == 2) running = false
                 }
-            )
+            ).unexpectedExit
         )
         assertEquals(2, sleeps)
     }
@@ -173,7 +200,7 @@ class CoreLivenessMonitorTest {
                 sleep = {
                     if (localApiChecks == 3) running = false
                 }
-            )
+            ).unexpectedExit
         )
         assertEquals(3, localApiChecks)
     }

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/CoreRecoveryPolicyTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/CoreRecoveryPolicyTest.kt
@@ -8,10 +8,54 @@ import org.junit.Test
 
 class CoreRecoveryPolicyTest {
     @Test
+    fun `119 seconds of continuous health does not reset the recovery attempt`() {
+        val budget = CoreRecoveryBudget(initialAttempt = 2)
+
+        budget.observeHealth(isHealthy = true, monotonicMillis = 0L)
+        budget.observeHealth(isHealthy = true, monotonicMillis = 119_999L)
+
+        assertEquals(2, budget.attempt)
+    }
+
+    @Test
+    fun `120 seconds of continuous health resets the recovery attempt`() {
+        val budget = CoreRecoveryBudget(initialAttempt = 2)
+
+        budget.observeHealth(isHealthy = true, monotonicMillis = 0L)
+        budget.observeHealth(isHealthy = true, monotonicMillis = 120_000L)
+
+        assertEquals(0, budget.attempt)
+    }
+
+    @Test
+    fun `unhealthy or unknown samples restart the stable health window`() {
+        val budget = CoreRecoveryBudget(initialAttempt = 2)
+
+        budget.observeHealth(isHealthy = true, monotonicMillis = 0L)
+        budget.observeHealth(isHealthy = false, monotonicMillis = 30_000L)
+        budget.observeHealth(isHealthy = true, monotonicMillis = 30_000L)
+        budget.observeHealth(isHealthy = null, monotonicMillis = 60_000L)
+        budget.observeHealth(isHealthy = true, monotonicMillis = 60_000L)
+        budget.observeHealth(isHealthy = true, monotonicMillis = 179_999L)
+        assertEquals(2, budget.attempt)
+
+        budget.observeHealth(isHealthy = true, monotonicMillis = 180_000L)
+        assertEquals(0, budget.attempt)
+    }
+
+    @Test
     fun `unexpected core exit allows two bounded retries`() {
         assertEquals(1, CoreRecoveryPolicy.nextAttempt(0))
         assertEquals(2, CoreRecoveryPolicy.nextAttempt(1))
         assertNull(CoreRecoveryPolicy.nextAttempt(2))
+    }
+
+    @Test
+    fun `a transient failure during first recovery gets one delayed final attempt`() {
+        assertNull(CoreRecoveryPolicy.retryAfterStartFailure(0))
+        assertEquals(2, CoreRecoveryPolicy.retryAfterStartFailure(1))
+        assertNull(CoreRecoveryPolicy.retryAfterStartFailure(2))
+        assertTrue(CoreRecoveryPolicy.retryDelayMillis(2) >= 1_000L)
     }
 
     @Test

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnDataPlaneProbeTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnDataPlaneProbeTest.kt
@@ -1,5 +1,9 @@
 package com.ssrvpn.android
 
+import java.net.UnknownHostException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -62,6 +66,226 @@ class VpnDataPlaneProbeTest {
                 "https://cp.cloudflare.com/generate_204"
             ),
             attempted
+        )
+    }
+
+    @Test
+    fun `probe diagnostics expose only bounded endpoint and cause categories`() {
+        val attempts = mutableListOf<VpnDataPlaneProbe.AttemptDiagnostic>()
+
+        assertFalse(
+            VpnDataPlaneProbe.isReachable(
+                endpoints = listOf("https://private.example/path?token=secret"),
+                maxAttempts = 1,
+                fetchStatus = { throw UnknownHostException("private.example") },
+                recordAttempt = attempts::add
+            )
+        )
+
+        val diagnostic = attempts.single()
+        assertEquals("other", diagnostic.endpointCategory)
+        assertEquals(1, diagnostic.attempt)
+        assertEquals(1, diagnostic.totalAttempts)
+        assertEquals(null, diagnostic.status)
+        assertEquals("dns", diagnostic.cause)
+        assertTrue(diagnostic.elapsedMillis >= 0L)
+        assertFalse(diagnostic.toString().contains("private.example"))
+        assertFalse(diagnostic.toString().contains("secret"))
+    }
+
+    @Test
+    fun `non-204 response is logged as an HTTP status without weakening the gate`() {
+        val attempts = mutableListOf<VpnDataPlaneProbe.AttemptDiagnostic>()
+
+        assertFalse(
+            VpnDataPlaneProbe.isReachable(
+                endpoints = listOf("https://www.gstatic.com/generate_204"),
+                maxAttempts = 1,
+                fetchStatus = { 200 },
+                recordAttempt = attempts::add
+            )
+        )
+
+        assertEquals("google", attempts.single().endpointCategory)
+        assertEquals(200, attempts.single().status)
+        assertEquals("http_status", attempts.single().cause)
+    }
+
+    @Test
+    fun `hard budget fails closed when resolver ignores URL timeouts`() {
+        val resolverStarted = CountDownLatch(1)
+        val releaseResolver = CountDownLatch(1)
+        val resolverFinished = CountDownLatch(1)
+        val diagnosticPublished = CountDownLatch(1)
+        val startedAt = System.nanoTime()
+
+        val outcome = VpnDataPlaneProbe.probeReachability(
+            endpoints = listOf("https://www.gstatic.com/generate_204"),
+            maxAttempts = 1,
+            totalBudgetMillis = 100L,
+            fetchStatus = {
+                resolverStarted.countDown()
+                try {
+                    releaseResolver.await()
+                    204
+                } finally {
+                    resolverFinished.countDown()
+                }
+            },
+            recordAttempt = { diagnosticPublished.countDown() }
+        )
+        val elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+        releaseResolver.countDown()
+
+        assertTrue(resolverStarted.await(1, TimeUnit.SECONDS))
+        assertEquals(VpnDataPlaneProbe.StartupOutcome.WATCHDOG_TIMEOUT, outcome)
+        assertTrue("probe exceeded its hard budget: ${elapsedMillis}ms", elapsedMillis < 1_000L)
+        assertTrue(resolverFinished.await(1, TimeUnit.SECONDS))
+        assertFalse(diagnosticPublished.await(100, TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun `timed out uninterruptible probe stays single flight until its worker exits`() {
+        val firstFetchStarted = CountDownLatch(1)
+        val releaseFirstFetch = CountDownLatch(1)
+        val firstFetchFinished = CountDownLatch(1)
+
+        val firstReachable = VpnDataPlaneProbe.isReachable(
+            endpoints = listOf("https://www.gstatic.com/generate_204"),
+            maxAttempts = 1,
+            totalBudgetMillis = 50L,
+            fetchStatus = {
+                firstFetchStarted.countDown()
+                try {
+                    while (true) {
+                        try {
+                            if (releaseFirstFetch.await(10, TimeUnit.MILLISECONDS)) break
+                        } catch (_: InterruptedException) {
+                            // Deliberately ignore interruption like a stuck resolver can.
+                        }
+                    }
+                    204
+                } finally {
+                    firstFetchFinished.countDown()
+                }
+            }
+        )
+
+        assertTrue(firstFetchStarted.await(1, TimeUnit.SECONDS))
+        assertFalse(firstReachable)
+        var overlappingFetches = 0
+        assertEquals(
+            VpnDataPlaneProbe.StartupOutcome.PREVIOUS_PROBE_STILL_RUNNING,
+            VpnDataPlaneProbe.probeReachability(
+                endpoints = listOf("https://www.gstatic.com/generate_204"),
+                maxAttempts = 1,
+                totalBudgetMillis = 50L,
+                fetchStatus = {
+                    overlappingFetches++
+                    204
+                }
+            ),
+        )
+        assertEquals(0, overlappingFetches)
+
+        releaseFirstFetch.countDown()
+        assertTrue(firstFetchFinished.await(1, TimeUnit.SECONDS))
+        val retryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1)
+        var recovered = false
+        while (!recovered && System.nanoTime() < retryDeadline) {
+            recovered = VpnDataPlaneProbe.isReachable(
+                endpoints = listOf("https://www.gstatic.com/generate_204"),
+                maxAttempts = 1,
+                totalBudgetMillis = 50L,
+                fetchStatus = { 204 }
+            )
+            if (!recovered) Thread.yield()
+        }
+        assertTrue(recovered)
+    }
+
+    @Test
+    fun `retry waits for a timed out worker then performs a fresh exact probe`() {
+        val firstFetchStarted = CountDownLatch(1)
+        val releaseFirstFetch = CountDownLatch(1)
+        val retryFetchStarted = CountDownLatch(1)
+        val retryResult = AtomicReference<Boolean>()
+
+        try {
+            assertFalse(
+                VpnDataPlaneProbe.isReachable(
+                    endpoints = listOf("https://www.gstatic.com/generate_204"),
+                    maxAttempts = 1,
+                    totalBudgetMillis = 50L,
+                    fetchStatus = {
+                        firstFetchStarted.countDown()
+                        while (true) {
+                            try {
+                                if (releaseFirstFetch.await(10, TimeUnit.MILLISECONDS)) break
+                            } catch (_: InterruptedException) {
+                                // Deliberately model a resolver that ignores interruption.
+                            }
+                        }
+                        204
+                    }
+                )
+            )
+            assertTrue(firstFetchStarted.await(1, TimeUnit.SECONDS))
+
+            val retryThread = Thread {
+                retryResult.set(
+                    VpnDataPlaneProbe.isReachable(
+                        endpoints = listOf("https://www.gstatic.com/generate_204"),
+                        maxAttempts = 1,
+                        totalBudgetMillis = 500L,
+                        fetchStatus = {
+                            retryFetchStarted.countDown()
+                            204
+                        }
+                    )
+                )
+            }
+            retryThread.start()
+
+            assertFalse(retryFetchStarted.await(50, TimeUnit.MILLISECONDS))
+            releaseFirstFetch.countDown()
+            assertTrue(retryFetchStarted.await(1, TimeUnit.SECONDS))
+            retryThread.join(1_000L)
+            assertFalse(retryThread.isAlive)
+            assertEquals(true, retryResult.get())
+        } finally {
+            releaseFirstFetch.countDown()
+        }
+    }
+
+    @Test
+    fun `busy and watchdog outcomes have distinct actionable messages`() {
+        assertEquals(
+            "上次 VPN 联网检查仍在结束，请稍后重试；若持续出现请重启应用",
+            VpnDataPlaneProbe.StartupOutcome.PREVIOUS_PROBE_STILL_RUNNING.failureMessage
+        )
+        assertEquals(
+            "VPN 联网检查超时，请稍后重试；若持续出现请重启应用",
+            VpnDataPlaneProbe.StartupOutcome.WATCHDOG_TIMEOUT.failureMessage
+        )
+    }
+
+    @Test
+    fun `activity timeout covers every legal native startup stage`() {
+        val requiredBudget =
+            VpnStartBudget.BRIDGE_MS +
+                VpnStartBudget.API_HEALTH_MS +
+                VpnStartBudget.PROXY_SELECTION_MS +
+                VpnDataPlaneProbe.MAX_STARTUP_DURATION_MILLIS
+
+        assertTrue(VpnStartBudget.RESULT_MS > requiredBudget)
+    }
+
+    @Test
+    fun `tile callback timeout covers the native startup result budget`() {
+        assertTrue(
+            VpnTileService.START_CALLBACK_TIMEOUT_MS >=
+                VpnStartBudget.RESULT_MS
         )
     }
 }

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnServiceStopGateTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/VpnServiceStopGateTest.kt
@@ -1,0 +1,29 @@
+package com.ssrvpn.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VpnServiceStopGateTest {
+    @Test
+    fun `rejected start during cleanup remains covered by the pending stop`() {
+        val gate = VpnServiceStopGate()
+        gate.acceptStart(10)
+        val stop = gate.beginOrJoinStop()
+
+        gate.includeRejectedStart(11)
+
+        assertEquals(11, gate.finishStop(stop))
+    }
+
+    @Test
+    fun `accepted later start invalidates the stale stop completion`() {
+        val gate = VpnServiceStopGate()
+        gate.acceptStart(10)
+        val staleStop = gate.beginOrJoinStop()
+
+        gate.acceptStart(11)
+
+        assertNull(gate.finishStop(staleStop))
+    }
+}

--- a/SSRVPN_Android/lib/app.dart
+++ b/SSRVPN_Android/lib/app.dart
@@ -10,7 +10,9 @@ import 'package:ssrvpn_shared/ssrvpn_shared.dart'
         HomeNodeController,
         SsrvpnAppBackdrop,
         SsrvpnBottomNavigation,
-        UpdateAvailabilityController;
+        UpdateAvailabilityController,
+        safeUserFacingFailureMessage,
+        safeUserFacingFailureWithAction;
 import 'package:ssrvpn_shared/widgets/crash_report_prompt.dart';
 import 'services/settings_service.dart';
 import 'services/clash_service.dart' as clash;
@@ -34,6 +36,24 @@ const androidSupportedLocales = <Locale>[
 ];
 final Iterable<LocalizationsDelegate<dynamic>> androidLocalizationsDelegates =
     GlobalMaterialLocalizations.delegates;
+
+@visibleForTesting
+String androidInitializationFailureMessage(
+  Object error, {
+  required int retryCount,
+}) {
+  final reason = error is AndroidApiSecretRecoveryRequired
+      ? 'Android 安全存储中的本机密钥无法读取。普通重试不会自动重建密钥。'
+      : safeUserFacingFailureMessage(error);
+  return '$reason\n\n自动重试 $retryCount 次后仍失败。';
+}
+
+@visibleForTesting
+String androidApiSecretRecoveryFailureMessage(Object error) =>
+    '本机密钥恢复失败：${safeUserFacingFailureWithAction(
+      error,
+      '未删除订阅和普通设置，请稍后重试。',
+    )}';
 
 class SSRVpnApp extends StatefulWidget {
   final StartupFlags startupFlags;
@@ -131,10 +151,10 @@ class _SSRVpnAppState extends State<SSRVpnApp> {
           setState(() {
             _initError = true;
             _apiSecretRecoveryRequired = e is AndroidApiSecretRecoveryRequired;
-            final reason = _apiSecretRecoveryRequired
-                ? 'Android 安全存储中的本机密钥无法读取。普通重试不会自动重建密钥。'
-                : e.toString().replaceFirst('Exception: ', '');
-            _initErrorMsg = '$reason\n\n自动重试 $_initRetryCount 次后仍失败';
+            _initErrorMsg = androidInitializationFailureMessage(
+              e,
+              retryCount: _initRetryCount,
+            );
           });
         }
         return;
@@ -191,7 +211,7 @@ class _SSRVpnAppState extends State<SSRVpnApp> {
       setState(() {
         _apiSecretRecoveryInProgress = false;
         _apiSecretRecoveryRequired = true;
-        _initErrorMsg = '本机密钥恢复失败：$error\n\n未删除订阅和普通设置，请稍后重试。';
+        _initErrorMsg = androidApiSecretRecoveryFailureMessage(error);
       });
     }
   }

--- a/SSRVPN_Android/lib/screens/home_connection_actions_part.dart
+++ b/SSRVPN_Android/lib/screens/home_connection_actions_part.dart
@@ -59,7 +59,13 @@ extension _AndroidHomeConnectionActions on HomeScreenState {
       )) {
         return;
       }
-      final result = await orch.connect(
+      if (mounted && !_disposed) {
+        _updateHomeState(() {
+          _isConnected = false;
+          _connectionNotice = null;
+        });
+      }
+      final outcome = await orch.connect(
         preferredNode?.name,
         connectionGeneration: connectionGeneration,
       );
@@ -72,14 +78,47 @@ extension _AndroidHomeConnectionActions on HomeScreenState {
       final connected = clashService.isRunning;
       if (mounted && !_disposed) {
         if (!connected) clashService.requestConnectionIntent(false);
+        ProxyNode? connectedNode;
+        var preferredNodePersisted = true;
+        if (connected) {
+          connectedNode = outcome.preferredNodeSwitchSucceeded
+              ? preferredNode
+              : HomeNodeController.resolveRuntimeSelectedNodeFrom(
+                  nodes,
+                  outcome.runtimeNodeName,
+                );
+          if (connectedNode != null) {
+            preferredNodePersisted = await _rememberSelectedNode(
+              connectedNode,
+              shouldContinue: () => clashService.isConnectionIntentCurrent(
+                connectionGeneration,
+                connected: true,
+              ),
+            );
+          }
+        }
+        if (!clashService.isConnectionIntentCurrent(
+          connectionGeneration,
+          connected: true,
+        )) {
+          return;
+        }
+        if (!mounted || _disposed) return;
+        final feedback = resolveAndroidConnectionFeedback(
+          connected: connected,
+          result: connected && !preferredNodePersisted
+              ? '已连接，但首选节点保存失败'
+              : outcome.message,
+          runtimeNotice:
+              connected ? clashService.underlyingNetworkNotice : null,
+        );
         _updateHomeState(() {
           _isConnected = connected;
-          _connectionNotice =
-              connected ? clashService.underlyingNetworkNotice : null;
+          _connectionNotice = feedback.connectionNotice;
           _isConnecting = false;
-          _errorMessage = connected ? result : result ?? '连接重载失败: 无法启动VPN核心';
+          _errorMessage = feedback.errorMessage;
           _nodes = nodes;
-          _selectedNode = connected ? preferredNode : null;
+          _selectedNode = connected ? connectedNode : null;
           if (!connected) _resetPublicIpState();
         });
         if (connected) _schedulePublicIpRefresh();
@@ -198,13 +237,13 @@ extension _AndroidHomeConnectionActions on HomeScreenState {
           settingsService: settingsService,
           subscriptionService: subService,
         );
-        final result = await clashService.runConnectionTransition(
+        final outcome = await clashService.runConnectionTransition(
           () async {
             if (!clashService.isConnectionIntentCurrent(
               connectionGeneration!,
               connected: true,
             )) {
-              return null;
+              return const AndroidConnectionOutcome();
             }
             return orchestrator.connect(
               autoSelect?.name,
@@ -227,9 +266,16 @@ extension _AndroidHomeConnectionActions on HomeScreenState {
         }
         if (!mounted || _disposed) return;
         if (connected) {
-          if (autoSelect != null) {
-            await _rememberSelectedNode(
-              autoSelect,
+          var preferredNodePersisted = true;
+          final connectedNode = outcome.preferredNodeSwitchSucceeded
+              ? autoSelect
+              : HomeNodeController.resolveRuntimeSelectedNodeFrom(
+                  nodes,
+                  outcome.runtimeNodeName,
+                );
+          if (connectedNode != null) {
+            preferredNodePersisted = await _rememberSelectedNode(
+              connectedNode,
               shouldContinue: () => clashService.isConnectionIntentCurrent(
                 connectionGeneration!,
                 connected: true,
@@ -251,25 +297,37 @@ extension _AndroidHomeConnectionActions on HomeScreenState {
               _isConnected = false;
               _connectionNotice = null;
               _isConnecting = false;
-              _errorMessage = result ?? '连接已中断，请重新连接';
+              _errorMessage = userFriendlyAndroidConnectionError(
+                outcome.message ?? '连接已中断，请重新连接',
+              );
               _resetPublicIpState();
             });
             return;
           }
+          final feedback = resolveAndroidConnectionFeedback(
+            connected: true,
+            result: preferredNodePersisted ? outcome.message : '已连接，但首选节点保存失败',
+            runtimeNotice: clashService.underlyingNetworkNotice,
+          );
           _updateHomeState(() {
             _isConnected = true;
-            _connectionNotice = clashService.underlyingNetworkNotice;
+            _connectionNotice = feedback.connectionNotice;
             _isConnecting = false;
-            _errorMessage = result;
+            _errorMessage = feedback.errorMessage;
             _nodes = nodes;
-            _selectedNode = autoSelect;
+            _selectedNode = connectedNode;
           });
           _schedulePublicIpRefresh();
           unawaited(_autoTestAllNodes());
           _checkUpdateDelayed();
         } else {
+          final feedback = resolveAndroidConnectionFeedback(
+            connected: false,
+            result: outcome.message,
+            runtimeNotice: null,
+          );
           _updateHomeState(() {
-            _errorMessage = result ?? '连接失败: 无法启动VPN核心';
+            _errorMessage = feedback.errorMessage;
             _isConnecting = false;
             _resetPublicIpState();
           });
@@ -299,26 +357,7 @@ extension _AndroidHomeConnectionActions on HomeScreenState {
   }
 
   String _userFriendlyError(Object error) {
-    final msg = error.toString();
-    if (msg.contains('TimeoutException') ||
-        msg.contains('timeout') ||
-        msg.contains('超时')) {
-      return '连接超时，请检查网络后重试';
-    }
-    if (msg.contains('SocketException') ||
-        msg.contains('Network') ||
-        msg.contains('Connection refused')) {
-      return '网络连接失败，请检查网络设置';
-    }
-    if (msg.contains('HttpException') || msg.contains('HTTP')) {
-      return '服务器响应异常，请稍后重试';
-    }
-    if (msg.contains('HandshakeException') ||
-        msg.contains('TLS') ||
-        msg.contains('Certificate')) {
-      return '安全连接失败，请检查网络环境';
-    }
-    return msg.replaceFirst('Exception: ', '');
+    return userFriendlyAndroidConnectionError(error);
   }
 
   Future<void> _handleProxyModeChanged(String mode) async {

--- a/SSRVPN_Android/lib/screens/home_lifecycle_actions_part.dart
+++ b/SSRVPN_Android/lib/screens/home_lifecycle_actions_part.dart
@@ -1,6 +1,31 @@
 part of 'home_screen.dart';
 
 extension _AndroidHomeLifecycleActions on HomeScreenState {
+  void _registerClashService(ClashService clashService) {
+    final previous = _registeredClashService;
+    if (identical(previous, clashService)) return;
+    if (previous != null) {
+      if (identical(previous.onAutoConnect, _onClashAutoConnect)) {
+        previous.onAutoConnect = null;
+      }
+      if (identical(previous.onStatusChanged, _onClashStatusChanged)) {
+        previous.onStatusChanged = null;
+      }
+      if (identical(previous.onRuntimeNotice, _onClashRuntimeNotice)) {
+        previous.onRuntimeNotice = null;
+      }
+    }
+    _registeredClashService = clashService;
+    _connectionStatusEpoch++;
+    _statusApplicationEpoch++;
+    _observedClashRunning = clashService.isRunning;
+    _observedNativeTransitioning = clashService.nativeConnectionTransitioning;
+    _observedNativeSessionGeneration = clashService.nativeSessionGeneration;
+    clashService.onAutoConnect = _onClashAutoConnect;
+    clashService.onStatusChanged = _onClashStatusChanged;
+    clashService.onRuntimeNotice = _onClashRuntimeNotice;
+  }
+
   bool _onSubscriptionChanged(SubscriptionService subService) {
     final controller = HomeNodeController(
       nodes: _nodes,
@@ -63,9 +88,6 @@ extension _AndroidHomeLifecycleActions on HomeScreenState {
     if (!mounted || _disposed) return;
     final subService = context.read<SubscriptionService>();
     final clashService = context.read<ClashService>();
-    _registeredClashService = clashService;
-    clashService.onAutoConnect = _onClashAutoConnect;
-    clashService.onStatusChanged = _onClashStatusChanged;
 
     final statusEpoch = _connectionStatusEpoch;
     final running = clashService.isRunning;
@@ -129,13 +151,50 @@ extension _AndroidHomeLifecycleActions on HomeScreenState {
   void _handleClashStatusChanged() {
     final clashService = _registeredClashService;
     if (!mounted || _disposed || clashService == null) return;
-    final statusEpoch = ++_connectionStatusEpoch;
-    unawaited(_applyClashStatusChanged(clashService, statusEpoch));
+    final running = clashService.isRunning;
+    final nativeTransitioning = clashService.nativeConnectionTransitioning;
+    final nativeSessionGeneration = clashService.nativeSessionGeneration;
+    if (_observedClashRunning != running ||
+        _observedNativeTransitioning != nativeTransitioning ||
+        _observedNativeSessionGeneration != nativeSessionGeneration) {
+      _connectionStatusEpoch++;
+      _observedClashRunning = running;
+      _observedNativeTransitioning = nativeTransitioning;
+      _observedNativeSessionGeneration = nativeSessionGeneration;
+    }
+    final applicationEpoch = ++_statusApplicationEpoch;
+    unawaited(
+      _applyClashStatusChanged(
+        clashService,
+        _connectionStatusEpoch,
+        applicationEpoch,
+      ),
+    );
+  }
+
+  void _handleClashRuntimeNotice(RuntimeNotice notice) {
+    if (!mounted || _disposed) return;
+    switch (notice.level) {
+      case RuntimeNoticeLevel.progress:
+      case RuntimeNoticeLevel.warning:
+        _updateHomeState(() {
+          _connectionNotice = notice.message;
+          _errorMessage = null;
+        });
+      case RuntimeNoticeLevel.error:
+        _updateHomeState(() {
+          _connectionNotice = null;
+          _errorMessage = notice.message;
+        });
+      case RuntimeNoticeLevel.success:
+        return;
+    }
   }
 
   Future<void> _applyClashStatusChanged(
     ClashService clashService,
     int statusEpoch,
+    int applicationEpoch,
   ) async {
     final running = clashService.isRunning;
     final nativeTransitioning = clashService.nativeConnectionTransitioning;
@@ -159,6 +218,7 @@ extension _AndroidHomeLifecycleActions on HomeScreenState {
     if (!mounted ||
         _disposed ||
         statusEpoch != _connectionStatusEpoch ||
+        applicationEpoch != _statusApplicationEpoch ||
         !identical(_registeredClashService, clashService) ||
         clashService.isRunning != running ||
         clashService.nativeConnectionTransitioning != nativeTransitioning) {

--- a/SSRVPN_Android/lib/screens/home_node_actions_part.dart
+++ b/SSRVPN_Android/lib/screens/home_node_actions_part.dart
@@ -14,11 +14,19 @@ extension _AndroidHomeNodeActions on HomeScreenState {
     _updateHomeState(() => _testingNodeName = nodeName);
     final clashService = context.read<ClashService>();
     final settings = context.read<SettingsService>().settings;
-    final measuredLatency = await clashService.testLatency(
-      server,
-      port,
-      timeoutMs: settings.latencyTestTimeout,
-    );
+    ProxyNode? nodeUnderTest;
+    for (final node in _nodes) {
+      if (node.name == nodeName && node.server == server && node.port == port) {
+        nodeUnderTest = node;
+        break;
+      }
+    }
+    final measuredLatency = nodeUnderTest == null
+        ? -1
+        : await clashService.testNodeLatency(
+            nodeUnderTest,
+            timeoutMs: settings.latencyTestTimeout,
+          );
     final latency = PrivateNodeLatencyPolicy.displayLatencyForNode(
       nodeName,
       measuredLatency,
@@ -64,10 +72,11 @@ extension _AndroidHomeNodeActions on HomeScreenState {
               .read<ClashService>()
               .invalidateIdleNativeConnectionSnapshot();
         }
-        await _rememberSelectedNode(
+        final remembered = await _rememberSelectedNode(
           node,
           shouldContinue: () => mounted && !_disposed,
         );
+        if (!remembered) throw StateError('首选节点保存失败');
         if (!mounted || _disposed) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -144,8 +153,10 @@ extension _AndroidHomeNodeActions on HomeScreenState {
     );
     if (!result.intentCurrent || !isCurrent()) return;
     var snapshotPersisted = result.snapshotPersisted;
+    var preferredNodePersisted = true;
+    var liveSwitchConfirmed = result.liveSwitched;
     ProxyNode? reconciledRuntimeNode;
-    if (result.liveSwitched) {
+    if (liveSwitchConfirmed) {
       snapshotPersisted = await _writePreferredNodeConfigForTile(
             node,
             shouldContinue: isCurrent,
@@ -155,16 +166,28 @@ extension _AndroidHomeNodeActions on HomeScreenState {
       if (!isCurrent()) return;
       if (!snapshotPersisted) {
         final runtimeNodeName = await clashService.currentSelectedProxyName();
-        if (!isCurrent() || runtimeNodeName != node.name) return;
+        if (!isCurrent()) return;
+        if (runtimeNodeName?.trim().isNotEmpty == true &&
+            runtimeNodeName != node.name) {
+          liveSwitchConfirmed = false;
+          reconciledRuntimeNode = resolveAndroidHomeNodeAfterFailedSwitch(
+            nodes: _nodes,
+            runtimeSelectedNodeName: runtimeNodeName,
+          );
+        }
       }
-      await _rememberSelectedNode(node, shouldContinue: isCurrent);
-      if (!isCurrent()) return;
-      if (mounted && !_disposed) {
-        _updateHomeState(() => _selectedNode = node);
+      if (liveSwitchConfirmed) {
+        preferredNodePersisted =
+            await _rememberSelectedNode(node, shouldContinue: isCurrent);
+        if (!isCurrent()) return;
+        if (mounted && !_disposed) {
+          _updateHomeState(() => _selectedNode = node);
+        }
+        _schedulePublicIpRefresh();
       }
-      _schedulePublicIpRefresh();
-    } else {
-      reconciledRuntimeNode = resolveAndroidHomeNodeAfterFailedSwitch(
+    }
+    if (!liveSwitchConfirmed) {
+      reconciledRuntimeNode ??= resolveAndroidHomeNodeAfterFailedSwitch(
         nodes: _nodes,
         runtimeSelectedNodeName: result.runtimeNodeName,
       );
@@ -175,7 +198,7 @@ extension _AndroidHomeNodeActions on HomeScreenState {
           expectedSessionGeneration: result.nativeSessionGeneration,
         );
         if (!isCurrent()) return;
-        await _rememberSelectedNode(
+        preferredNodePersisted = await _rememberSelectedNode(
           reconciledRuntimeNode,
           shouldContinue: isCurrent,
         );
@@ -191,15 +214,19 @@ extension _AndroidHomeNodeActions on HomeScreenState {
         SnackBar(
           margin: EdgeInsets.fromLTRB(16, 0, 16, 88),
           content: Text(
-            !result.liveSwitched
+            !liveSwitchConfirmed
                 ? reconciledRuntimeNode == null
                     ? '切换失败: ${node.name}'
+                    : !preferredNodePersisted
+                        ? '切换失败: ${node.name}；当前节点: ${reconciledRuntimeNode.name}；首选节点保存失败'
+                        : snapshotPersisted
+                            ? '切换失败: ${node.name}；当前节点: ${reconciledRuntimeNode.name}'
+                            : '切换失败: ${node.name}；当前节点: ${reconciledRuntimeNode.name}；快速启动信息保存失败'
+                : !preferredNodePersisted
+                    ? '已切换，但首选节点保存失败'
                     : snapshotPersisted
-                        ? '切换失败: ${node.name}；当前节点: ${reconciledRuntimeNode.name}'
-                        : '切换失败: ${node.name}；当前节点: ${reconciledRuntimeNode.name}；快速启动信息保存失败'
-                : snapshotPersisted
-                    ? '已切换: ${node.name}'
-                    : '已切换: ${node.name}；快速启动信息保存失败',
+                        ? '已切换: ${node.name}'
+                        : '已切换: ${node.name}；快速启动信息保存失败',
           ),
           duration: const Duration(seconds: 4),
         ),
@@ -227,14 +254,20 @@ extension _AndroidHomeNodeActions on HomeScreenState {
     );
   }
 
-  Future<void> _rememberSelectedNode(
+  Future<bool> _rememberSelectedNode(
     ProxyNode node, {
     required bool Function() shouldContinue,
   }) async {
-    if (!shouldContinue()) return;
+    if (!shouldContinue()) return false;
     final settingsService = context.read<SettingsService>();
-    if (settingsService.settings.lastSelectedNodeName == node.name) return;
-    await settingsService.setLastSelectedNodeName(node.name);
+    if (settingsService.settings.lastSelectedNodeName == node.name) return true;
+    try {
+      await settingsService.setLastSelectedNodeName(node.name);
+      return shouldContinue();
+    } catch (error) {
+      AppLogger.warning('NodeSelection', '首选节点保存失败: $error');
+      return false;
+    }
   }
 
   Future<bool> _writePreferredNodeConfigForTile(
@@ -268,6 +301,7 @@ extension _AndroidHomeNodeActions on HomeScreenState {
   Future<void> _runBatchLatencyTest() async {
     if (_nodes.isEmpty) return;
     final clashService = context.read<ClashService>();
+    final timeout = context.read<SettingsService>().settings.latencyTestTimeout;
     final subscriptionService = context.read<SubscriptionService>();
     final nodesUnderTest = List<ProxyNode>.from(_nodes);
     final subscriptionRevision = subscriptionService.revision;
@@ -293,6 +327,7 @@ extension _AndroidHomeNodeActions on HomeScreenState {
           }
           _scheduleLatencyFlush(generation);
         },
+        timeoutMs: timeout,
         shouldContinue: isCurrent,
       );
     } catch (error) {

--- a/SSRVPN_Android/lib/screens/home_screen.dart
+++ b/SSRVPN_Android/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:ssrvpn_shared/runtime_notice.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 import '../services/clash_service.dart';
 import '../services/subscription_service.dart';
@@ -71,13 +72,21 @@ class HomeScreenState extends State<HomeScreen>
   bool _updateCheckInProgress = false;
   int _lastRevision = -1;
   int _publicIpGeneration = 0;
+  // Invalidates mutations only when the service lifecycle/session changes.
   int _connectionStatusEpoch = 0;
+  // Orders async status rendering without cancelling an in-flight node switch.
+  int _statusApplicationEpoch = 0;
+  bool? _observedClashRunning;
+  bool? _observedNativeTransitioning;
+  int? _observedNativeSessionGeneration;
   bool _disposed = false;
   Future<void> _nodeSelectionTail = Future<void>.value();
   ClashService? _registeredClashService;
   SubscriptionService? _subscriptionService;
   late final VoidCallback _onClashAutoConnect = _handleClashAutoConnect;
   late final VoidCallback _onClashStatusChanged = _handleClashStatusChanged;
+  late final void Function(RuntimeNotice) _onClashRuntimeNotice =
+      _handleClashRuntimeNotice;
 
   @override
   void initState() {
@@ -91,6 +100,7 @@ class HomeScreenState extends State<HomeScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _registerClashService(context.watch<ClashService>());
     final subService = context.read<SubscriptionService>();
     if (identical(_subscriptionService, subService)) return;
     _subscriptionService?.removeListener(_handleSubscriptionServiceChanged);
@@ -147,6 +157,9 @@ class HomeScreenState extends State<HomeScreen>
       }
       if (identical(clashService.onStatusChanged, _onClashStatusChanged)) {
         clashService.onStatusChanged = null;
+      }
+      if (identical(clashService.onRuntimeNotice, _onClashRuntimeNotice)) {
+        clashService.onRuntimeNotice = null;
       }
     }
     _cancelSingleLatencyTest();

--- a/SSRVPN_Android/lib/services/clash_service.dart
+++ b/SSRVPN_Android/lib/services/clash_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:ssrvpn_shared/runtime_notice.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 
 part 'clash_service_snapshot_cleanup.dart';
@@ -54,15 +55,17 @@ class ClashService extends ClashServiceBase {
   String get corePath => _corePath;
   bool get coreExists => File(_corePath).existsSync();
   bool get nativeConnectionTransitioning => _nativeConnectionTransitioning;
+  int? get nativeSessionGeneration => _nativeSessionGeneration;
   String? get underlyingNetworkNotice {
-    if (!isRunning || _underlyingNetworkAvailable == null) return null;
+    if (!isRunning) return null;
     if (_underlyingNetworkAvailable == false) {
       return '无可用网络，VPN 正在等待恢复';
     }
-    if (_underlyingNetworkValidated == false) {
+    if (_underlyingNetworkAvailable == true &&
+        _underlyingNetworkValidated == false) {
       return '网络尚未验证，VPN 正在等待恢复';
     }
-    return null;
+    return connectivityWarning;
   }
 
   void setCorePath(String path) => _corePath = path;
@@ -110,8 +113,26 @@ class ClashService extends ClashServiceBase {
       _invalidateIdleNativeConnectionSnapshot();
 
   void _markNativeConnectionLost() => markConnectionLost();
-  void _notifyNativeRuntimeNotice(String message) =>
-      notifyRuntimeNotice(message);
+  void _notifyNativeRuntimeNotice(RuntimeNotice notice) =>
+      notifyRuntimeNotice(notice);
+
+  /// Native exact-204 startup validation is authoritative. This secondary
+  /// external observation is advisory and deliberately does not delay the
+  /// connected state or own the VPN lifecycle.
+  void scheduleUserConnectivityObservation() => scheduleDataPlaneObservation();
+
+  @override
+  Future<void> observeDataPlaneHealth() async {
+    final connectionGeneration = captureAutomaticRestartIntent();
+    if (connectionGeneration == null) return;
+    final startGeneration = _startGeneration;
+    await verifyUserConnectivity(
+      shouldContinue: () =>
+          isRunning &&
+          startGeneration == _startGeneration &&
+          isConnectionIntentCurrent(connectionGeneration, connected: true),
+    );
+  }
 
   // The native VPN service owns the authoritative 3-second Bridge monitor and
   // tears down the TUN fd when the core exits, including while Flutter sleeps.
@@ -442,7 +463,7 @@ class ClashService extends ClashServiceBase {
         );
         _ensureStartCurrent(startToken);
         if (!snapshotSaved) {
-          const snapshotError = '无法保存快速启动配置，VPN 已安全回滚';
+          const snapshotError = '无法保存连接恢复信息，VPN 已安全回滚';
           try {
             await stop();
             setLastStartError(snapshotError);

--- a/SSRVPN_Android/lib/services/clash_service_native_bridge.dart
+++ b/SSRVPN_Android/lib/services/clash_service_native_bridge.dart
@@ -115,8 +115,10 @@ extension AndroidNativeBridge on ClashService {
     final activeConfigPath =
         _runningConfigPath ?? _nativeSnapshotConfigPath ?? configPath;
     _notifyNativeRuntimeNotice(
-      'Mihomo 持续失去响应，正在执行安全重启'
-      '（${_healthRecoveryPolicy.attempts}/${_healthRecoveryPolicy.maxAttempts}）…',
+      RuntimeNotice.progress(
+        '连接服务持续失去响应，正在执行安全重启'
+        '（${_healthRecoveryPolicy.attempts}/${_healthRecoveryPolicy.maxAttempts}）…',
+      ),
     );
     try {
       await stop();
@@ -284,7 +286,7 @@ extension AndroidNativeBridge on ClashService {
     _markNativeConnectionLost();
     const message = '无法确认 Android VPN 运行状态，已标记为断开，请重新连接';
     log(message);
-    _notifyNativeRuntimeNotice(message);
+    _notifyNativeRuntimeNotice(const RuntimeNotice.error(message));
   }
 
   void _applyNativeRunningFallback({required String source}) {
@@ -376,6 +378,11 @@ extension AndroidNativeBridge on ClashService {
       stopStatusMonitor();
       if (terminalUnexpectedStop) {
         _markNativeConnectionLost();
+        _notifyNativeRuntimeNotice(
+          const RuntimeNotice.error(
+            '连接服务意外停止，请点击连接重试；如仍失败，请查看运行日志。',
+          ),
+        );
       } else {
         setRunning(false);
       }

--- a/SSRVPN_Android/lib/services/connection_orchestrator.dart
+++ b/SSRVPN_Android/lib/services/connection_orchestrator.dart
@@ -4,6 +4,132 @@ import '../services/clash_service.dart';
 import '../services/settings_service.dart';
 import '../services/subscription_service.dart';
 
+class AndroidConnectionOutcome {
+  const AndroidConnectionOutcome({
+    this.message,
+    this.preferredNodeSwitchSucceeded = true,
+    this.runtimeNodeName,
+  });
+
+  final String? message;
+  final bool preferredNodeSwitchSucceeded;
+  final String? runtimeNodeName;
+}
+
+({String? errorMessage, String? connectionNotice})
+    resolveAndroidConnectionFeedback({
+  required bool connected,
+  required String? result,
+  required String? runtimeNotice,
+}) {
+  final outcomeMessage = result?.trim();
+  final noticeMessage = runtimeNotice?.trim();
+  if (connected) {
+    return (
+      errorMessage: null,
+      connectionNotice: outcomeMessage?.isNotEmpty == true
+          ? outcomeMessage
+          : noticeMessage?.isNotEmpty == true
+              ? noticeMessage
+              : null,
+    );
+  }
+  return (
+    errorMessage: userFriendlyAndroidConnectionError(
+      outcomeMessage?.isNotEmpty == true ? outcomeMessage : null,
+    ),
+    connectionNotice: null,
+  );
+}
+
+String userFriendlyAndroidConnectionError(Object? error) {
+  final raw = error?.toString().trim() ?? '';
+  final lower = raw.toLowerCase();
+
+  if (raw.contains('上次 VPN 联网检查仍在结束')) {
+    return '上次 VPN 联网检查仍在结束，请稍后重试；若持续出现请重启应用';
+  }
+  if (raw.contains('VPN 联网检查超时')) {
+    return 'VPN 联网检查超时，请稍后重试；若持续出现请重启应用';
+  }
+  if (raw.contains('VPN 数据通道不可用')) {
+    return 'VPN 数据通道不可用，请切换节点或重试';
+  }
+  if (raw == '请先添加并刷新订阅' || raw.startsWith('订阅已更新')) {
+    return raw;
+  }
+  if (raw.contains('Missing required arguments') ||
+      raw.contains('连接参数不完整') ||
+      lower.contains('invalid_args')) {
+    return '连接参数不完整，请重试';
+  }
+  if (raw.contains('VPN establish failed') || raw.contains('创建 VPN 接口')) {
+    return '系统未能创建 VPN 接口，请检查 VPN 权限后重试';
+  }
+  if (lower.contains('local api') ||
+      raw.contains('本地控制服务') ||
+      raw.contains('Health check timeout')) {
+    return 'VPN 核心已启动，但本地控制服务未及时就绪，请重新连接';
+  }
+  if (lower.contains('bridge.start') ||
+      lower.contains('core start timeout') ||
+      raw.contains('核心启动超时') ||
+      raw.contains('设备性能不足')) {
+    return 'VPN 核心启动超时，请重新连接';
+  }
+  if (lower.contains('core_timeout') || raw.contains('VPN 启动超时')) {
+    return 'VPN 启动超时，请重新连接；若持续失败请打开诊断与运行日志';
+  }
+  if (raw.contains('用户拒绝了 VPN 权限') || lower.contains('permission_denied')) {
+    return '未获得 VPN 权限，请允许后重试';
+  }
+  if (lower.contains('stop_incomplete') || raw.contains('正在释放系统资源')) {
+    return 'VPN 正在释放系统资源，请稍后重试';
+  }
+  if (lower.contains('stop_failed') || raw.contains('VPN 断开失败')) {
+    return 'VPN 断开失败，请重试；若持续失败请打开诊断与运行日志';
+  }
+  if (lower.contains('core_busy') ||
+      raw.contains('核心正在启动') ||
+      raw.contains('核心正在清理')) {
+    return 'VPN 核心正在启动或清理，请稍后重试';
+  }
+  if (raw.contains('VPN 网络保护服务启动失败') || raw.contains('VPN 网络保护服务异常')) {
+    return 'VPN 网络保护服务异常，请重新连接';
+  }
+  if (raw.contains('VPN 凭据不可用')) {
+    return 'VPN 凭据不可用，请打开应用重新连接';
+  }
+  if (raw.contains('VPN 配置不可用')) {
+    return 'VPN 配置不可用，请打开应用重新连接';
+  }
+  if (raw.contains('无法保存连接恢复信息')) {
+    return '无法保存连接恢复信息，VPN 已安全回滚，请重试';
+  }
+  if (raw.contains('Mihomo 原生组件不可用')) {
+    return 'VPN 原生组件不可用，请重新安装应用';
+  }
+  if (raw.contains('连接已取消')) return '连接已取消';
+  if (raw.contains('连接已中断')) return '连接已中断，请重新连接';
+  if (lower.contains('timeoutexception') || lower.contains('timeout')) {
+    return '连接超时，请检查网络后重试';
+  }
+  if (lower.contains('handshakeexception') ||
+      lower.contains('certificate') ||
+      lower.contains('tls')) {
+    return '安全连接失败，请检查网络环境';
+  }
+  if (lower.contains('socketexception') ||
+      lower.contains('connection refused') ||
+      lower.contains('network')) {
+    return '网络连接失败，请检查网络设置';
+  }
+  if (lower.contains('httpexception')) {
+    return '服务器响应异常，请稍后重试';
+  }
+  return 'VPN 启动失败，请重试；若持续失败请打开诊断与运行日志';
+}
+
 /// Clears only the still-current connection intent owned by a failed attempt.
 ///
 /// A newer connect/disconnect request must never be overwritten, and a core
@@ -41,19 +167,20 @@ class ConnectionOrchestrator {
   /// 执行连接流程
   ///
   /// [nodeName] 可选的首选节点名，null 则自动选择。
-  /// 返回 null 表示完全成功；返回非 null 可能是启动错误，也可能是
-  /// 核心已运行后的连通性提示。调用方应以 [clashService.isRunning]
-  /// 判断连接状态，以返回文本作为用户提示。
-  Future<String?> connect(
+  /// 调用方仍以 [clashService.isRunning] 判断连接状态。结果将启动提示
+  /// 与首选节点切换状态分开，避免把未成功切换的请求节点记为当前节点。
+  Future<AndroidConnectionOutcome> connect(
     String? nodeName, {
     required int connectionGeneration,
   }) async {
     await settingsService.waitForPendingWrites();
-    if (!_isCurrent(connectionGeneration)) return null;
+    if (!_isCurrent(connectionGeneration)) {
+      return const AndroidConnectionOutcome();
+    }
 
     final rawYaml = subscriptionService.rawYaml;
     if (rawYaml == null || rawYaml.isEmpty) {
-      return '请先添加并刷新订阅';
+      return const AndroidConnectionOutcome(message: '请先添加并刷新订阅');
     }
     final subscriptionRevision = subscriptionService.revision;
     final preferredSettings = settingsService.settings;
@@ -64,9 +191,11 @@ class ConnectionOrchestrator {
       var started = false;
       for (var attempt = 0; attempt < 2; attempt++) {
         final settings = await clashService.prepareForStart(preferredSettings);
-        if (!_isCurrent(connectionGeneration)) return null;
+        if (!_isCurrent(connectionGeneration)) {
+          return const AndroidConnectionOutcome();
+        }
         if (!_isSubscriptionCurrent(subscriptionRevision)) {
-          return '订阅已更新，请重新连接';
+          return const AndroidConnectionOutcome(message: '订阅已更新，请重新连接');
         }
         runtimePortNotice = clashService.lastRuntimePortAdjustmentMessage;
 
@@ -75,25 +204,33 @@ class ConnectionOrchestrator {
           settings,
           preferredNodeName: nodeName,
         );
-        if (!_isCurrent(connectionGeneration)) return null;
+        if (!_isCurrent(connectionGeneration)) {
+          return const AndroidConnectionOutcome();
+        }
         if (!_isSubscriptionCurrent(subscriptionRevision)) {
-          return '订阅已更新，请重新连接';
+          return const AndroidConnectionOutcome(message: '订阅已更新，请重新连接');
         }
 
         preparedConfigPath = await clashService.writeConfig(config);
-        if (!_isCurrent(connectionGeneration)) return null;
+        if (!_isCurrent(connectionGeneration)) {
+          return const AndroidConnectionOutcome();
+        }
         if (!_isSubscriptionCurrent(subscriptionRevision)) {
-          return '订阅已更新，请重新连接';
+          return const AndroidConnectionOutcome(message: '订阅已更新，请重新连接');
         }
 
         started = await clashService.start(
           nodeName: nodeName,
           preparedConfigPath: preparedConfigPath,
         );
-        if (!_isCurrent(connectionGeneration)) return null;
+        if (!_isCurrent(connectionGeneration)) {
+          return const AndroidConnectionOutcome();
+        }
         final staleAfterStart =
             await _handleStaleSubscription(subscriptionRevision);
-        if (staleAfterStart != null) return staleAfterStart;
+        if (staleAfterStart != null) {
+          return AndroidConnectionOutcome(message: staleAfterStart);
+        }
         if (started) break;
 
         final reason = clashService.lastStartError ?? '无法启动VPN核心';
@@ -104,20 +241,32 @@ class ConnectionOrchestrator {
           // for that cleanup barrier before regenerating ports; an immediate
           // retry would otherwise be rejected as CORE_BUSY.
           await clashService.stop();
-          if (!_isCurrent(connectionGeneration)) return null;
+          if (!_isCurrent(connectionGeneration)) {
+            return const AndroidConnectionOutcome();
+          }
           if (!_isSubscriptionCurrent(subscriptionRevision)) {
-            return '订阅已更新，请重新连接';
+            return const AndroidConnectionOutcome(message: '订阅已更新，请重新连接');
           }
           await clashService.discardPreparedConfig(preparedConfigPath);
           preparedConfigPath = null;
           continue;
         }
-        return '连接失败: $reason';
+        return AndroidConnectionOutcome(
+          message: userFriendlyAndroidConnectionError(reason),
+          preferredNodeSwitchSucceeded: false,
+        );
       }
-      if (!started) return '连接失败: 无法启动VPN核心';
+      if (!started) {
+        return const AndroidConnectionOutcome(
+          message: 'VPN 启动失败，请重试；若持续失败请打开诊断与运行日志',
+          preferredNodeSwitchSucceeded: false,
+        );
+      }
 
       // 切换选中节点
       String? snapshotWarning;
+      var preferredNodeSwitchSucceeded = true;
+      String? runtimeNodeName;
       if (nodeName != null && nodeName.isNotEmpty) {
         final switchResult =
             await clashService.switchSelectedProxyForConnection(
@@ -125,32 +274,56 @@ class ConnectionOrchestrator {
           connectionGeneration: connectionGeneration,
         );
         if (!_isCurrent(connectionGeneration)) {
-          return null;
+          return const AndroidConnectionOutcome();
         }
         final staleAfterSwitch =
             await _handleStaleSubscription(subscriptionRevision);
-        if (staleAfterSwitch != null) return staleAfterSwitch;
-        if (!switchResult.liveSwitched) {
-          return '连接失败: 无法切换到所选节点';
+        if (staleAfterSwitch != null) {
+          return AndroidConnectionOutcome(message: staleAfterSwitch);
         }
-        if (!switchResult.snapshotPersisted) {
+        var preferredSwitchSucceeded =
+            switchResult.liveSwitched && switchResult.intentCurrent;
+        if (!preferredSwitchSucceeded) {
+          runtimeNodeName = switchResult.runtimeNodeName;
+          if (runtimeNodeName == null || runtimeNodeName.trim().isEmpty) {
+            try {
+              runtimeNodeName = await clashService.currentSelectedProxyName();
+            } catch (_) {
+              runtimeNodeName = null;
+            }
+          }
+          if (!_isCurrent(connectionGeneration)) {
+            return const AndroidConnectionOutcome();
+          }
+          if (!_isSubscriptionCurrent(subscriptionRevision)) {
+            final staleAfterReadback =
+                await _handleStaleSubscription(subscriptionRevision);
+            return AndroidConnectionOutcome(message: staleAfterReadback);
+          }
+          preferredSwitchSucceeded =
+              switchResult.intentCurrent && runtimeNodeName == nodeName;
+          if (!preferredSwitchSucceeded) {
+            preferredNodeSwitchSucceeded = false;
+            snapshotWarning = '未能切换节点，当前连接仍保留';
+          } else if (!switchResult.snapshotPersisted) {
+            snapshotWarning = 'VPN 已连接，但快速启动节点信息保存失败';
+          }
+        } else if (!switchResult.snapshotPersisted) {
           snapshotWarning = 'VPN 已连接，但快速启动节点信息保存失败';
+        }
+        if (preferredSwitchSucceeded) {
+          runtimeNodeName = switchResult.runtimeNodeName ?? nodeName;
         }
       }
 
-      // 验证连通性
-      final connectivityWarning = await clashService.verifyUserConnectivity(
-        shouldContinue: () =>
-            _isCurrent(connectionGeneration) &&
-            _isSubscriptionCurrent(subscriptionRevision),
+      // Native exact-204 validation already established the usable data path.
+      // External endpoints are advisory and update connectivityWarning later.
+      clashService.scheduleUserConnectivityObservation();
+      return AndroidConnectionOutcome(
+        message: snapshotWarning ?? runtimePortNotice,
+        preferredNodeSwitchSucceeded: preferredNodeSwitchSucceeded,
+        runtimeNodeName: runtimeNodeName,
       );
-      if (!_isCurrent(connectionGeneration)) return null;
-      final staleAfterVerification =
-          await _handleStaleSubscription(subscriptionRevision);
-      if (staleAfterVerification != null) return staleAfterVerification;
-      return connectivityWarning ??
-          snapshotWarning ??
-          runtimePortNotice; // null = 完全成功
     } finally {
       if (preparedConfigPath != null) {
         await clashService.discardPreparedConfig(preparedConfigPath);

--- a/SSRVPN_Android/lib/services/update_service.dart
+++ b/SSRVPN_Android/lib/services/update_service.dart
@@ -521,7 +521,7 @@ class UpdateService {
   }
 
   static String _cleanError(Object error) =>
-      error.toString().replaceFirst('Bad state: ', '');
+      safeUserFacingFailureMessage(error);
 
   static Future<void> _showUpdateMessage(
     BuildContext context,

--- a/SSRVPN_Android/test/api_secret_recovery_dialog_test.dart
+++ b/SSRVPN_Android/test/api_secret_recovery_dialog_test.dart
@@ -3,6 +3,30 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ssrvpn_android/app.dart';
 
 void main() {
+  test('initialization failure copy never exposes raw internal details', () {
+    final message = androidInitializationFailureMessage(
+      StateError(
+        'bootstrap failed token=top-secret for '
+        'https://example.com/private/startup/path',
+      ),
+      retryCount: 2,
+    );
+
+    expect(message, isNot(contains('top-secret')));
+    expect(message, isNot(contains('/private/startup/path')));
+    expect(message, contains('自动重试 2 次后仍失败'));
+  });
+
+  test('API secret recovery failure copy never exposes raw details', () {
+    final message = androidApiSecretRecoveryFailureMessage(
+      StateError('keystore failed password=top-secret alias=private-alias'),
+    );
+
+    expect(message, isNot(contains('top-secret')));
+    expect(message, isNot(contains('private-alias')));
+    expect(message, contains('未删除订阅和普通设置'));
+  });
+
   testWidgets('API secret recovery requires explicit destructive confirmation',
       (tester) async {
     await tester.binding.setSurfaceSize(const Size(320, 360));

--- a/SSRVPN_Android/test/clash_service_test.dart
+++ b/SSRVPN_Android/test/clash_service_test.dart
@@ -4,7 +4,9 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:ssrvpn_shared/runtime_notice.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 import 'package:yaml/yaml.dart';
 import 'package:ssrvpn_android/services/clash_service.dart';
@@ -27,7 +29,43 @@ proxies:
 
 class _RealHttpOverrides extends HttpOverrides {}
 
+class _ConnectionGenerationObservationService extends ClashService {
+  bool Function()? observationStillCurrent;
+
+  void publishRunning() => setRunning(true);
+
+  Future<void> observeNow() => observeDataPlaneHealth();
+
+  @override
+  Future<String?> verifyUserConnectivity({
+    int maxAttempts = 3,
+    Duration retryDelay = const Duration(seconds: 2),
+    Future<http.Response> Function(Uri uri)? request,
+    bool Function()? shouldContinue,
+  }) async {
+    observationStillCurrent = shouldContinue;
+    return null;
+  }
+}
+
 void main() {
+  test('an Android advisory observation cannot publish into a newer session',
+      () async {
+    final service = _ConnectionGenerationObservationService();
+    addTearDown(service.dispose);
+    service.requestConnectionIntent(true);
+    service.publishRunning();
+
+    await service.observeNow();
+    expect(service.observationStillCurrent?.call(), isTrue);
+
+    service.requestConnectionIntent(false);
+    service.requestConnectionIntent(true);
+    expect(service.isRunning, isTrue);
+    expect(service.connectionDesired, isTrue);
+    expect(service.observationStillCurrent?.call(), isFalse);
+  });
+
   test(
       'native snapshot keeps VPN liveness separate from the underlying network',
       () async {
@@ -447,6 +485,44 @@ void main() {
       expect(service.connectionDesired, isFalse);
     },
   );
+
+  test('terminal native stop publishes an actionable sanitized error',
+      () async {
+    const channel = MethodChannel('com.ssrvpn/native');
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'getConnectionState') {
+        return <String, Object?>{
+          'running': false,
+          'transitioning': false,
+          'protectedConfigPath': null,
+          'sessionGeneration': null,
+          'error': 'sensitive native exception details',
+        };
+      }
+      return null;
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+    final notices = <RuntimeNotice>[];
+    final service = ClashService()
+      ..setRunning(true)
+      ..requestConnectionIntent(true)
+      ..onRuntimeNotice = notices.add;
+    addTearDown(service.dispose);
+
+    expect(await service.refreshNativeConnectionState(), isTrue);
+
+    expect(service.isRunning, isFalse);
+    expect(service.connectionDesired, isFalse);
+    expect(notices, hasLength(1));
+    expect(notices.single.level, RuntimeNoticeLevel.error);
+    expect(
+      notices.single.message,
+      '连接服务意外停止，请点击连接重试；如仍失败，请查看运行日志。',
+    );
+    expect(notices.single.message, isNot(contains('sensitive')));
+  });
 
   test('native running sync adopts the externally started session', () async {
     const channel = MethodChannel('com.ssrvpn/native');
@@ -1885,7 +1961,7 @@ void main() {
         ..updateSettings(AppSettings(apiSecret: 'current-secret'));
 
       expect(await service.start(nodeName: 'New Node'), isFalse);
-      expect(service.lastStartError, contains('快速启动'));
+      expect(service.lastStartError, contains('连接恢复信息'));
       expect(service.isRunning, isFalse);
       expect(stops, 1);
 

--- a/SSRVPN_Android/test/connection_orchestrator_test.dart
+++ b/SSRVPN_Android/test/connection_orchestrator_test.dart
@@ -48,7 +48,7 @@ void main() {
     await subscriptionService.setRawYaml(_yaml('New', 'new.example.com'));
     clashService.releaseGeneration.complete();
 
-    expect(await connecting, contains('订阅已更新'));
+    expect((await connecting).message, contains('订阅已更新'));
     expect(clashService.writeCalls, 0);
     expect(clashService.startCalls, 0);
   });
@@ -88,7 +88,7 @@ void main() {
     await subscriptionService.setRawYaml(_yaml('New', 'new.example.com'));
     clashService.releaseSwitch.complete();
 
-    expect(await connecting, contains('订阅已更新'));
+    expect((await connecting).message, contains('订阅已更新'));
     expect(clashService.stopCalls, 1);
     expect(clashService.isRunning, isFalse);
   });
@@ -179,7 +179,7 @@ void main() {
     releaseSecureWrite.complete();
     await blockingWrite;
     await modeWrite;
-    expect(await connecting, isNull);
+    expect((await connecting).message, isNull);
     expect(clashService.generatedSettings?.proxyMode, ProxyMode.global);
     expect(clashService.startCalls, 1);
   });
@@ -225,7 +225,7 @@ void main() {
 
     expect(clashService.generatedSettings?.proxyPort, isNot(occupied.port));
     expect(clashService.lastRuntimePortAdjustmentMessage, contains('端口被占用'));
-    expect(result, contains('端口被占用'));
+    expect(result.message, contains('端口被占用'));
   });
 
   test('connection regenerates config once after a start-time port race',
@@ -260,7 +260,7 @@ void main() {
       connectionGeneration: generation,
     );
 
-    expect(result, isNull);
+    expect(result.message, isNull);
     expect(clashService.prepareCalls, 2);
     expect(clashService.startCalls, 2);
     expect(clashService.stopCalls, 1);
@@ -312,7 +312,7 @@ void main() {
 
     await blockingWrite;
     await modeWrite;
-    expect(await connecting, isNull);
+    expect((await connecting).message, isNull);
     expect(clashService.generatedSettings, isNull);
     expect(clashService.startCalls, 0);
   });
@@ -365,14 +365,234 @@ void main() {
     await firstConnectExpectation;
 
     expect(
-      await orchestrator.connect(
+      (await orchestrator.connect(
         null,
         connectionGeneration: generation,
-      ),
+      ))
+          .message,
       isNull,
     );
     expect(clashService.generatedSettings?.apiSecret, 'test-secret');
     expect(clashService.startCalls, 1);
+  });
+
+  test('native success is returned before advisory external verification',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final tempDir = await Directory.systemTemp.createTemp(
+      'ssrvpn_non_blocking_connectivity_',
+    );
+    final clashService = _BlockingConnectivityClashService();
+    addTearDown(() async {
+      SubscriptionService.resetInstanceForTesting();
+      if (!clashService.releaseVerification.isCompleted) {
+        clashService.releaseVerification.complete();
+      }
+      await tempDir.delete(recursive: true);
+    });
+    SubscriptionService.resetInstanceForTesting();
+    final subscriptionService =
+        await SubscriptionService.getInstance(tempDir.path);
+    await subscriptionService.setRawYaml(_yaml('Node', 'node.example.com'));
+    final settingsService = await SettingsService.createForTesting(
+      configPath: '${tempDir.path}/settings.json',
+      readApiSecret: () async => 'test-secret',
+      writeApiSecret: (_) async {},
+    );
+    await _assignCurrentlyFreeRuntimePorts(settingsService);
+    final generation = clashService.requestConnectionIntent(true);
+    final orchestrator = ConnectionOrchestrator(
+      clashService: clashService,
+      settingsService: settingsService,
+      subscriptionService: subscriptionService,
+    );
+
+    final result = await orchestrator
+        .connect(null, connectionGeneration: generation)
+        .timeout(
+          const Duration(seconds: 1),
+          onTimeout: () => const AndroidConnectionOutcome(message: 'blocked'),
+        );
+
+    expect(result.message, isNull);
+    expect(clashService.isRunning, isTrue);
+    expect(clashService.verificationStarted.isCompleted, isTrue);
+    expect(clashService.observationIsCurrent?.call(), isTrue);
+    clashService.requestConnectionIntent(false);
+    clashService.requestConnectionIntent(true);
+    expect(clashService.observationIsCurrent?.call(), isFalse);
+  });
+
+  test('connected feedback is a notice while failed startup is an error', () {
+    expect(
+      resolveAndroidConnectionFeedback(
+        connected: true,
+        result: '连接已建立，但外部网络暂时无法确认',
+        runtimeNotice: null,
+      ),
+      (
+        errorMessage: null,
+        connectionNotice: '连接已建立，但外部网络暂时无法确认',
+      ),
+    );
+    expect(
+      resolveAndroidConnectionFeedback(
+        connected: false,
+        result: 'VPN 数据通道不可用，请切换节点或重试',
+        runtimeNotice: null,
+      ),
+      (
+        errorMessage: 'VPN 数据通道不可用，请切换节点或重试',
+        connectionNotice: null,
+      ),
+    );
+  });
+
+  test('unknown native details never reach the connection error surface', () {
+    final message = userFriendlyAndroidConnectionError(
+      'Mihomo: parse password secret-value at /data/user/0/private.yaml',
+    );
+
+    expect(message, 'VPN 启动失败，请重试；若持续失败请打开诊断与运行日志');
+    expect(message, isNot(contains('secret-value')));
+    expect(message, isNot(contains('/data/user')));
+    expect(
+      userFriendlyAndroidConnectionError(
+        'VPN 数据通道不可用，请切换节点或重试',
+      ),
+      'VPN 数据通道不可用，请切换节点或重试',
+    );
+    expect(
+      userFriendlyAndroidConnectionError(
+        '上次 VPN 联网检查仍在结束，请稍后重试；若持续出现请重启应用',
+      ),
+      '上次 VPN 联网检查仍在结束，请稍后重试；若持续出现请重启应用',
+    );
+    expect(
+      userFriendlyAndroidConnectionError(
+        'VPN 联网检查超时，请稍后重试；若持续出现请重启应用',
+      ),
+      'VPN 联网检查超时，请稍后重试；若持续出现请重启应用',
+    );
+  });
+
+  test('stable native startup stages have actionable friendly messages', () {
+    expect(
+      userFriendlyAndroidConnectionError('Missing required arguments'),
+      '连接参数不完整，请重试',
+    );
+    expect(
+      userFriendlyAndroidConnectionError('VPN establish failed'),
+      '系统未能创建 VPN 接口，请检查 VPN 权限后重试',
+    );
+    expect(
+      userFriendlyAndroidConnectionError('Bridge.start timed out'),
+      'VPN 核心启动超时，请重新连接',
+    );
+    expect(
+      userFriendlyAndroidConnectionError('Health check timeout'),
+      'VPN 核心已启动，但本地控制服务未及时就绪，请重新连接',
+    );
+    expect(
+      userFriendlyAndroidConnectionError(
+        'PlatformException(STOP_INCOMPLETE, VPN resources are still releasing)',
+      ),
+      'VPN 正在释放系统资源，请稍后重试',
+    );
+    expect(
+      userFriendlyAndroidConnectionError(
+        'PlatformException(STOP_FAILED, native secret detail)',
+      ),
+      'VPN 断开失败，请重试；若持续失败请打开诊断与运行日志',
+    );
+    expect(
+      userFriendlyAndroidConnectionError(
+        '无法保存连接恢复信息，VPN 已安全回滚',
+      ),
+      '无法保存连接恢复信息，VPN 已安全回滚，请重试',
+    );
+  });
+
+  test('failed preferred-node switch preserves the live runtime node',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final tempDir = await Directory.systemTemp.createTemp(
+      'ssrvpn_failed_preferred_switch_',
+    );
+    addTearDown(() async {
+      SubscriptionService.resetInstanceForTesting();
+      await tempDir.delete(recursive: true);
+    });
+    SubscriptionService.resetInstanceForTesting();
+    final subscriptionService =
+        await SubscriptionService.getInstance(tempDir.path);
+    await subscriptionService.setRawYaml(
+      _yaml('Requested Node', 'node.example.com'),
+    );
+    final settingsService = await SettingsService.createForTesting(
+      configPath: '${tempDir.path}/settings.json',
+      readApiSecret: () async => 'test-secret',
+      writeApiSecret: (_) async {},
+    );
+    await _assignCurrentlyFreeRuntimePorts(settingsService);
+    final clashService = _FailedPreferredNodeSwitchClashService();
+    final generation = clashService.requestConnectionIntent(true);
+    final orchestrator = ConnectionOrchestrator(
+      clashService: clashService,
+      settingsService: settingsService,
+      subscriptionService: subscriptionService,
+    );
+
+    final outcome = await orchestrator.connect(
+      'Requested Node',
+      connectionGeneration: generation,
+    );
+
+    expect(clashService.isRunning, isTrue);
+    expect(outcome.preferredNodeSwitchSucceeded, isFalse);
+    expect(outcome.runtimeNodeName, 'Actual Node');
+    expect(outcome.message, '未能切换节点，当前连接仍保留');
+  });
+
+  test('late preferred-node readback promotes the confirmed runtime node',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final tempDir = await Directory.systemTemp.createTemp(
+      'ssrvpn_late_preferred_switch_',
+    );
+    addTearDown(() async {
+      SubscriptionService.resetInstanceForTesting();
+      await tempDir.delete(recursive: true);
+    });
+    SubscriptionService.resetInstanceForTesting();
+    final subscriptionService =
+        await SubscriptionService.getInstance(tempDir.path);
+    await subscriptionService.setRawYaml(
+      _yaml('Requested Node', 'node.example.com'),
+    );
+    final settingsService = await SettingsService.createForTesting(
+      configPath: '${tempDir.path}/settings.json',
+      readApiSecret: () async => 'test-secret',
+      writeApiSecret: (_) async {},
+    );
+    await _assignCurrentlyFreeRuntimePorts(settingsService);
+    final clashService = _LatePreferredNodeSwitchClashService();
+    final generation = clashService.requestConnectionIntent(true);
+    final orchestrator = ConnectionOrchestrator(
+      clashService: clashService,
+      settingsService: settingsService,
+      subscriptionService: subscriptionService,
+    );
+
+    final outcome = await orchestrator.connect(
+      'Requested Node',
+      connectionGeneration: generation,
+    );
+
+    expect(clashService.isRunning, isTrue);
+    expect(outcome.preferredNodeSwitchSucceeded, isTrue);
+    expect(outcome.runtimeNodeName, 'Requested Node');
+    expect(outcome.message, 'VPN 已连接，但快速启动节点信息保存失败');
   });
 }
 
@@ -518,6 +738,48 @@ class _SettingsSnapshotClashService extends ClashService {
     bool Function()? shouldContinue,
   }) async =>
       null;
+}
+
+class _BlockingConnectivityClashService extends _SettingsSnapshotClashService {
+  final verificationStarted = Completer<void>();
+  final releaseVerification = Completer<void>();
+  bool Function()? observationIsCurrent;
+
+  @override
+  Future<String?> verifyUserConnectivity({
+    int maxAttempts = 3,
+    Duration retryDelay = const Duration(seconds: 2),
+    Future<http.Response> Function(Uri uri)? request,
+    bool Function()? shouldContinue,
+  }) async {
+    observationIsCurrent = shouldContinue;
+    verificationStarted.complete();
+    await releaseVerification.future;
+    return null;
+  }
+}
+
+class _FailedPreferredNodeSwitchClashService
+    extends _SettingsSnapshotClashService {
+  @override
+  Future<AndroidProxySwitchResult> switchSelectedProxyForConnection(
+    String nodeName, {
+    required int connectionGeneration,
+  }) async =>
+      const AndroidProxySwitchResult(
+        liveSwitched: false,
+        snapshotPersisted: false,
+        intentCurrent: true,
+      );
+
+  @override
+  Future<String?> currentSelectedProxyName() async => 'Actual Node';
+}
+
+class _LatePreferredNodeSwitchClashService
+    extends _FailedPreferredNodeSwitchClashService {
+  @override
+  Future<String?> currentSelectedProxyName() async => 'Requested Node';
 }
 
 class _PortRaceClashService extends _SettingsSnapshotClashService {

--- a/SSRVPN_Android/test/real_home_node_widgets_test.dart
+++ b/SSRVPN_Android/test/real_home_node_widgets_test.dart
@@ -12,6 +12,7 @@ import 'package:ssrvpn_android/services/clash_service.dart';
 import 'package:ssrvpn_android/services/settings_service.dart';
 import 'package:ssrvpn_android/services/subscription_service.dart';
 import 'package:ssrvpn_android/theme/app_theme.dart';
+import 'package:ssrvpn_shared/runtime_notice.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 
 const _nodeYaml = '''
@@ -180,10 +181,12 @@ void main() {
     final fixture =
         (await tester.runAsync(() => _AndroidHomeFixture.create(clash)))!;
     addTearDown(fixture.dispose);
+    fixture.settings.settings.latencyTestTimeout = 8700;
 
     await tester.pumpWidget(fixture.build());
     await tester.pump();
     await _pumpUntil(tester, () => clash.latencyStarted.isCompleted);
+    expect(clash.lastTimeoutMs, 8700);
 
     await tester.tap(find.byKey(const Key('ssrvpn-current-node-card')));
     await tester.pumpAndSettle();
@@ -306,6 +309,224 @@ void main() {
     await tester.pump();
   });
 
+  testWidgets(
+      'Android Home uses and persists the first runnable node when all latencies are unknown',
+      (tester) async {
+    final clash = _SuccessfulInitialSwitchAndroidClashService();
+    final fixture =
+        (await tester.runAsync(() => _AndroidHomeFixture.create(clash)))!;
+    addTearDown(fixture.dispose);
+    for (final node in fixture.subscription.allNodes) {
+      node.latency = -1;
+    }
+
+    await tester.pumpWidget(fixture.build());
+    await _waitForWidget(
+      tester,
+      find.byKey(const Key('ssrvpn-current-node-card')),
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('ssrvpn-current-node-card')),
+        matching: find.text('东京节点'),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('ssrvpn-power-button')));
+    await _waitForAsyncCondition(
+      tester,
+      () => fixture.settings.settings.lastSelectedNodeName == '东京节点',
+    );
+
+    expect(clash.generatedPreferredNodeName, '东京节点');
+    expect(clash.liveSwitchCalls, 1);
+    expect(clash.isRunning, isTrue);
+  });
+
+  testWidgets(
+      'failed initial node switch keeps and persists the actual runtime node',
+      (tester) async {
+    final clash = _FailedInitialSwitchAndroidClashService();
+    final fixture =
+        (await tester.runAsync(() => _AndroidHomeFixture.create(clash)))!;
+    addTearDown(fixture.dispose);
+    await tester.runAsync(
+      () => fixture.settings.setLastSelectedNodeName('新加坡节点'),
+    );
+
+    await tester.pumpWidget(fixture.build());
+    await _waitForWidget(
+      tester,
+      find.byKey(const Key('ssrvpn-power-button')),
+    );
+    await tester.tap(find.byKey(const Key('ssrvpn-power-button')));
+    await _waitForWidget(tester, find.text('未能切换节点，当前连接仍保留'));
+    await _waitForAsyncCondition(
+      tester,
+      () => fixture.settings.settings.lastSelectedNodeName == '东京节点',
+    );
+
+    expect(clash.generatedPreferredNodeName, '新加坡节点');
+    expect(clash.liveSwitchCalls, 1);
+    expect(clash.isRunning, isTrue);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('ssrvpn-current-node-card')),
+        matching: find.text('东京节点'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('ssrvpn-current-node-card')),
+        matching: find.text('新加坡节点'),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets(
+      'successful live switch survives its synchronous status notification',
+      (tester) async {
+    final clash = _RecordingAndroidClashService()..setRunning(true);
+    final fixture =
+        (await tester.runAsync(() => _AndroidHomeFixture.create(clash)))!;
+    addTearDown(fixture.dispose);
+
+    await tester.pumpWidget(fixture.build());
+    await _waitForWidget(tester, find.text('已连接'));
+    await tester.tap(find.byKey(const Key('ssrvpn-current-node-card')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('ssrvpn-node-select-新加坡节点')),
+    );
+    await _waitForWidget(tester, find.text('已切换: 新加坡节点'));
+    await _waitForAsyncCondition(
+      tester,
+      () => fixture.settings.settings.lastSelectedNodeName == '新加坡节点',
+    );
+
+    expect(clash.isRunning, isTrue);
+    expect(clash.connectionDesired, isTrue);
+    expect(clash.runtimeNodeName, '新加坡节点');
+    expect(clash.liveSwitchCalls, 1);
+  });
+
+  testWidgets(
+      'successful connection warns when only node preference persistence fails',
+      (tester) async {
+    final clash = _SuccessfulInitialSwitchAndroidClashService();
+    final fixture =
+        (await tester.runAsync(() => _AndroidHomeFixture.create(clash)))!;
+    addTearDown(fixture.dispose);
+    await tester.runAsync(() => Directory(fixture.settingsPath).create());
+
+    await tester.pumpWidget(fixture.build());
+    await _waitForWidget(
+      tester,
+      find.byKey(const Key('ssrvpn-power-button')),
+    );
+    await tester.tap(find.byKey(const Key('ssrvpn-power-button')));
+    await _waitForWidget(tester, find.text('已连接，但首选节点保存失败'));
+
+    expect(clash.isRunning, isTrue);
+    expect(clash.connectionDesired, isTrue);
+    expect(clash.liveSwitchCalls, 1);
+    expect(fixture.settings.settings.lastSelectedNodeName, isNull);
+    expect(find.text('连接异常'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('ssrvpn-current-node-card')),
+        matching: find.text('东京节点'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      'successful live switch warns when only node preference persistence fails',
+      (tester) async {
+    final clash = _RecordingAndroidClashService()..setRunning(true);
+    final fixture =
+        (await tester.runAsync(() => _AndroidHomeFixture.create(clash)))!;
+    addTearDown(fixture.dispose);
+
+    await tester.pumpWidget(fixture.build());
+    await _waitForWidget(tester, find.text('已连接'));
+    await tester.runAsync(() => Directory(fixture.settingsPath).create());
+    await tester.tap(find.byKey(const Key('ssrvpn-current-node-card')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('ssrvpn-node-select-新加坡节点')),
+    );
+    await _waitForWidget(tester, find.text('已切换，但首选节点保存失败'));
+
+    expect(clash.isRunning, isTrue);
+    expect(clash.connectionDesired, isTrue);
+    expect(clash.runtimeNodeName, '新加坡节点');
+    expect(clash.liveSwitchCalls, 1);
+    expect(fixture.settings.settings.lastSelectedNodeName, isNull);
+    expect(find.text('节点切换失败，请稍后重试'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('ssrvpn-node-card-新加坡节点')),
+        matching: find.byIcon(Icons.check_circle_rounded),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('live switch readback mismatch reports the retained runtime node',
+      (tester) async {
+    final clash = _MismatchedReadbackAndroidClashService()..setRunning(true);
+    final fixture =
+        (await tester.runAsync(() => _AndroidHomeFixture.create(clash)))!;
+    addTearDown(fixture.dispose);
+
+    await tester.pumpWidget(fixture.build());
+    await _waitForWidget(tester, find.text('已连接'));
+    await tester.tap(find.byKey(const Key('ssrvpn-current-node-card')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('ssrvpn-node-select-新加坡节点')),
+    );
+    await _waitForWidget(
+      tester,
+      find.text('切换失败: 新加坡节点；当前节点: 东京节点'),
+    );
+
+    expect(clash.isRunning, isTrue);
+    expect(clash.connectionDesired, isTrue);
+    expect(fixture.settings.settings.lastSelectedNodeName, '东京节点');
+  });
+
+  testWidgets('live switch blank readback preserves the confirmed switch',
+      (tester) async {
+    final clash = _UnknownReadbackAndroidClashService()..setRunning(true);
+    final fixture =
+        (await tester.runAsync(() => _AndroidHomeFixture.create(clash)))!;
+    addTearDown(fixture.dispose);
+
+    await tester.pumpWidget(fixture.build());
+    await _waitForWidget(tester, find.text('已连接'));
+    await tester.tap(find.byKey(const Key('ssrvpn-current-node-card')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('ssrvpn-node-select-新加坡节点')),
+    );
+    await _waitForWidget(
+      tester,
+      find.text('已切换: 新加坡节点；快速启动信息保存失败'),
+    );
+
+    expect(clash.isRunning, isTrue);
+    expect(clash.connectionDesired, isTrue);
+    expect(fixture.settings.settings.lastSelectedNodeName, '新加坡节点');
+    expect(find.textContaining('切换失败:'), findsNothing);
+  });
+
   testWidgets('Android native recovery stays visible and power cancels it',
       (tester) async {
     final clash = _RecoveryAndroidClashService()..setRunning(true);
@@ -327,6 +548,64 @@ void main() {
 
     expect(clash.connectionDesired, isFalse);
     expect(find.text('未连接'), findsOneWidget);
+  });
+
+  testWidgets(
+      'Android Home presents runtime notices and retires callbacks by service identity',
+      (tester) async {
+    final originalClash = _RecordingAndroidClashService();
+    final replacementClash = _RecordingAndroidClashService();
+    final fixture = (await tester.runAsync(
+      () => _AndroidHomeFixture.create(originalClash),
+    ))!;
+    addTearDown(fixture.dispose);
+
+    await tester.pumpWidget(fixture.build());
+    await _waitForWidget(
+      tester,
+      find.byKey(const Key('ssrvpn-current-node-card')),
+    );
+    expect(originalClash.onRuntimeNotice, isNotNull);
+
+    originalClash.publishRuntimeNotice(
+      const RuntimeNotice.progress('连接服务正在自动恢复…'),
+    );
+    await tester.pump();
+    expect(find.text('连接服务正在自动恢复…'), findsOneWidget);
+
+    originalClash.publishRuntimeNotice(
+      const RuntimeNotice.warning('当前网络尚未恢复，VPN 会继续等待'),
+    );
+    await tester.pump();
+    expect(find.text('当前网络尚未恢复，VPN 会继续等待'), findsOneWidget);
+    expect(find.text('连接服务正在自动恢复…'), findsNothing);
+
+    originalClash.publishRuntimeNotice(
+      const RuntimeNotice.error('连接服务已停止，请点击连接重试'),
+    );
+    await tester.pump();
+    expect(find.text('连接异常'), findsOneWidget);
+    expect(find.text('连接服务已停止，请点击连接重试'), findsOneWidget);
+    expect(find.text('当前网络尚未恢复，VPN 会继续等待'), findsNothing);
+
+    await tester.pumpWidget(fixture.build(clashOverride: replacementClash));
+    await tester.pump();
+    expect(originalClash.onRuntimeNotice, isNull);
+    expect(replacementClash.onRuntimeNotice, isNotNull);
+
+    originalClash.publishRuntimeNotice(
+      const RuntimeNotice.error('旧服务实例不得更新页面'),
+    );
+    replacementClash.publishRuntimeNotice(
+      const RuntimeNotice.progress('新服务实例已接管'),
+    );
+    await tester.pump();
+    expect(find.text('旧服务实例不得更新页面'), findsNothing);
+    expect(find.text('新服务实例已接管'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    expect(replacementClash.onRuntimeNotice, isNull);
   });
 
   testWidgets(
@@ -710,12 +989,15 @@ class _AndroidHomeFixture {
     );
   }
 
-  Widget build({double textScaleFactor = 1}) {
+  Widget build({
+    double textScaleFactor = 1,
+    ClashService? clashOverride,
+  }) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<SubscriptionService>.value(value: subscription),
         ChangeNotifierProvider<SettingsService>.value(value: settings),
-        Provider<ClashService>.value(value: clash),
+        Provider<ClashService>.value(value: clashOverride ?? clash),
       ],
       child: MaterialApp(
         builder: (context, child) => MediaQuery(
@@ -744,6 +1026,11 @@ class _RecordingAndroidClashService extends ClashService {
   int liveSwitchCalls = 0;
   int idleSnapshotInvalidations = 0;
   bool failIdleSnapshotInvalidation = false;
+  String runtimeNodeName = '东京节点';
+
+  void publishRuntimeNotice(RuntimeNotice notice) {
+    onRuntimeNotice?.call(notice);
+  }
 
   @override
   Future<List<AppDiagnosticCheck>> platformDiagnosticChecks() async => const [];
@@ -782,21 +1069,145 @@ class _RecordingAndroidClashService extends ClashService {
     required int connectionGeneration,
   }) async {
     liveSwitchCalls++;
-    return const AndroidProxySwitchResult(
+    runtimeNodeName = nodeName;
+    onStatusChanged?.call();
+    return AndroidProxySwitchResult(
       liveSwitched: true,
       snapshotPersisted: true,
       intentCurrent: true,
+      nativeSessionGeneration: 1,
+      runtimeNodeName: runtimeNodeName,
     );
   }
 
   @override
+  Future<String?> currentSelectedProxyName() async => runtimeNodeName;
+
+  @override
+  Future<String> writePreferredNodeConfig(
+    String rawYaml,
+    AppSettings settings,
+    String nodeName, {
+    bool Function()? shouldContinue,
+    int? expectedSessionGeneration,
+  }) async =>
+      '/tmp/ssrvpn-test-preferred-node.yaml';
+
+  @override
   Future<void> stop() async => setRunning(false);
+}
+
+class _FailedInitialSwitchAndroidClashService
+    extends _RecordingAndroidClashService {
+  @override
+  Future<AppSettings> prepareForStart(AppSettings preferred) async {
+    updateSettings(preferred);
+    return preferred;
+  }
+
+  @override
+  Future<String> generateClashConfigAsync(
+    String rawYaml,
+    AppSettings settings, {
+    String? preferredNodeName,
+  }) async {
+    generatedPreferredNodeName = preferredNodeName;
+    return 'generated-config';
+  }
+
+  @override
+  Future<String> writeConfig(String config) async =>
+      '/tmp/ssrvpn-failed-initial-switch.yaml';
+
+  @override
+  Future<bool> start({String? nodeName, String? preparedConfigPath}) async {
+    setRunning(true);
+    return true;
+  }
+
+  @override
+  Future<AndroidProxySwitchResult> switchSelectedProxyForConnection(
+    String nodeName, {
+    required int connectionGeneration,
+  }) async {
+    liveSwitchCalls++;
+    return const AndroidProxySwitchResult(
+      liveSwitched: false,
+      snapshotPersisted: false,
+      intentCurrent: true,
+      runtimeNodeName: '东京节点',
+    );
+  }
+
+  @override
+  Future<String?> currentSelectedProxyName() async => '东京节点';
+
+  @override
+  Future<void> observeDataPlaneHealth() async {}
+}
+
+class _SuccessfulInitialSwitchAndroidClashService
+    extends _FailedInitialSwitchAndroidClashService {
+  @override
+  Future<AndroidProxySwitchResult> switchSelectedProxyForConnection(
+    String nodeName, {
+    required int connectionGeneration,
+  }) async {
+    liveSwitchCalls++;
+    return AndroidProxySwitchResult(
+      liveSwitched: true,
+      snapshotPersisted: true,
+      intentCurrent: true,
+      runtimeNodeName: nodeName,
+    );
+  }
+}
+
+class _MismatchedReadbackAndroidClashService
+    extends _RecordingAndroidClashService {
+  int preferredConfigWrites = 0;
+
+  @override
+  Future<AndroidProxySwitchResult> switchSelectedProxyForConnection(
+    String nodeName, {
+    required int connectionGeneration,
+  }) async {
+    liveSwitchCalls++;
+    return const AndroidProxySwitchResult(
+      liveSwitched: true,
+      snapshotPersisted: false,
+      intentCurrent: true,
+      nativeSessionGeneration: 1,
+    );
+  }
+
+  @override
+  Future<String> writePreferredNodeConfig(
+    String rawYaml,
+    AppSettings settings,
+    String nodeName, {
+    bool Function()? shouldContinue,
+    int? expectedSessionGeneration,
+  }) async {
+    preferredConfigWrites++;
+    if (preferredConfigWrites == 1) {
+      throw StateError('snapshot unavailable');
+    }
+    return '/tmp/ssrvpn-test-preferred-node.yaml';
+  }
+}
+
+class _UnknownReadbackAndroidClashService
+    extends _MismatchedReadbackAndroidClashService {
+  @override
+  Future<String?> currentSelectedProxyName() async => '   ';
 }
 
 class _DelayedAndroidClashService extends ClashService {
   final Completer<void> latencyStarted = Completer<void>();
   final Completer<void> releaseLatency = Completer<void>();
   bool _running = false;
+  int? lastTimeoutMs;
 
   @override
   bool get isRunning => _running;
@@ -817,6 +1228,7 @@ class _DelayedAndroidClashService extends ClashService {
     int timeoutMs = 5000,
     bool Function()? shouldContinue,
   }) async {
+    lastTimeoutMs = timeoutMs;
     if (!latencyStarted.isCompleted) latencyStarted.complete();
     await releaseLatency.future;
     for (var index = 0; index < nodes.length; index++) {

--- a/SSRVPN_Android/test/services/update_service_test.dart
+++ b/SSRVPN_Android/test/services/update_service_test.dart
@@ -555,10 +555,12 @@ void main() {
           installApk: (_) async {
             installAttempted.complete();
             throw StateError(
-              List<String>.generate(
+              'installer failed token=top-secret for '
+              'https://example.com/private/update/path\n'
+              '${List<String>.generate(
                 40,
                 (index) => '安装程序响应异常 ${index + 1}',
-              ).join('\n'),
+              ).join('\n')}',
             );
           },
         );
@@ -570,6 +572,9 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.text('update-page'), findsOneWidget);
       expect(find.textContaining('更新失败'), findsOneWidget);
+      expect(find.textContaining('top-secret'), findsNothing);
+      expect(find.textContaining('/private/update/path'), findsNothing);
+      expect(find.textContaining('当前版本仍可使用'), findsOneWidget);
       expect(
         tester.widget<AlertDialog>(find.byType(AlertDialog)).scrollable,
         isTrue,

--- a/SSRVPN_MacOS/lib/app.dart
+++ b/SSRVPN_MacOS/lib/app.dart
@@ -19,7 +19,9 @@ import 'package:ssrvpn_shared/ssrvpn_shared.dart'
         SsrvpnBottomNavigation,
         SsrvpnDesktopTitlebarInset,
         UpdateAvailabilityController,
-        desktopSubscriptionChangedMessage;
+        desktopSubscriptionChangedMessage,
+        safeUserFacingFailureMessage,
+        safeUserFacingFailureWithAction;
 import 'package:ssrvpn_shared/widgets/crash_report_prompt.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -128,13 +130,16 @@ class _SSRVpnAppState extends State<SSRVpnApp>
       _clashService?.onProcessExit = null;
       _clashService?.onRuntimeNotice = null;
       _clashService = nextClashService;
+      _lastObservedCoreRunning = nextClashService.isRunning;
       _clashService!.addStatusListener(_handleCoreStatusChanged);
       _clashService!.onRuntimeNotice = (message) {
         unawaited(_presentRuntimeNotice(message));
       };
       _clashService!.onProcessExit = () {
-        final notice = _clashService?.lastUnexpectedExitNotice ??
-            'Mihomo 异常退出，系统代理恢复结果未知。请点击首页“连接”重试。';
+        final notice = _clashService?.lastUnexpectedExitRuntimeNotice ??
+            const RuntimeNotice.error(
+              '本地代理服务异常退出，系统代理恢复结果未知。请点击首页“连接”重试。',
+            );
         unawaited(_presentRuntimeNotice(notice));
       };
       _configureTrayCallbacks();
@@ -142,7 +147,7 @@ class _SSRVpnAppState extends State<SSRVpnApp>
       if (recoveryNotice != null) {
         unawaited(
           _presentRuntimeNotice(
-            recoveryNotice,
+            RuntimeNotice.warning(recoveryNotice),
             tracksPendingRecovery: true,
           ),
         );
@@ -153,6 +158,24 @@ class _SSRVpnAppState extends State<SSRVpnApp>
     _subscriptionService = nextSubscriptionService;
 
     if (mounted) setState(() {});
+  }
+
+  void _handleCoreStatusChanged() {
+    final core = _clashService;
+    final isRunning = core?.isRunning ?? false;
+    final clearStaleNotice = shouldClearRuntimeNoticeOnRunningEdge(
+      wasRunning: _lastObservedCoreRunning,
+      isRunning: isRunning,
+      notice: _runtimeNotice,
+    );
+    _lastObservedCoreRunning = isRunning;
+    if (clearStaleNotice) _clearRuntimeNotice();
+    if (_runtimeNoticeTracksPendingRecovery &&
+        core != null &&
+        !core.hasPendingSystemProxyRecovery) {
+      _clearRuntimeNotice();
+    }
+    unawaited(_refreshTrayStatus());
   }
 
   @override

--- a/SSRVPN_MacOS/lib/app_runtime_actions_part.dart
+++ b/SSRVPN_MacOS/lib/app_runtime_actions_part.dart
@@ -5,7 +5,8 @@ mixin _MacosAppRuntimeActions on State<SSRVpnApp> {
 
   int _currentIndex = 0;
   bool _isQuitting = false;
-  String? _runtimeNotice;
+  RuntimeNotice? _runtimeNotice;
+  bool _lastObservedCoreRunning = false;
   bool _runtimeNoticeTracksPendingRecovery = false;
   Timer? _runtimeNoticeAutoClearTimer;
 
@@ -160,9 +161,19 @@ mixin _MacosAppRuntimeActions on State<SSRVpnApp> {
           );
         }
       }
+      final preferredNodeWarning = connectionResult.preferredNodeSwitchWarning(
+        preferredNodeName: preferredNodeName,
+      );
       final portAdjustmentNotice = connectionResult.runtimeNotice;
-      if (portAdjustmentNotice != null && portAdjustmentNotice.isNotEmpty) {
-        await _presentRuntimeNotice(portAdjustmentNotice);
+      if (preferredNodeWarning != null) {
+        await _presentRuntimeNotice(
+          RuntimeNotice.warning(preferredNodeWarning),
+        );
+      } else if (portAdjustmentNotice != null &&
+          portAdjustmentNotice.isNotEmpty) {
+        await _presentRuntimeNotice(
+          RuntimeNotice.success(portAdjustmentNotice),
+        );
       }
     } catch (error, stack) {
       final isCurrent = connectionGeneration != null &&
@@ -176,13 +187,7 @@ mixin _MacosAppRuntimeActions on State<SSRVpnApp> {
         core.interruptPendingStart();
       }
       StartupLogger.error('Tray connect toggle failed', error, stack);
-      final reason = error
-          .toString()
-          .replaceFirst('Bad state: ', '')
-          .replaceFirst('Exception: ', '');
-      await _presentTrayFailure(
-        reason.startsWith('订阅已更新') ? reason : '托盘连接失败，请重试或查看日志',
-      );
+      await _presentTrayFailure(error);
     } finally {
       await _trayManager.refreshMenu();
     }
@@ -194,24 +199,25 @@ mixin _MacosAppRuntimeActions on State<SSRVpnApp> {
     return HomeNodeController.resolveDefaultNodeFrom(nodes, remembered)?.name;
   }
 
-  Future<void> _presentTrayFailure(String reason) =>
-      _presentRuntimeNotice('连接失败：$reason');
+  Future<void> _presentTrayFailure(Object? reason) => _presentRuntimeNotice(
+        RuntimeNotice.error(safeUserFacingFailureMessage(reason)),
+      );
 
   Future<void> _presentRuntimeNotice(
-    String message, {
+    RuntimeNotice notice, {
     bool tracksPendingRecovery = false,
   }) async {
     _runtimeNoticeAutoClearTimer?.cancel();
     _runtimeNoticeAutoClearTimer = null;
     if (mounted) {
       setState(() {
-        _runtimeNotice = message;
+        _runtimeNotice = notice;
         _runtimeNoticeTracksPendingRecovery = tracksPendingRecovery;
         _currentIndex = 0;
       });
       _runtimeNoticeAutoClearTimer = scheduleSuccessfulRuntimeNoticeClear(
-        message: message,
-        currentMessage: () => _runtimeNotice,
+        notice: notice,
+        currentNotice: () => _runtimeNotice,
         clear: _clearRuntimeNotice,
       );
     }
@@ -235,21 +241,6 @@ mixin _MacosAppRuntimeActions on State<SSRVpnApp> {
     unawaited(_refreshTrayStatus());
   }
 
-  void _handleCoreStatusChanged() {
-    final core = _clashService;
-    if (_runtimeNoticeTracksPendingRecovery &&
-        core != null &&
-        !core.hasPendingSystemProxyRecovery) {
-      _clearRuntimeNotice();
-    } else if (mounted &&
-        (core?.isRunning ?? false) &&
-        _runtimeNotice != null &&
-        !isSuccessfulRuntimeNotice(_runtimeNotice)) {
-      _clearRuntimeNotice();
-    }
-    unawaited(_refreshTrayStatus());
-  }
-
   Future<void> _refreshTrayStatus() async {
     final core = _clashService;
     final connected = core?.isRunning ?? false;
@@ -257,7 +248,7 @@ mixin _MacosAppRuntimeActions on State<SSRVpnApp> {
         core?.runtimeProxyPort ?? _settingsService?.settings.proxyPort ?? 7890;
     final notice = _runtimeNotice;
     final tooltip = notice != null
-        ? 'SSRVPN · ${notice.length <= 90 ? notice : '${notice.substring(0, 90)}…'}'
+        ? 'SSRVPN · ${notice.message.length <= 90 ? notice.message : '${notice.message.substring(0, 90)}…'}'
         : connected
             ? 'SSRVPN · 已连接 · HTTP 127.0.0.1:$port'
             : 'SSRVPN · 未连接';
@@ -301,7 +292,13 @@ mixin _MacosAppRuntimeActions on State<SSRVpnApp> {
           .toString()
           .replaceFirst('Bad state: ', '')
           .replaceFirst('StateError: ', '');
-      await _presentRuntimeNotice('退出未完成：$reason。窗口和菜单栏图标已保留，请稍后重试退出');
+      final message = safeUserFacingFailureWithAction(
+        reason,
+        '窗口和菜单栏图标已保留，请稍后重试退出。',
+      );
+      await _presentRuntimeNotice(
+        RuntimeNotice.error('退出未完成：$message'),
+      );
       return false;
     }
     SystemNavigator.pop();

--- a/SSRVPN_MacOS/lib/services/clash_service.dart
+++ b/SSRVPN_MacOS/lib/services/clash_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show MethodChannel, rootBundle;
 import 'package:path_provider/path_provider.dart';
 
+import 'package:ssrvpn_shared/runtime_notice.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 
 import 'macos_tun_session.dart';
@@ -49,14 +50,11 @@ class ClashService extends ClashServiceBase
   // ═══════════════════════════════════════════════════════════
 
   @override
-  void log(String message) {
-    super.log(message);
+  void writePlatformLog(String line) {
     // macOS: 写入文件日志
     final fileLogger = _fileLogger;
     if (fileLogger != null) {
-      final sanitized = LogRedactor.sanitize(message);
-      final line = '[${DateTime.now().toIso8601String()}] $sanitized\n';
-      fileLogger.add(line);
+      fileLogger.add('$line\n');
     }
   }
 

--- a/SSRVPN_MacOS/lib/services/clash_service_lifecycle.dart
+++ b/SSRVPN_MacOS/lib/services/clash_service_lifecycle.dart
@@ -92,18 +92,18 @@ String buildMacosUnexpectedExitNotice({
   required bool proxyRecovered,
 }) =>
     proxyRecovered
-        ? 'Mihomo 异常退出（退出码 $exitCode），系统代理已恢复。请点击首页“连接”重试。'
-        : 'Mihomo 异常退出（退出码 $exitCode），系统代理恢复失败。已保留恢复记录并暂停新连接，请点击首页“连接”重试；仍失败请打开日志诊断。';
+        ? '本地代理服务异常退出（退出码 $exitCode），系统代理已恢复。请点击首页“连接”重试。'
+        : '本地代理服务异常退出（退出码 $exitCode），系统代理恢复失败。已保留恢复记录并暂停新连接，请点击首页“连接”重试；仍失败请打开日志诊断。';
 
 String? buildMacosStartupRecoveryNotice({
   required bool proxyRecoveryPending,
   required bool corePreparationPending,
 }) {
   if (proxyRecoveryPending) {
-    return '检测到上次退出遗留的系统代理状态。为保护网络，SSRVPN 已保留旧核心并暂停新连接；请点击首页“连接”重试恢复。';
+    return '检测到上次退出遗留的系统代理状态。为保护网络，SSRVPN 已保留原本地代理服务并暂停新连接；请点击首页“连接”重试恢复。';
   }
   if (corePreparationPending) {
-    return '系统代理已恢复，但 Mihomo 核心安全准备尚未完成。SSRVPN 已保留旧核心并暂停新连接；请点击首页“连接”重试准备。';
+    return '系统代理已恢复，但本地代理服务的安全准备尚未完成。SSRVPN 已保留原服务并暂停新连接；请点击首页“连接”重试准备。';
   }
   return null;
 }
@@ -138,13 +138,10 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
   bool _lastTunDataPathHealthy = true;
   Future<bool>? _tunDataPathProbe;
   int _tunDataPathProbeGeneration = 0;
-  int _consecutiveTunDataPathFailures = 0;
+  RuntimeNotice? _lastUnexpectedExitRuntimeNotice;
 
   @protected
   Duration get tunDataPathProbeInterval => const Duration(seconds: 30);
-
-  @protected
-  int get tunDataPathFailureThreshold => 2;
 
   bool get isStartupDisabled => _startupDisabledReason != null;
   String? get startupDisabledReason => _startupDisabledReason;
@@ -157,12 +154,14 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
         corePreparationPending: _startupBlockedByProxyRecovery,
       );
   String? get lastUnexpectedExitNotice => _lastUnexpectedExitNotice;
+  RuntimeNotice? get lastUnexpectedExitRuntimeNotice =>
+      _lastUnexpectedExitRuntimeNotice;
   String get _recoveryDiagnosticSummary {
     if (_proxyService.recoveryPending) {
       return '检测到 SSRVPN 自有的待恢复代理状态';
     }
     if (_startupBlockedByProxyRecovery) {
-      return '系统代理已恢复，但 Mihomo 核心资产尚未安全就绪';
+      return '系统代理已恢复，但本地代理服务尚未安全就绪';
     }
     return '没有待恢复的 SSRVPN 系统代理状态';
   }
@@ -305,16 +304,31 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
       if (isRunning) {
         final ownershipStatus = await inspectSystemProxyOwnership();
         if (ownershipStatus == SystemProxyOwnershipStatus.owned) {
+          if (connectivityWarning ==
+              desktopSystemProxyOwnershipUnavailableWarning) {
+            setConnectivityWarning(null);
+          }
           setLastHealthCheckError(null);
           return true;
         }
+        if (ownershipStatus == SystemProxyOwnershipStatus.unavailable) {
+          setLastHealthCheckError(null);
+          if (connectivityWarning !=
+              desktopSystemProxyOwnershipUnavailableWarning) {
+            log(
+              '系统代理所有权探针暂时不可用；Mihomo API 正常，保留当前连接',
+              level: RuntimeLogLevel.warning,
+              event: 'system_proxy_health',
+            );
+          }
+          setConnectivityWarning(
+            desktopSystemProxyOwnershipUnavailableWarning,
+          );
+          return true;
+        }
         final ownershipError = _proxyService.lastError ?? 'macOS 系统代理所有权无法确认';
-        final prefix =
-            ownershipStatus == SystemProxyOwnershipStatus.externallyChanged
-                ? desktopSystemProxyOwnershipLostPrefix
-                : desktopSystemProxyOwnershipUnavailablePrefix;
         setLastHealthCheckError(
-          '$prefix $ownershipError',
+          '$desktopSystemProxyOwnershipLostPrefix $ownershipError',
         );
         return false;
       }
@@ -347,6 +361,21 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
     await _checkThrottledTunDataPath();
   }
 
+  @override
+  @protected
+  void onPeriodicHealthCheckResult(bool healthy) {
+    if (!healthy) {
+      _automaticRecoveryPolicy.recordUnhealthy();
+      return;
+    }
+    if (_automaticRecoveryPolicy.recordHealthy(DateTime.now())) {
+      log(
+        '连接达到稳定健康观察窗口，自动恢复次数预算已复位',
+        event: 'health_recovery',
+      );
+    }
+  }
+
   Future<bool> _checkThrottledTunDataPath() async {
     final activeProbe = _tunDataPathProbe;
     if (activeProbe != null) return activeProbe;
@@ -372,125 +401,35 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
     final warning = await verifyUserConnectivity(
       maxAttempts: 2,
       retryDelay: const Duration(seconds: 1),
-      shouldContinue: () => isRunning && settings.enableTun,
+      shouldContinue: () =>
+          probeGeneration == _tunDataPathProbeGeneration &&
+          isRunning &&
+          settings.enableTun,
     );
     if (probeGeneration != _tunDataPathProbeGeneration) return true;
     if (!isRunning || !settings.enableTun) return false;
     _lastTunDataPathProbeAt = DateTime.now();
+    final wasHealthy = _lastTunDataPathHealthy;
     _lastTunDataPathHealthy = warning == null;
     if (warning != null) {
-      _consecutiveTunDataPathFailures++;
       setConnectivityWarning(
-        '节点或外部网络暂时不可用，TUN 保持连接并继续恢复：$warning',
+        '连接与 TUN 仍在运行；外部网络观察暂未通过，仅供参考：$warning',
       );
       log(
-        'EXTERNAL_CHECK_BLOCKED '
-        '($_consecutiveTunDataPathFailures/$tunDataPathFailureThreshold): '
-        '$warning',
+        '外部网络观察未通过: $warning；未切换节点，未关闭既有连接',
+        level: RuntimeLogLevel.warning,
+        event: 'data_plane_probe',
       );
-      if (_consecutiveTunDataPathFailures >= tunDataPathFailureThreshold) {
-        await _attemptTunNodeRecovery(probeGeneration);
-      }
     } else {
-      if (_consecutiveTunDataPathFailures > 0) {
-        log('TUN 数据通道已恢复，核心和 TUN 会话始终保持运行');
+      if (!wasHealthy) {
+        log(
+          'TUN 数据通道已恢复，核心和 TUN 会话始终保持运行',
+          event: 'data_plane_probe',
+        );
       }
-      _consecutiveTunDataPathFailures = 0;
       setConnectivityWarning(null);
     }
     return _lastTunDataPathHealthy;
-  }
-
-  Future<void> _attemptTunNodeRecovery(int probeGeneration) async {
-    if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-    final groups = await getProxies();
-    ProxyGroup? proxyGroup;
-    for (final group in groups) {
-      if (group.name == 'PROXY') {
-        proxyGroup = group;
-        break;
-      }
-    }
-    if (proxyGroup == null || proxyGroup.nodes.length < 2) {
-      log('NODE_RECOVERY_UNAVAILABLE: 没有其他可切换节点，TUN 保持受限连接');
-      return;
-    }
-    final original = await currentSelectedProxyName();
-    if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-    if (original == null) {
-      setConnectivityWarning(
-        '无法确认当前节点，未执行自动切换；TUN 仍保持接管，请手动选择节点',
-      );
-      log('NODE_RECOVERY_UNAVAILABLE: 无法确认当前节点，未执行自动切换');
-      return;
-    }
-    final candidates = proxyGroup.nodes
-        .where((node) => node.name != original)
-        .take(3)
-        .toList(growable: false);
-    var recoveryOwnedSelection = original;
-    setConnectivityWarning('当前节点不可用，TUN 保持接管并正在热切换节点…');
-    for (final candidate in candidates) {
-      if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-      final selectedBeforeSwitch = await currentSelectedProxyName();
-      if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-      if (selectedBeforeSwitch != recoveryOwnedSelection) {
-        _handleExternalNodeSelectionDuringRecovery();
-        return;
-      }
-      final switched = await switchSelectedProxy(candidate.name);
-      if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-      if (!switched) continue;
-      recoveryOwnedSelection = candidate.name;
-      final warning = await verifyUserConnectivity(
-        maxAttempts: 2,
-        retryDelay: const Duration(seconds: 1),
-        shouldContinue: () =>
-            probeGeneration == _tunDataPathProbeGeneration && isRunning,
-      );
-      if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-      final selectedAfterProbe = await currentSelectedProxyName();
-      if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-      if (selectedAfterProbe != recoveryOwnedSelection) {
-        _handleExternalNodeSelectionDuringRecovery();
-        return;
-      }
-      if (warning == null) {
-        _lastTunDataPathHealthy = true;
-        _consecutiveTunDataPathFailures = 0;
-        setConnectivityWarning(null);
-        log('NODE_RECOVERED: 已热切换到 ${candidate.name}，TUN 会话未重建');
-        notifyStatusChanged();
-        return;
-      }
-      log('NODE_RECOVERY_FAILED: ${candidate.name}: $warning');
-    }
-    if (probeGeneration == _tunDataPathProbeGeneration && isRunning) {
-      final selectedBeforeRestore = await currentSelectedProxyName();
-      if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-      if (selectedBeforeRestore != recoveryOwnedSelection) {
-        _handleExternalNodeSelectionDuringRecovery();
-        return;
-      }
-      final restored = await switchSelectedProxy(original);
-      if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-      if (!restored) {
-        setConnectivityWarning(
-          '节点自动恢复未成功，且未能恢复原节点；TUN 仍保持接管，请手动选择节点',
-        );
-        log('NODE_ROLLBACK_FAILED: 自动恢复失败后未能恢复原节点 $original');
-        return;
-      }
-    }
-    if (probeGeneration != _tunDataPathProbeGeneration || !isRunning) return;
-    setConnectivityWarning('节点自动恢复未成功，TUN 仍保持接管；请手动切换节点或刷新订阅');
-  }
-
-  void _handleExternalNodeSelectionDuringRecovery() {
-    _lastTunDataPathProbeAt = null;
-    _consecutiveTunDataPathFailures = 0;
-    setConnectivityWarning('节点已切换，TUN 保持连接并等待重新验证…');
-    log('NODE_RECOVERY_CANCELLED: 检测到其他节点选择，未覆盖当前选择');
   }
 
   Future<bool> _verifyTunFinalControlPlaneHealth(
@@ -524,7 +463,11 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
       await stop();
       return false;
     }
-    if (await healthCheck()) {
+    final healthy = await healthCheck();
+    if (!isConnectionIntentCurrent(connectionGeneration, connected: true)) {
+      return false;
+    }
+    if (healthy) {
       setRunning(true);
       return true;
     }
@@ -533,6 +476,9 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
       // returns as soon as the API is unavailable, so inspect ownership again
       // immediately before any stop/restart that could reacquire the proxy.
       final ownershipStatus = await inspectSystemProxyOwnership();
+      if (!isConnectionIntentCurrent(connectionGeneration, connected: true)) {
+        return false;
+      }
       if (ownershipStatus != SystemProxyOwnershipStatus.owned) {
         final externallyChanged =
             ownershipStatus == SystemProxyOwnershipStatus.externallyChanged;
@@ -544,15 +490,19 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
         } catch (error) {
           log('系统代理所有权失效后的核心清理未完成: $error');
           notifyRuntimeNotice(
-            '已取消自动重连，但系统代理或 Mihomo 核心清理状态无法确认；'
-            '请在诊断页检查并重试断开，SSRVPN 不会重新接管代理。',
+            const RuntimeNotice.error(
+              '已取消自动重连，但系统代理或本地代理服务的清理状态无法确认；'
+              '请在诊断页检查并重试断开，SSRVPN 不会重新接管代理。',
+            ),
           );
           return false;
         }
         notifyRuntimeNotice(
-          externallyChanged
-              ? '检测到系统代理已被其他程序接管，SSRVPN 已安全断开且不会覆盖当前代理。'
-              : '无法确认当前系统代理所有权，SSRVPN 已安全断开且不会覆盖未知代理状态。',
+          RuntimeNotice.warning(
+            externallyChanged
+                ? '检测到系统代理已被其他程序接管，SSRVPN 已安全断开且不会覆盖当前代理。'
+                : '无法确认当前系统代理所有权，SSRVPN 已安全断开且不会覆盖未知代理状态。',
+          ),
         );
         return false;
       }
@@ -563,9 +513,11 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
     }
 
     notifyRuntimeNotice(
-      'Mihomo 持续失去响应，正在执行安全重启'
-      '（${_automaticRecoveryPolicy.attempts}/'
-      '${_automaticRecoveryPolicy.maxAttempts}）…',
+      RuntimeNotice.progress(
+        '运行状态持续异常，正在执行安全重启'
+        '（${_automaticRecoveryPolicy.attempts}/'
+        '${_automaticRecoveryPolicy.maxAttempts}）…',
+      ),
     );
     try {
       await stop();
@@ -580,8 +532,10 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
         systemProxyOwnershipChangedSinceLastAcquisition) {
       markConnectionLost();
       notifyRuntimeNotice(
-        '系统代理在清理期间发生变化，已取消自动重连；'
-        'SSRVPN 不会重新接管当前代理。',
+        const RuntimeNotice.warning(
+          '系统代理在清理期间发生变化，已取消自动重连；'
+          'SSRVPN 不会重新接管当前代理。',
+        ),
       );
       return false;
     }
@@ -721,7 +675,7 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
       return false;
     }
     if (_corePath.isEmpty || configDir.isEmpty || configPath.isEmpty) {
-      setLastStartError('Mihomo service is not initialized');
+      setLastStartError('连接服务尚未初始化，请重启 SSRVPN；若仍失败，请重新安装官方版本');
       log(lastStartError!);
       return false;
     }
@@ -1231,28 +1185,6 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
           continue;
         }
         if (await healthCheck()) {
-          final connectivityWarning = await verifyUserConnectivity(
-            shouldContinue: () => startToken == _startGeneration,
-          );
-          _ensureStartCurrent(startToken);
-          if (connectivityWarning != null) {
-            _lastTunDataPathProbeAt = DateTime.now();
-            _lastTunDataPathHealthy = false;
-            _consecutiveTunDataPathFailures = 1;
-            setConnectivityWarning(
-              '节点或外部网络暂时不可用，TUN 保持连接并继续恢复：'
-              '$connectivityWarning',
-            );
-            log(
-              'EXTERNAL_CHECK_BLOCKED (startup advisory): '
-              '$connectivityWarning',
-            );
-          } else {
-            _lastTunDataPathProbeAt = DateTime.now();
-            _lastTunDataPathHealthy = true;
-            _consecutiveTunDataPathFailures = 0;
-            setConnectivityWarning(null);
-          }
           final finalControlPlaneHealthy =
               await _verifyTunFinalControlPlaneHealth(tunSession);
           _ensureStartCurrent(startToken);
@@ -1270,6 +1202,7 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
           );
           notifyStatusChanged();
           startStatusMonitor();
+          scheduleDataPlaneObservation();
           return true;
         }
         await Future<void>.delayed(const Duration(milliseconds: 250));
@@ -1297,7 +1230,6 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
     _tunDataPathProbe = null;
     _lastTunDataPathProbeAt = null;
     _lastTunDataPathHealthy = true;
-    _consecutiveTunDataPathFailures = 0;
     setConnectivityWarning(null);
   }
 
@@ -1515,15 +1447,18 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
           SystemProxyOwnershipStatus.externallyChanged;
       _lastUnexpectedExitNotice = proxyCleanup.proxyCleared
           ? (changedDuringClear
-              ? 'Mihomo 异常退出（退出码 $exitCode）；系统代理在清理期间发生变化，'
+              ? '本地代理服务异常退出（退出码 $exitCode）；系统代理在清理期间发生变化，'
                   'SSRVPN 已取消自动重连，不会重新接管当前代理。'
               : externallyChanged
-                  ? 'Mihomo 异常退出（退出码 $exitCode）；检测到系统代理已由其他程序接管，'
+                  ? '本地代理服务异常退出（退出码 $exitCode）；检测到系统代理已由其他程序接管，'
                       'SSRVPN 已清理自身恢复状态并取消自动重连，未覆盖当前代理。'
-                  : 'Mihomo 异常退出（退出码 $exitCode）；此前无法确认系统代理所有权，'
+                  : '本地代理服务异常退出（退出码 $exitCode）；此前无法确认系统代理所有权，'
                       'SSRVPN 已完成清理并取消自动重连，不会重新接管代理。')
-          : 'Mihomo 异常退出（退出码 $exitCode）；已取消自动重连，但系统代理恢复状态'
+          : '本地代理服务异常退出（退出码 $exitCode）；已取消自动重连，但系统代理恢复状态'
               '清理无法确认。请在诊断页检查并重试断开，SSRVPN 不会重新接管代理。';
+      _lastUnexpectedExitRuntimeNotice = RuntimeNotice.error(
+        _lastUnexpectedExitNotice!,
+      );
       try {
         onProcessExit?.call();
       } catch (error) {
@@ -1533,11 +1468,7 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
     }
 
     var automaticallyRecovered = false;
-    if (proxyCleanup.permitsAutomaticRestart &&
-        recoveryGeneration != null &&
-        isConnectionIntentCurrent(recoveryGeneration, connected: true) &&
-        _automaticRecoveryPolicy.tryAcquire()) {
-      notifyRuntimeNotice('Mihomo 异常退出（退出码 $exitCode），正在自动恢复…');
+    if (proxyCleanup.permitsAutomaticRestart && recoveryGeneration != null) {
       automaticallyRecovered = await runConnectionTransition(() async {
         if (!isConnectionIntentCurrent(
           recoveryGeneration,
@@ -1545,19 +1476,37 @@ mixin _MacosCoreLifecycle on ClashServiceBase {
         )) {
           return false;
         }
+        if (!_automaticRecoveryPolicy.tryAcquire()) return false;
+        notifyRuntimeNotice(
+          RuntimeNotice.progress(
+            '核心异常退出（退出码 $exitCode），正在自动恢复…',
+          ),
+        );
         return recoverDesktopConnection(recoveryGeneration);
       });
+      if (!isConnectionIntentCurrent(
+        recoveryGeneration,
+        connected: true,
+      )) {
+        return;
+      }
     }
 
     final intentCurrent = recoveryGeneration != null &&
         isConnectionIntentCurrent(recoveryGeneration, connected: true);
     if (automaticallyRecovered && intentCurrent && isRunning) {
-      _lastUnexpectedExitNotice = 'Mihomo 异常退出（退出码 $exitCode），连接已自动恢复。';
+      _lastUnexpectedExitNotice = '本地代理服务异常退出（退出码 $exitCode），连接已自动恢复。';
+      _lastUnexpectedExitRuntimeNotice = RuntimeNotice.success(
+        _lastUnexpectedExitNotice!,
+      );
     } else {
       if (intentCurrent) markConnectionLost();
       _lastUnexpectedExitNotice = buildMacosUnexpectedExitNotice(
         exitCode: exitCode,
         proxyRecovered: proxyCleanup.proxyCleared,
+      );
+      _lastUnexpectedExitRuntimeNotice = RuntimeNotice.error(
+        _lastUnexpectedExitNotice!,
       );
     }
     try {

--- a/SSRVPN_MacOS/lib/startup/startup_status.dart
+++ b/SSRVPN_MacOS/lib/startup/startup_status.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/foundation.dart';
+import 'package:ssrvpn_shared/ssrvpn_shared.dart'
+    show safeUserFacingFailureMessage;
 
 import '../services/clash_service.dart';
 import '../services/settings_service.dart';
@@ -16,10 +18,8 @@ class StartupFailure {
   final String message;
   final DateTime time;
 
-  static String _formatError(Object error) {
-    final message = error.toString().replaceFirst('Exception: ', '');
-    return message.length <= 800 ? message : '${message.substring(0, 800)}...';
-  }
+  static String _formatError(Object error) =>
+      safeUserFacingFailureMessage(error);
 }
 
 class StartupStatus extends ChangeNotifier {

--- a/SSRVPN_MacOS/test/clash_service_test.dart
+++ b/SSRVPN_MacOS/test/clash_service_test.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:ssrvpn_macos/services/clash_service.dart';
 import 'package:ssrvpn_macos/services/macos_tun_session.dart';
 import 'package:ssrvpn_macos/services/system_proxy_service.dart';
+import 'package:ssrvpn_shared/runtime_notice.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 
 const _subscriptionYaml = '''
@@ -165,11 +166,11 @@ void main() {
           proxyRecovered: false,
         ),
         allOf(
+          contains('本地代理服务'),
           contains('退出码 9'),
           contains('系统代理恢复失败'),
-          contains('保留'),
           contains('暂停新连接'),
-          isNot(contains('安全核心')),
+          isNot(contains('Mihomo')),
           contains('日志诊断'),
         ),
       );
@@ -183,7 +184,12 @@ void main() {
           proxyRecoveryPending: true,
           corePreparationPending: true,
         ),
-        allOf(contains('系统代理状态'), contains('旧核心'), contains('重试恢复')),
+        allOf(
+          contains('系统代理状态'),
+          contains('本地代理服务'),
+          contains('重试恢复'),
+          isNot(contains('Mihomo')),
+        ),
       );
       expect(
         buildMacosStartupRecoveryNotice(
@@ -193,8 +199,9 @@ void main() {
         allOf(
           contains('系统代理已恢复'),
           contains('安全准备'),
-          contains('旧核心'),
+          contains('本地代理服务'),
           contains('重试准备'),
+          isNot(contains('Mihomo')),
         ),
       );
       expect(
@@ -475,10 +482,11 @@ void main() {
       expect(
         service.startupRecoveryNotice,
         allOf(
-          contains('旧核心'),
+          contains('本地代理服务'),
           contains('首页'),
           contains('连接'),
           contains('重试'),
+          isNot(contains('Mihomo')),
         ),
       );
       expect(nativeTerminationCalls, 0);
@@ -827,6 +835,14 @@ void main() {
       expect(recoveryConfigGenerations, 1);
       expect(service.isRunning, isTrue);
       expect(
+        service.lastUnexpectedExitRuntimeNotice?.level,
+        RuntimeNoticeLevel.success,
+      );
+      expect(
+        service.lastUnexpectedExitRuntimeNotice?.message,
+        allOf(contains('本地代理服务'), isNot(contains('Mihomo'))),
+      );
+      expect(
         service.isConnectionIntentCurrent(generation, connected: true),
         isTrue,
       );
@@ -941,7 +957,7 @@ void main() {
         ..updateSettings(AppSettings(enableTun: true));
 
       expect(await service.start(), isFalse);
-      expect(service.lastStartError, 'Mihomo service is not initialized');
+      expect(service.lastStartError, contains('尚未初始化'));
     });
 
     test('core startup is blocked when stale TUN DNS recovery fails', () async {
@@ -1137,6 +1153,27 @@ void main() {
       expect(await service.healthCheck(), isFalse);
       expect(service.lastHealthCheckError, contains('关闭或修改'));
       expect(mutations, hasLength(mutationsAfterSetup));
+    });
+
+    test(
+        'system proxy health keeps the connection when ownership is temporarily unavailable',
+        () async {
+      final service = _UncertainProxyOwnershipClashService()
+        ..updateSettings(AppSettings())
+        ..setRunning(true);
+      addTearDown(service.dispose);
+
+      expect(await service.healthCheck(), isTrue);
+      expect(service.isRunning, isTrue);
+      expect(service.lastHealthCheckError, isNull);
+      expect(
+        service.connectivityWarning,
+        allOf(contains('暂时无法确认'), contains('当前连接仍保留')),
+      );
+
+      service.ownershipStatus = SystemProxyOwnershipStatus.owned;
+      expect(await service.healthCheck(), isTrue);
+      expect(service.connectivityWarning, isNull);
     });
 
     test('TUN does not commit after the privileged runner loses readiness',
@@ -1371,7 +1408,7 @@ void main() {
       expect(service.lastHealthCheckError, contains('TUN_CONFIG_MISMATCH'));
     });
 
-    test('persistent data-plane failure hot-switches a node without TUN exit',
+    test('persistent data-plane failures never switch nodes or stop TUN',
         () async {
       final tempDir = await Directory.systemTemp.createTemp(
         'ssrvpn_macos_tun_node_recovery_',
@@ -1397,12 +1434,12 @@ void main() {
 
       expect(service.isRunning, isTrue);
       expect(tunSession.stopCalls, 0);
-      expect(service.switchedNodes, ['Node B']);
-      expect(service.connectivityWarning, isNull);
-      expect(service.connectivityProbes, 3);
+      expect(service.switchedNodes, isEmpty);
+      expect(service.connectivityWarning, contains('second external failure'));
+      expect(service.connectivityProbes, 2);
     });
 
-    test('automatic node recovery never overrides a concurrent node choice',
+    test('external observation remains advisory when a node choice changes',
         () async {
       final tempDir = await Directory.systemTemp.createTemp(
         'ssrvpn_macos_tun_node_recovery_ownership_',
@@ -1428,12 +1465,12 @@ void main() {
 
       expect(service.isRunning, isTrue);
       expect(tunSession.stopCalls, 0);
-      expect(service.switchedNodes, ['Node B']);
-      expect(service.selectedNode, 'User Node');
-      expect(service.connectivityWarning, contains('节点已切换'));
+      expect(service.switchedNodes, isEmpty);
+      expect(service.selectedNode, 'Node A');
+      expect(service.connectivityWarning, contains('second external failure'));
     });
 
-    test('automatic node recovery does not switch when ownership is unknown',
+    test('external observation does not inspect or switch node ownership',
         () async {
       final tempDir = await Directory.systemTemp.createTemp(
         'ssrvpn_macos_tun_node_recovery_unknown_owner_',
@@ -1460,11 +1497,10 @@ void main() {
       await service.runDataPlaneObservation();
 
       expect(service.switchedNodes, isEmpty);
-      expect(service.connectivityWarning, contains('无法确认当前节点'));
+      expect(service.connectivityWarning, contains('external failure 2'));
     });
 
-    test('automatic node recovery reports a failed rollback explicitly',
-        () async {
+    test('external observation never attempts a rollback', () async {
       final tempDir = await Directory.systemTemp.createTemp(
         'ssrvpn_macos_tun_node_recovery_rollback_',
       );
@@ -1490,9 +1526,9 @@ void main() {
       await service.runDataPlaneObservation();
       await service.runDataPlaneObservation();
 
-      expect(service.switchedNodes, ['Node B', 'Node A']);
-      expect(service.selectedNode, 'Node B');
-      expect(service.connectivityWarning, contains('未能恢复原节点'));
+      expect(service.switchedNodes, isEmpty);
+      expect(service.selectedNode, 'Node A');
+      expect(service.connectivityWarning, contains('external failure 2'));
     });
 
     test('TUN DNS stop failure disconnects locally and blocks a new start',
@@ -1705,8 +1741,50 @@ void main() {
 
       expect(await service.start(), isTrue);
       expect(service.isRunning, isTrue);
+      await (() async {
+        while (service.connectivityWarning == null) {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      })()
+          .timeout(const Duration(seconds: 1));
       expect(service.connectivityWarning, contains('连续 3 次网络验证失败'));
       expect(service.lastStartError, isNull);
+      expect(tunSession.stopCalls, 0);
+    });
+
+    test('TUN startup commits before an external data-path probe completes',
+        () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'ssrvpn_macos_tun_async_data_path_',
+      );
+      final tunSession = _FakeMacosTunSession(tempDir.path);
+      final service =
+          _BlockingStartupDataPathClashService(tunSession: tunSession);
+      addTearDown(() async {
+        service.dataPathResult.complete(null);
+        await service.stop();
+        service.dispose();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        if (await tempDir.exists()) await tempDir.delete(recursive: true);
+      });
+
+      final settings = AppSettings(enableTun: true);
+      await service.init(
+        settings,
+        dataDir: tempDir.path,
+        skipCoreProbes: true,
+      );
+      await service.writeConfig(
+        service.generateClashConfig(_subscriptionYaml, settings),
+      );
+
+      final start = service.start();
+      await service.dataPathProbeStarted.future.timeout(
+        const Duration(seconds: 10),
+      );
+
+      expect(await start.timeout(const Duration(milliseconds: 100)), isTrue);
+      expect(service.isRunning, isTrue);
       expect(tunSession.stopCalls, 0);
     });
 
@@ -1715,13 +1793,13 @@ void main() {
         ..updateSettings(AppSettings(enableTun: false));
 
       expect(await service.start(), isFalse);
-      expect(service.lastStartError, 'Mihomo service is not initialized');
+      expect(service.lastStartError, contains('尚未初始化'));
     });
 
     test(
         'API failure plus external proxy takeover disconnects without reacquiring proxy',
         () async {
-      final notices = <String>[];
+      final notices = <RuntimeNotice>[];
       final service = _ExternalProxyTakeoverRecoveryClashService()
         ..onRuntimeNotice = notices.add;
       addTearDown(service.dispose);
@@ -1749,15 +1827,34 @@ void main() {
       expect(service.connectionDesired, isFalse);
       expect(service.isRunning, isFalse);
       expect(
-        notices.single,
+        notices.single.message,
         allOf(contains('其他程序'), contains('不会覆盖')),
       );
+    });
+
+    test('a stale health probe cannot cancel a newer connection intent',
+        () async {
+      final service = _StaleHealthProbeRecoveryClashService();
+      addTearDown(service.dispose);
+      final oldGeneration = service.requestConnectionIntent(true);
+      service.setRunning(true);
+
+      final recovery = service.recoverAfterHealthCheckFailure(oldGeneration);
+      await service.healthProbeStarted.future;
+      service.requestConnectionIntent(true);
+      service.releaseHealthProbe.complete();
+
+      expect(await recovery, isFalse);
+      expect(service.connectionDesired, isTrue);
+      expect(service.isRunning, isTrue);
+      expect(service.stopCalls, 0);
+      expect(service.proxyOwnershipInspectionCalls, 0);
     });
 
     test(
         'unexpected core exit clears external takeover state without restarting or reacquiring',
         () async {
-      final notices = <String>[];
+      final notices = <RuntimeNotice>[];
       final service = _ExternalProxyTakeoverRecoveryClashService()
         ..onRuntimeNotice = notices.add;
       addTearDown(service.dispose);
@@ -1796,7 +1893,7 @@ void main() {
     test(
         'proxy ownership change during health cleanup blocks automatic reacquisition',
         () async {
-      final notices = <String>[];
+      final notices = <RuntimeNotice>[];
       final service = _ProxyChangedDuringCleanupRecoveryClashService()
         ..onRuntimeNotice = notices.add;
       addTearDown(service.dispose);
@@ -1822,7 +1919,7 @@ void main() {
       expect(service.automaticRecoveryStartCalls, 0);
       expect(service.connectionDesired, isFalse);
       expect(
-        notices.last,
+        notices.last.message,
         allOf(contains('清理期间'), contains('不会重新接管')),
       );
     });
@@ -1859,7 +1956,7 @@ void main() {
 
     test('unavailable proxy ownership disconnects without reacquiring proxy',
         () async {
-      final notices = <String>[];
+      final notices = <RuntimeNotice>[];
       final service = _UnavailableProxyOwnershipRecoveryClashService()
         ..onRuntimeNotice = notices.add;
       addTearDown(service.dispose);
@@ -1881,13 +1978,16 @@ void main() {
       expect(service.prepareCalls, 0);
       expect(service.automaticRecoveryStartCalls, 0);
       expect(service.connectionDesired, isFalse);
-      expect(notices.single, allOf(contains('无法确认'), contains('不会覆盖')));
+      expect(
+        notices.single.message,
+        allOf(contains('无法确认'), contains('不会覆盖')),
+      );
     });
 
     test(
         'proxy ownership cleanup failure cancels recovery without false success',
         () async {
-      final notices = <String>[];
+      final notices = <RuntimeNotice>[];
       final service = _FailingProxyOwnershipCleanupClashService()
         ..onRuntimeNotice = notices.add;
       addTearDown(service.dispose);
@@ -1910,10 +2010,10 @@ void main() {
       expect(service.connectionDesired, isFalse);
       expect(service.isRunning, isFalse);
       expect(
-        notices.single,
+        notices.single.message,
         allOf(contains('清理状态无法确认'), contains('不会重新接管')),
       );
-      expect(notices.single, isNot(contains('已安全断开')));
+      expect(notices.single.message, isNot(contains('已安全断开')));
     });
 
     test('health recovery rebuilds runtime config before automatic start',
@@ -1969,6 +2069,65 @@ void main() {
         service.calls.where((call) => call == 'recovery-start'),
         hasLength(2),
       );
+    });
+
+    test(
+        'stale queued unexpected exit stays silent and preserves recovery budget',
+        () async {
+      final notices = <RuntimeNotice>[];
+      final oldProgress = Completer<void>();
+      var processExitCalls = 0;
+      final service = _SerializedUnexpectedExitRecoveryClashService()
+        ..onRuntimeNotice = (notice) {
+          notices.add(notice);
+          if (notice.level == RuntimeNoticeLevel.progress &&
+              !oldProgress.isCompleted) {
+            oldProgress.complete();
+          }
+        }
+        ..onProcessExit = () => processExitCalls++;
+      addTearDown(service.dispose);
+      service.rememberDesktopConnectionRecoveryPlan(
+        preferredSettings: AppSettings(),
+        generateConfig: (runtimeSettings, preferredNodeName) async =>
+            'mixed-port: ${runtimeSettings.proxyPort}',
+        isRevisionCurrent: () => true,
+      );
+      final oldGeneration = service.requestConnectionIntent(true);
+      service.setRunning(false);
+
+      final queueEntered = Completer<void>();
+      final releaseQueue = Completer<void>();
+      final occupied = service.runConnectionTransition(() async {
+        queueEntered.complete();
+        await releaseQueue.future;
+      });
+      await queueEntered.future;
+
+      final staleRecovery = service.simulateUnexpectedExit(oldGeneration);
+      await Future.any<void>([
+        oldProgress.future,
+        Future<void>.delayed(const Duration(milliseconds: 50)),
+      ]);
+      final currentGeneration = service.requestConnectionIntent(true);
+
+      releaseQueue.complete();
+      await occupied;
+      await staleRecovery;
+
+      expect(notices, isEmpty);
+      expect(processExitCalls, 0);
+      expect(service.lastUnexpectedExitRuntimeNotice, isNull);
+      expect(service.automaticRecoveryStartCalls, 0);
+
+      await service.simulateUnexpectedExit(currentGeneration);
+      expect(service.automaticRecoveryStartCalls, 1);
+      expect(service.isRunning, isTrue);
+
+      service.setRunning(false);
+      await service.simulateUnexpectedExit(currentGeneration);
+      expect(service.automaticRecoveryStartCalls, 2);
+      expect(service.isRunning, isTrue);
     });
 
     test('legacy core symlinks are replaced without touching their targets',
@@ -2170,12 +2329,58 @@ class _ExternalProxyTakeoverRecoveryClashService extends ClashService {
   }
 }
 
+class _SerializedUnexpectedExitRecoveryClashService extends ClashService {
+  int automaticRecoveryStartCalls = 0;
+
+  Future<void> simulateUnexpectedExit(int generation) =>
+      runUnexpectedExitRecovery(generation: generation, exitCode: 17);
+
+  @override
+  Future<SystemProxyOwnershipStatus> inspectSystemProxyOwnership() async =>
+      SystemProxyOwnershipStatus.owned;
+
+  @override
+  Future<bool> clearSystemProxyAfterUnexpectedExit() async => true;
+
+  @override
+  Future<void> stop() async => setRunning(false);
+
+  @override
+  Future<AppSettings> prepareForStart(AppSettings preferred) async {
+    updateSettings(preferred);
+    return preferred;
+  }
+
+  @override
+  Future<void> writeConfig(String configContent) async {}
+
+  @override
+  Future<bool> startForAutomaticRecovery() async {
+    automaticRecoveryStartCalls++;
+    setRunning(true);
+    return true;
+  }
+}
+
 class _UnavailableProxyOwnershipRecoveryClashService
     extends _ExternalProxyTakeoverRecoveryClashService {
   @override
   Future<SystemProxyOwnershipStatus> inspectSystemProxyOwnership() async {
     proxyOwnershipInspectionCalls++;
     return SystemProxyOwnershipStatus.unavailable;
+  }
+}
+
+class _StaleHealthProbeRecoveryClashService
+    extends _ExternalProxyTakeoverRecoveryClashService {
+  final Completer<void> healthProbeStarted = Completer<void>();
+  final Completer<void> releaseHealthProbe = Completer<void>();
+
+  @override
+  Future<bool> healthCheck() async {
+    healthProbeStarted.complete();
+    await releaseHealthProbe.future;
+    return false;
   }
 }
 
@@ -2247,6 +2452,18 @@ class _ApiHealthyClashService extends ClashService {
   Future<bool> checkMihomoApiHealth() async => true;
 }
 
+class _UncertainProxyOwnershipClashService extends ClashService {
+  SystemProxyOwnershipStatus ownershipStatus =
+      SystemProxyOwnershipStatus.unavailable;
+
+  @override
+  Future<bool> checkMihomoApiHealth() async => true;
+
+  @override
+  Future<SystemProxyOwnershipStatus> inspectSystemProxyOwnership() async =>
+      ownershipStatus;
+}
+
 String _effectiveProxyOutput(int port) => '''<dictionary> {
   HTTPEnable : 1
   HTTPPort : $port
@@ -2281,6 +2498,28 @@ class _TunDataPathClashService extends ClashService
     bool Function()? shouldContinue,
   }) async =>
       '已连接，但连续 3 次网络验证失败，请尝试切换节点或刷新订阅';
+}
+
+class _BlockingStartupDataPathClashService extends ClashService
+    with _HealthyTunRuntimeConfig {
+  _BlockingStartupDataPathClashService({required super.tunSession});
+
+  final Completer<void> dataPathProbeStarted = Completer<void>();
+  final Completer<String?> dataPathResult = Completer<String?>();
+
+  @override
+  Future<bool> checkMihomoApiHealth() async => true;
+
+  @override
+  Future<String?> verifyUserConnectivity({
+    int maxAttempts = 3,
+    Duration retryDelay = const Duration(seconds: 2),
+    Future<http.Response> Function(Uri uri)? request,
+    bool Function()? shouldContinue,
+  }) {
+    if (!dataPathProbeStarted.isCompleted) dataPathProbeStarted.complete();
+    return dataPathResult.future;
+  }
 }
 
 class _TunHealthyClashService extends ClashService

--- a/SSRVPN_MacOS/test/desktop_home_screen_test.dart
+++ b/SSRVPN_MacOS/test/desktop_home_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
+import 'package:ssrvpn_shared/runtime_notice.dart';
 import 'package:ssrvpn_macos/app.dart' as desktop_app;
 import 'package:ssrvpn_macos/screens/home_screen.dart';
 import 'package:ssrvpn_macos/services/clash_service.dart';
@@ -205,7 +206,9 @@ void main() {
       ),
     );
     await tester.pump();
-    const runtimeNotice = '连接未完成：本地端口被其他应用占用，已保留原有配置与系统代理恢复状态，请稍后重试连接。';
+    const runtimeNotice = RuntimeNotice.error(
+      '连接未完成：本地端口被其他应用占用，已保留原有配置与系统代理恢复状态，请稍后重试连接。',
+    );
     fixture.clash.onRuntimeNotice?.call(runtimeNotice);
     await tester.pump();
 
@@ -434,6 +437,152 @@ void main() {
     await tester.pump();
     await _pumpUntil(tester, () => fixture.clash.isRunning);
     expect(fixture.clash.lastPreferredNodeName, '新加坡节点');
+  });
+
+  testWidgets(
+      'successful connection stays live and warns when node persistence fails',
+      (tester) async {
+    final fixture = (await tester.runAsync(
+      () => _HomeFixture.create(
+        withNodes: true,
+        failSettingsWrites: true,
+      ),
+    ))!;
+    addTearDown(fixture.dispose);
+    fixture.clash
+      ..switchResult = true
+      ..runtimeSelectedNodeName = '东京节点';
+
+    await tester.pumpWidget(fixture.build());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    await tester.tap(find.byKey(const Key('ssrvpn-power-button')));
+    await tester.pump();
+    await _pumpUntil(tester, () => fixture.clash.isRunning);
+    expect(fixture.clash.lastPreferredNodeName, '东京节点');
+    expect(fixture.clash.lastSwitchAttempt, '东京节点');
+    expect(fixture.settings.settings.lastSelectedNodeName, isNull);
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 150));
+    await _pumpUntil(tester, () => find.text('已连接').evaluate().isNotEmpty);
+    await _pumpUntil(
+      tester,
+      () => find.text('已连接，但首选节点保存失败').evaluate().isNotEmpty,
+    );
+
+    expect(fixture.clash.isRunning, isTrue);
+    expect(fixture.settings.settings.lastSelectedNodeName, isNull);
+    expect(find.text('已连接'), findsWidgets);
+    expect(find.textContaining('连接失败'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('ssrvpn-current-node-card')),
+        matching: find.text('东京节点'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      'successful live switch stays selected and warns when persistence fails',
+      (tester) async {
+    final fixture = (await tester.runAsync(
+      () => _HomeFixture.create(
+        withNodes: true,
+        running: true,
+        failSettingsWrites: true,
+      ),
+    ))!;
+    addTearDown(fixture.dispose);
+    fixture.clash
+      ..switchResult = true
+      ..runtimeSelectedNodeName = '东京节点';
+
+    await tester.pumpWidget(fixture.build());
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ssrvpn-current-node-card')));
+    await tester.pumpAndSettle();
+    final selector = tester.widget<SsrvpnNodeSelectionPage>(
+      find.byType(SsrvpnNodeSelectionPage),
+    );
+    final node = selector.nodesOf().singleWhere(
+          (candidate) => candidate.name == '新加坡节点',
+        );
+    await tester.runAsync(() => selector.onSelectNode(node));
+    await tester.pump();
+
+    expect(fixture.clash.isRunning, isTrue);
+    expect(fixture.settings.settings.lastSelectedNodeName, isNull);
+    expect(find.text('已切换，但首选节点保存失败: 新加坡节点'), findsOneWidget);
+    expect(find.text('切换失败: 新加坡节点'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('ssrvpn-node-card-新加坡节点')),
+        matching: find.byIcon(Icons.check_circle_rounded),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      'failed preferred-node switch keeps the initial connection and warns with the runtime node',
+      (tester) async {
+    final fixture =
+        (await tester.runAsync(() => _HomeFixture.create(withNodes: true)))!;
+    addTearDown(fixture.dispose);
+    fixture.clash
+      ..switchResult = false
+      ..runtimeSelectedNodeName = '新加坡节点';
+
+    await tester.pumpWidget(fixture.build());
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ssrvpn-power-button')));
+    await tester.pump();
+    await _pumpUntil(tester, () => fixture.clash.isRunning);
+    await _pumpUntil(
+      tester,
+      () => find
+          .text('未能切换到首选节点“东京节点”，当前连接仍保留，正在使用“新加坡节点”。')
+          .evaluate()
+          .isNotEmpty,
+    );
+
+    expect(fixture.clash.isRunning, isTrue);
+    expect(fixture.clash.connectionDesired, isTrue);
+    expect(find.text('已连接'), findsWidgets);
+  });
+
+  testWidgets(
+      'failed preferred-node switch keeps a reloaded connection and warns with the runtime node',
+      (tester) async {
+    final fixture = (await tester.runAsync(
+      () => _HomeFixture.create(withNodes: true, running: true),
+    ))!;
+    addTearDown(fixture.dispose);
+    fixture.clash
+      ..switchResult = false
+      ..runtimeSelectedNodeName = '新加坡节点'
+      ..requestConnectionIntent(true);
+
+    await tester.pumpWidget(fixture.build());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    await tester.runAsync(
+      () => fixture.subscription.setRawYaml('$_nodeYaml\n# reloaded'),
+    );
+    await tester.pump();
+    await _pumpUntil(tester, () => fixture.clash.startCalls == 1);
+    await _pumpUntil(
+      tester,
+      () => find
+          .text('未能切换到首选节点“东京节点”，当前连接仍保留，正在使用“新加坡节点”。')
+          .evaluate()
+          .isNotEmpty,
+    );
+
+    expect(fixture.clash.isRunning, isTrue);
+    expect(fixture.clash.connectionDesired, isTrue);
+    expect(find.text('已连接'), findsWidgets);
   });
 
   for (final switchResult in [false, true]) {
@@ -1029,6 +1178,7 @@ class _HomeFixture {
     required bool withNodes,
     bool recordBatchLatencyResults = true,
     bool running = false,
+    bool failSettingsWrites = false,
   }) async {
     SubscriptionService.resetInstanceForTesting();
     final directory = Directory.systemTemp.createTempSync('ssrvpn_home_');
@@ -1038,7 +1188,9 @@ class _HomeFixture {
       settings: AppSettings(),
       dataDir: directory.path,
       settingsPath: '${directory.path}/settings.json',
-      writeSettings: (_) => SynchronousFuture<void>(null),
+      writeSettings: (_) => failSettingsWrites
+          ? Future<void>.error(StateError('disk full'))
+          : SynchronousFuture<void>(null),
       readApiSecret: () async => '',
       writeApiSecret: (_) async {},
     );

--- a/SSRVPN_MacOS/test/startup_status_retry_test.dart
+++ b/SSRVPN_MacOS/test/startup_status_retry_test.dart
@@ -2,6 +2,20 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ssrvpn_macos/startup/startup_status.dart';
 
 void main() {
+  test('startup failures never expose raw local details', () {
+    final status = StartupStatus.forTesting();
+
+    status.reportFailure(
+      'mihomo_core',
+      StateError('launch failed at /Users/example/private/credential.bin'),
+    );
+
+    final message = status.failures.single.message;
+    expect(message, contains('操作未完成'));
+    expect(message, isNot(contains('/Users/example')));
+    expect(message, isNot(contains('credential.bin')));
+  });
+
   test('core retry retires the prior failure and returns to running state', () {
     final status = StartupStatus.forTesting();
     status.markStarting();

--- a/SSRVPN_Windows/lib/app.dart
+++ b/SSRVPN_Windows/lib/app.dart
@@ -20,7 +20,9 @@ import 'package:ssrvpn_shared/ssrvpn_shared.dart'
         SsrvpnAppBackdrop,
         SsrvpnBottomNavigation,
         UpdateAvailabilityController,
-        desktopSubscriptionChangedMessage;
+        desktopSubscriptionChangedMessage,
+        safeUserFacingFailureMessage,
+        safeUserFacingFailureWithAction;
 import 'package:ssrvpn_shared/widgets/crash_report_prompt.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -45,6 +47,13 @@ part 'package:ssrvpn_shared/desktop_ui/desktop_app_shell_part.dart';
 part 'app_runtime_actions_part.dart';
 part 'app_startup_shell_part.dart';
 
+@visibleForTesting
+String windowsApiSecretRecoveryFailureMessage(Object error) =>
+    '恢复失败：${safeUserFacingFailureWithAction(
+      error,
+      '旧密文和用户数据仍已保留，请重试。',
+    )}';
+
 class SSRVpnApp extends StatefulWidget {
   const SSRVpnApp({super.key, required this.startupFlags});
 
@@ -59,7 +68,8 @@ class _SSRVpnAppState extends State<SSRVpnApp> with WindowListener {
 
   int _currentIndex = 0;
   bool _isQuitting = false;
-  String? _runtimeNotice;
+  RuntimeNotice? _runtimeNotice;
+  bool _lastObservedCoreRunning = false;
   Timer? _runtimeNoticeAutoClearTimer;
   bool _windowListenerAttached = false;
   Timer? _windowStateSaveDebounce;
@@ -134,6 +144,7 @@ class _SSRVpnAppState extends State<SSRVpnApp> with WindowListener {
       _clashService?.removeStatusListener(_handleCoreStatusChanged);
       _clashService?.onRuntimeNotice = null;
       _clashService = nextClashService;
+      _lastObservedCoreRunning = nextClashService.isRunning;
       _clashService!.addStatusListener(_handleCoreStatusChanged);
       _clashService!.onRuntimeNotice = (message) {
         unawaited(_presentRuntimeNotice(message));
@@ -205,20 +216,21 @@ class _SSRVpnAppState extends State<SSRVpnApp> with WindowListener {
     return HomeNodeController.resolveDefaultNodeFrom(nodes, remembered)?.name;
   }
 
-  Future<void> _presentTrayFailure(String reason) =>
-      _presentRuntimeNotice('连接失败：$reason');
+  Future<void> _presentTrayFailure(String reason) => _presentRuntimeNotice(
+        RuntimeNotice.error(safeUserFacingFailureMessage(reason)),
+      );
 
-  Future<void> _presentRuntimeNotice(String message) async {
+  Future<void> _presentRuntimeNotice(RuntimeNotice notice) async {
     _runtimeNoticeAutoClearTimer?.cancel();
     _runtimeNoticeAutoClearTimer = null;
     if (mounted) {
       setState(() {
-        _runtimeNotice = message;
+        _runtimeNotice = notice;
         _currentIndex = 0;
       });
       _runtimeNoticeAutoClearTimer = scheduleSuccessfulRuntimeNoticeClear(
-        message: message,
-        currentMessage: () => _runtimeNotice,
+        notice: notice,
+        currentNotice: () => _runtimeNotice,
         clear: _clearRuntimeNotice,
       );
     }
@@ -256,12 +268,14 @@ class _SSRVpnAppState extends State<SSRVpnApp> with WindowListener {
   }
 
   void _handleCoreStatusChanged() {
-    if (mounted &&
-        (_clashService?.isRunning ?? false) &&
-        _runtimeNotice != null &&
-        !isSuccessfulRuntimeNotice(_runtimeNotice)) {
-      _clearRuntimeNotice();
-    }
+    final isRunning = _clashService?.isRunning ?? false;
+    final clearStaleNotice = shouldClearRuntimeNoticeOnRunningEdge(
+      wasRunning: _lastObservedCoreRunning,
+      isRunning: isRunning,
+      notice: _runtimeNotice,
+    );
+    _lastObservedCoreRunning = isRunning;
+    if (clearStaleNotice) _clearRuntimeNotice();
     _refreshTrayStatus();
   }
 
@@ -337,7 +351,13 @@ class _SSRVpnAppState extends State<SSRVpnApp> with WindowListener {
           .toString()
           .replaceFirst('Bad state: ', '')
           .replaceFirst('StateError: ', '');
-      await _presentRuntimeNotice('退出未完成：$reason。请稍后再次退出');
+      final message = safeUserFacingFailureWithAction(
+        reason,
+        '请稍后再次退出。',
+      );
+      await _presentRuntimeNotice(
+        RuntimeNotice.error('退出未完成：$message'),
+      );
       return false;
     }
     return true;
@@ -438,7 +458,7 @@ class _SSRVpnAppState extends State<SSRVpnApp> with WindowListener {
       if (!mounted) return;
       setState(() {
         _secretRecoveryInProgress = false;
-        _secretRecoveryError = '恢复失败：$error。旧密文和用户数据仍已保留，请重试。';
+        _secretRecoveryError = windowsApiSecretRecoveryFailureMessage(error);
       });
     }
   }

--- a/SSRVPN_Windows/lib/app_runtime_actions_part.dart
+++ b/SSRVPN_Windows/lib/app_runtime_actions_part.dart
@@ -152,9 +152,19 @@ extension _WindowsAppRuntimeActions on _SSRVpnAppState {
           );
         }
       }
+      final preferredNodeWarning = connectionResult.preferredNodeSwitchWarning(
+        preferredNodeName: preferredNodeName,
+      );
       final portAdjustmentNotice = connectionResult.runtimeNotice;
-      if (portAdjustmentNotice != null && portAdjustmentNotice.isNotEmpty) {
-        await _presentRuntimeNotice(portAdjustmentNotice);
+      if (preferredNodeWarning != null) {
+        await _presentRuntimeNotice(
+          RuntimeNotice.warning(preferredNodeWarning),
+        );
+      } else if (portAdjustmentNotice != null &&
+          portAdjustmentNotice.isNotEmpty) {
+        await _presentRuntimeNotice(
+          RuntimeNotice.success(portAdjustmentNotice),
+        );
       }
     } catch (error, stack) {
       final isCurrent = connectionGeneration != null &&

--- a/SSRVPN_Windows/lib/services/clash_service.dart
+++ b/SSRVPN_Windows/lib/services/clash_service.dart
@@ -77,13 +77,10 @@ class ClashService extends ClashServiceBase
   }
 
   @override
-  void log(String message) {
-    super.log(message);
+  void writePlatformLog(String line) {
     final fileLogger = _fileLogger;
     if (fileLogger != null) {
-      final sanitized = LogRedactor.sanitize(message);
-      final line = '[${DateTime.now().toIso8601String()}] $sanitized\r\n';
-      fileLogger.add(line);
+      fileLogger.add('$line\r\n');
     }
   }
 
@@ -205,7 +202,7 @@ class ClashService extends ClashServiceBase
       throw StateError(_startupDisabledReason!);
     }
     if (configPath.isEmpty) {
-      throw StateError('Mihomo service is not initialized');
+      throw StateError('连接服务尚未初始化，请重启 SSRVPN；若仍失败，请重新安装官方版本');
     }
     final file = File(configPath);
     final temp = File('$configPath.tmp');

--- a/SSRVPN_Windows/lib/services/clash_service_lifecycle.dart
+++ b/SSRVPN_Windows/lib/services/clash_service_lifecycle.dart
@@ -18,7 +18,7 @@ enum _VerifiedCoreTermination {
 const _tunTeardownTimeoutError = '核心已停止，但 Windows TUN 网卡未在超时前移除；'
     '为避免路由冲突，已阻止再次连接，请保持 SSRVPN 打开并重试断开';
 const _tunResidualProbeError = '无法确认旧 Windows TUN 网卡和路由已清理；'
-    '为避免死路由，已在启动 Mihomo 前安全中止';
+    '为避免死路由，已在启动本地代理服务前安全中止';
 
 Future<bool> terminateCoreProcess(
   Process process, {
@@ -64,6 +64,7 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
   bool _stoppingCore = false;
   bool _proxyRecoveryListenerActive = false;
   WindowsTunRuntimeStatus? _lastTunRuntimeObservation;
+  DateTime? _lastTunDataPlaneObservationAt;
   final CoreRecoveryPolicy _unexpectedExitRecoveryPolicy = CoreRecoveryPolicy(
     maxAttempts: 2,
   );
@@ -85,6 +86,19 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
   String get corePath => _corePath;
   bool get hasPendingSystemProxyRecovery => _proxyService.recoveryPending;
 
+  @override
+  @protected
+  Duration get healthCheckTimeout => const Duration(seconds: 25);
+
+  @protected
+  Duration get tunDataPlaneObservationInterval => const Duration(seconds: 30);
+
+  @protected
+  void resetTunDataPlaneObservationSession() {
+    _lastTunDataPlaneObservationAt = null;
+    clearConnectivityWarningSilently();
+  }
+
   @protected
   Future<SystemProxyOwnershipStatus> inspectSystemProxyOwnership() =>
       _proxyService.currentSystemProxyOwnershipStatus();
@@ -103,15 +117,32 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
       if (isRunning || _proxyService.isProxyEnabled) {
         final ownershipStatus = await inspectSystemProxyOwnership();
         if (ownershipStatus == SystemProxyOwnershipStatus.owned) {
+          if (connectivityWarning ==
+              desktopSystemProxyOwnershipUnavailableWarning) {
+            setConnectivityWarning(null);
+          }
           setLastHealthCheckError(null);
           return true;
         }
+        if (ownershipStatus == SystemProxyOwnershipStatus.unavailable) {
+          setLastHealthCheckError(null);
+          if (connectivityWarning !=
+              desktopSystemProxyOwnershipUnavailableWarning) {
+            log(
+              '系统代理所有权探针暂时不可用；Mihomo API 正常，保留当前连接',
+              level: RuntimeLogLevel.warning,
+              event: 'system_proxy_health',
+            );
+          }
+          setConnectivityWarning(
+            desktopSystemProxyOwnershipUnavailableWarning,
+          );
+          return true;
+        }
         final ownershipError = _proxyService.lastError ?? 'Windows 系统代理所有权无法确认';
-        final prefix =
-            ownershipStatus == SystemProxyOwnershipStatus.externallyChanged
-                ? desktopSystemProxyOwnershipLostPrefix
-                : desktopSystemProxyOwnershipUnavailablePrefix;
-        setLastHealthCheckError('$prefix $ownershipError');
+        setLastHealthCheckError(
+          '$desktopSystemProxyOwnershipLostPrefix $ownershipError',
+        );
         return false;
       }
       return true;
@@ -129,6 +160,61 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
     // route probe advisory so a false negative cannot tear down live traffic.
     setLastHealthCheckError(null);
     return true;
+  }
+
+  @override
+  @protected
+  void onPeriodicHealthCheckResult(bool healthy) {
+    if (!healthy) {
+      _unexpectedExitRecoveryPolicy.recordUnhealthy();
+      return;
+    }
+    if (_unexpectedExitRecoveryPolicy.recordHealthy(DateTime.now())) {
+      log(
+        '连接达到稳定健康观察窗口，自动恢复次数预算已复位',
+        event: 'health_recovery',
+      );
+    }
+  }
+
+  @override
+  @protected
+  Future<void> observeDataPlaneHealth() async {
+    if (!isRunning || !settings.enableTun) return;
+    final now = DateTime.now();
+    final lastObservedAt = _lastTunDataPlaneObservationAt;
+    if (lastObservedAt != null &&
+        now.difference(lastObservedAt) < tunDataPlaneObservationInterval) {
+      return;
+    }
+    final generation = captureAutomaticRestartIntent();
+    if (generation == null) return;
+    _lastTunDataPlaneObservationAt = now;
+    final warning = await verifyUserConnectivity(
+      maxAttempts: 2,
+      retryDelay: const Duration(seconds: 1),
+      shouldContinue: () =>
+          isRunning &&
+          settings.enableTun &&
+          isConnectionIntentCurrent(generation, connected: true),
+    );
+    if (!isRunning ||
+        !settings.enableTun ||
+        !isConnectionIntentCurrent(generation, connected: true)) {
+      return;
+    }
+    if (warning == null) {
+      setConnectivityWarning(null);
+      return;
+    }
+    setConnectivityWarning(
+      '连接与 Windows TUN 仍在运行；外部网络观察暂未通过，仅供参考：$warning',
+    );
+    log(
+      '外部网络观察未通过: $warning；未断开连接，未切换节点',
+      level: RuntimeLogLevel.warning,
+      event: 'data_plane_probe',
+    );
   }
 
   void _recordTunRuntimeObservation(WindowsTunRuntimeStatus status) {
@@ -219,11 +305,8 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
   }
 
   // ── Lifecycle overrides ──
-
   @override
-  Future<void> onStopRequired() async {
-    await stop();
-  }
+  Future<void> onStopRequired() => stop();
 
   @override
   Future<bool> recoverAfterHealthCheckFailure(int connectionGeneration) async {
@@ -231,7 +314,11 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
       await stop();
       return false;
     }
-    if (await healthCheck()) {
+    final healthy = await healthCheck();
+    if (!isConnectionIntentCurrent(connectionGeneration, connected: true)) {
+      return false;
+    }
+    if (healthy) {
       setRunning(true);
       return true;
     }
@@ -240,10 +327,12 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
       // returns as soon as the API is unavailable, so inspect ownership again
       // immediately before any stop/restart that could reacquire the proxy.
       final ownershipStatus = await inspectSystemProxyOwnership();
+      if (!isConnectionIntentCurrent(connectionGeneration, connected: true)) {
+        return false;
+      }
       if (ownershipStatus != SystemProxyOwnershipStatus.owned) {
         final externallyChanged =
             ownershipStatus == SystemProxyOwnershipStatus.externallyChanged;
-        final ownershipDetail = _proxyService.lastError?.trim();
         // Invalidate intent before asynchronous cleanup so neither the health
         // monitor nor an in-flight recovery can reacquire the system proxy.
         markConnectionLost();
@@ -252,17 +341,19 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
         } catch (error) {
           log('系统代理所有权失效后的核心清理未完成: $error');
           notifyRuntimeNotice(
-            '已取消自动重连，但系统代理或 Mihomo 核心清理状态无法确认；'
-            '请在诊断页检查并重试断开，SSRVPN 不会重新接管代理。',
+            const RuntimeNotice.error(
+              '已取消自动重连，但系统代理或本地代理服务的清理状态无法确认；'
+              '请在诊断页检查并重试断开，SSRVPN 不会重新接管代理。',
+            ),
           );
           return false;
         }
         notifyRuntimeNotice(
-          externallyChanged
-              ? ownershipDetail != null && ownershipDetail.isNotEmpty
-                  ? '$ownershipDetail。SSRVPN 已安全断开且不会覆盖当前代理。'
-                  : '检测到系统代理已被其他程序接管，SSRVPN 已安全断开且不会覆盖当前代理。'
-              : '无法确认当前系统代理所有权，SSRVPN 已安全断开且不会覆盖未知代理状态。',
+          RuntimeNotice.warning(
+            externallyChanged
+                ? '检测到系统代理已被其他程序接管，SSRVPN 已安全断开且不会覆盖当前代理。'
+                : '无法确认当前系统代理所有权，SSRVPN 已安全断开且不会覆盖未知代理状态。',
+          ),
         );
         return false;
       }
@@ -273,9 +364,11 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
     }
 
     notifyRuntimeNotice(
-      'Mihomo 持续失去响应，正在执行安全重启'
-      '（${_unexpectedExitRecoveryPolicy.attempts}/'
-      '${_unexpectedExitRecoveryPolicy.maxAttempts}）…',
+      RuntimeNotice.progress(
+        '运行状态持续异常，正在执行安全重启'
+        '（${_unexpectedExitRecoveryPolicy.attempts}/'
+        '${_unexpectedExitRecoveryPolicy.maxAttempts}）…',
+      ),
     );
     try {
       await stop();
@@ -290,8 +383,10 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
         systemProxyOwnershipChangedSinceLastAcquisition) {
       markConnectionLost();
       notifyRuntimeNotice(
-        '系统代理在清理期间发生变化，已取消自动重连；'
-        'SSRVPN 不会重新接管当前代理。',
+        const RuntimeNotice.warning(
+          '系统代理在清理期间发生变化，已取消自动重连；'
+          'SSRVPN 不会重新接管当前代理。',
+        ),
       );
       return false;
     }
@@ -570,7 +665,7 @@ exit 4
           windowsPowerShellUtf8Script(script),
         ],
         timeout: timeout,
-        timeoutStderr: '电脑性能不足，请重新连接',
+        timeoutStderr: 'Windows PowerShell 命令响应超时；可能是系统繁忙或安全软件暂时拦截，请稍后重试',
         cancellation: cancellation,
       );
 
@@ -683,7 +778,7 @@ try {
       return false;
     }
     if (_corePath.isEmpty || configDir.isEmpty || configPath.isEmpty) {
-      setLastStartError('Mihomo service is not initialized');
+      setLastStartError('连接服务尚未初始化，请重启 SSRVPN；若仍失败，请重新安装官方版本');
       log(lastStartError!);
       return false;
     }
@@ -821,8 +916,10 @@ try {
             if (!memoryCleanup.releaseProcessReference) {
               setLastStartError('Mihomo 进程身份清理无法安全完成，已阻止自动重启');
               notifyRuntimeNotice(
-                '连接已断开；检测到进程身份记录异常，为避免误清理其他进程，'
-                '本次不会自动重连。请重新安装或联系支持。',
+                const RuntimeNotice.error(
+                  '连接已断开；检测到进程身份记录异常，为避免误清理其他进程，'
+                  '本次不会自动重连。请重新安装或联系支持。',
+                ),
               );
             }
             if (memoryCleanup.clearConnectionIntent) {
@@ -965,11 +1062,13 @@ try {
           );
         }
         _proxyRecoveryListenerActive = preserveSystemProxyRecovery;
+        if (startedWithTun) resetTunDataPlaneObservationSession();
         setRunning(true);
         resetHealthCheckFailures();
         log('✅ Mihomo API 就绪，耗时 ${startupWatch.elapsedMilliseconds}ms');
         notifyStatusChanged();
         startStatusMonitor();
+        if (startedWithTun) scheduleDataPlaneObservation();
       },
       rollback: _cleanupFailedStart,
       isCancellation: (error) => error is _DesktopStartCancelled,
@@ -1050,6 +1149,7 @@ try {
         : const <WindowsTunInterfaceIdentity>{};
     stopStatusMonitor();
     resetHealthCheckFailures();
+    resetTunDataPlaneObservationSession();
 
     // Restore Windows networking while the local proxy is still alive. Keep
     // the core only while Windows may still point at its local endpoint; once
@@ -1076,8 +1176,10 @@ try {
       final warning = _proxyService.lastError ?? 'SSRVPN 代理端点已安全释放，但恢复日志仍待清理';
       log('⚠️ $warning');
       notifyRuntimeNotice(
-        '连接已安全断开，但 Windows 代理恢复日志仍待清理；请保持 SSRVPN '
-        '打开并使用“诊断”重试，清理完成前不要强制退出。',
+        const RuntimeNotice.warning(
+          '连接已安全断开，但 Windows 代理恢复日志仍待清理；请保持 SSRVPN '
+          '打开并使用“诊断”重试，清理完成前不要强制退出。',
+        ),
       );
     }
     if (_proxyService.recoveryPending && _proxyService.lastError != null) {
@@ -1359,6 +1461,15 @@ try {
     }
   }
 
+  @protected
+  Future<bool> waitForUnexpectedExitTunTeardown() => _waitForTunTeardown();
+
+  bool _hasActiveUnexpectedExitRecoveryIntent(int? generation) =>
+      hasActiveUnexpectedExitRecoveryIntent(
+        generation,
+        (value) => isConnectionIntentCurrent(value, connected: true),
+      );
+
   Future<void> _recoverFromUnexpectedExit(
     int? generation,
     int exitCode,
@@ -1374,23 +1485,21 @@ try {
       final externallyChanged = proxyCleanup.ownershipBeforeClear ==
           SystemProxyOwnershipStatus.externallyChanged;
       notifyRuntimeNotice(
-        proxyCleared
-            ? (changedDuringClear
-                ? '核心异常退出；系统代理在清理期间发生变化，SSRVPN '
-                    '已取消自动重连，不会重新接管当前代理。'
-                : externallyChanged
-                    ? '核心异常退出；检测到系统代理已由其他程序接管，SSRVPN 已清理自身恢复状态并取消自动重连，未覆盖当前代理。'
-                    : '核心异常退出；此前无法确认系统代理所有权，SSRVPN 已完成清理并取消自动重连，不会重新接管代理。')
-            : '核心异常退出；已取消自动重连，但系统代理恢复状态清理无法确认。'
-                '请在诊断页检查并重试断开，SSRVPN 不会重新接管代理。',
+        RuntimeNotice.error(
+          proxyCleared
+              ? (changedDuringClear
+                  ? '核心异常退出；系统代理在清理期间发生变化，SSRVPN '
+                      '已取消自动重连，不会重新接管当前代理。'
+                  : externallyChanged
+                      ? '核心异常退出；检测到系统代理已由其他程序接管，SSRVPN 已清理自身恢复状态并取消自动重连，未覆盖当前代理。'
+                      : '核心异常退出；此前无法确认系统代理所有权，SSRVPN 已完成清理并取消自动重连，不会重新接管代理。')
+              : '核心异常退出；已取消自动重连，但系统代理恢复状态清理无法确认。'
+                  '请在诊断页检查并重试断开，SSRVPN 不会重新接管代理。',
+        ),
       );
       return;
     }
-    final hasRecoveryIntent = hasActiveUnexpectedExitRecoveryIntent(
-      generation,
-      (value) => isConnectionIntentCurrent(value, connected: true),
-    );
-    if (!hasRecoveryIntent) {
+    if (!_hasActiveUnexpectedExitRecoveryIntent(generation)) {
       if (!proxyCleared) await clearSystemProxyAfterUnexpectedExit();
       return;
     }
@@ -1418,12 +1527,16 @@ try {
         setLastStartError(recoveryReason);
         markConnectionLost();
         notifyRuntimeNotice(
-          '连接已安全断开；Windows 代理端点已释放，但恢复日志仍待清理。'
-          '请保持 SSRVPN 打开并使用“诊断”重试，清理完成前不要强制退出。',
+          const RuntimeNotice.warning(
+            '连接已安全断开；Windows 代理端点已释放，但恢复日志仍待清理。'
+            '请保持 SSRVPN 打开并使用“诊断”重试，清理完成前不要强制退出。',
+          ),
         );
         return;
       }
-      notifyRuntimeNotice('系统代理恢复未完成，正在恢复本地保护监听…');
+      notifyRuntimeNotice(
+        const RuntimeNotice.progress('系统代理恢复未完成，正在恢复本地保护监听…'),
+      );
       final listenerRestored = await _start(
         automaticRecovery: true,
         preserveSystemProxyRecovery: true,
@@ -1431,46 +1544,65 @@ try {
       if (listenerRestored && isRunning) {
         setLastStartError(recoveryReason);
         notifyRuntimeNotice(
-          '连接处于保护模式：Mihomo 本地代理监听已恢复，但 Windows '
-          '系统代理旧状态仍未恢复。为避免死代理，SSRVPN 将保持运行；'
-          '请使用“诊断”重试，恢复前不要强制退出。',
+          const RuntimeNotice.warning(
+            '连接处于保护模式：本地代理监听已恢复，但 Windows '
+            '系统代理旧状态仍未恢复。为避免死代理，SSRVPN 将保持运行；'
+            '请使用“诊断”重试，恢复前不要强制退出。',
+          ),
         );
         return;
       }
 
-      final listenerReason = lastStartError ?? 'Mihomo 本地代理监听未能重新启动';
+      final listenerReason = lastStartError ?? '本地代理监听未能重新启动';
+      final listenerFailure = AppFailure.fromMessage(listenerReason);
       markConnectionLost();
       notifyRuntimeNotice(
-        '紧急：系统代理恢复失败，本地保护监听也未能启动（$listenerReason）。'
-        '请保持 SSRVPN 打开并立即使用“诊断”重试恢复。',
+        RuntimeNotice.error(
+          '紧急：系统代理恢复失败，本地保护监听也未能启动。'
+          '${listenerFailure.userMessage}'
+          '请保持 SSRVPN 打开并立即使用“诊断”重试恢复。',
+        ),
       );
       return;
     }
-    if (!hasActiveUnexpectedExitRecoveryIntent(
-      generation,
-      (value) => isConnectionIntentCurrent(value, connected: true),
-    )) {
+    if (!_hasActiveUnexpectedExitRecoveryIntent(generation)) {
       return;
     }
-    if (tunInterfaces != null && !await _waitForTunTeardown()) {
-      setLastStartError(_tunTeardownTimeoutError);
-      markConnectionLost();
-      notifyRuntimeNotice('核心已退出：$_tunTeardownTimeoutError');
-      return;
-    }
-    if (!_unexpectedExitRecoveryPolicy.tryAcquire()) {
-      markConnectionLost();
-      notifyRuntimeNotice('连接已断开：核心再次异常退出，自动恢复失败，请重新连接');
-      return;
+    if (tunInterfaces != null) {
+      final tunTeardownComplete = await waitForUnexpectedExitTunTeardown();
+      if (!_hasActiveUnexpectedExitRecoveryIntent(generation)) {
+        return;
+      }
+      if (!tunTeardownComplete) {
+        setLastStartError(_tunTeardownTimeoutError);
+        markConnectionLost();
+        notifyRuntimeNotice(
+          RuntimeNotice.error('核心已退出：$_tunTeardownTimeoutError'),
+        );
+        return;
+      }
     }
 
-    notifyRuntimeNotice('核心异常退出，正在自动恢复（退出码 $exitCode）');
-    final restarted = await recoverDesktopConnection(generation!);
+    final restarted = await runConnectionTransition(() async {
+      if (!_hasActiveUnexpectedExitRecoveryIntent(generation)) {
+        return false;
+      }
+      if (!_unexpectedExitRecoveryPolicy.tryAcquire()) {
+        markConnectionLost();
+        notifyRuntimeNotice(
+          const RuntimeNotice.error(
+            '连接已断开：核心再次异常退出，自动恢复失败，请重新连接',
+          ),
+        );
+        return false;
+      }
+      notifyRuntimeNotice(
+        RuntimeNotice.progress('核心异常退出，正在自动恢复（退出码 $exitCode）'),
+      );
+      return recoverDesktopConnection(generation!);
+    });
 
-    if (!hasActiveUnexpectedExitRecoveryIntent(
-      generation,
-      (value) => isConnectionIntentCurrent(value, connected: true),
-    )) {
+    if (!_hasActiveUnexpectedExitRecoveryIntent(generation)) {
       return;
     }
     if (restarted && isRunning) {
@@ -1478,9 +1610,12 @@ try {
       return;
     }
 
-    final reason = lastStartError ?? 'Mihomo 未能重新启动';
+    final reason = lastStartError ?? '本地代理服务未能重新启动';
+    final failure = AppFailure.fromMessage(reason);
     markConnectionLost();
-    notifyRuntimeNotice('连接已断开：核心自动恢复失败（$reason），请重新连接');
+    notifyRuntimeNotice(
+      RuntimeNotice.error('连接已断开：核心自动恢复失败。${failure.userMessage}'),
+    );
   }
 
   @protected
@@ -1550,27 +1685,12 @@ $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
   Future<T> _awaitStartOperation<T>(Future<T> operation, int startToken) async {
     final cancellation = _startCancellation?.future;
-    if (cancellation == null) {
-      final value = await operation;
-      _ensureStartCurrent(startToken);
-      return value;
-    }
-
-    final completion = Completer<T>();
-    operation.then<void>(
-      (value) {
-        if (!completion.isCompleted) completion.complete(value);
-      },
-      onError: (Object error, StackTrace stack) {
-        if (!completion.isCompleted) completion.completeError(error, stack);
-      },
-    );
-    cancellation.then<void>((_) {
-      if (!completion.isCompleted) {
-        completion.completeError(_DesktopStartCancelled());
-      }
-    });
-    final value = await completion.future;
+    final value = await (cancellation == null
+        ? operation
+        : Future.any<T>([
+            operation,
+            cancellation.then<T>((_) => throw _DesktopStartCancelled()),
+          ]));
     _ensureStartCurrent(startToken);
     return value;
   }
@@ -1617,7 +1737,7 @@ $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
         environment: environment,
         timeout: const Duration(seconds: 40),
         cancellation: _startCancellation?.future,
-        timeoutStderr: '电脑性能不足，请重新连接',
+        timeoutStderr: 'Windows Mihomo 核心启动配置校验响应超时；可能是系统繁忙或安全软件暂时拦截，请稍后重试',
       );
       final stdout = result.stdout.toString().trim();
       final stderr = result.stderr.toString().trim();
@@ -1629,7 +1749,9 @@ $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
       }
       if (result.exitCode == 125) throw _DesktopStartCancelled();
       if (result.exitCode == 124) {
-        setLastStartError('电脑性能不足，请重新连接');
+        setLastStartError(
+          'Windows Mihomo 核心启动配置校验响应超时；可能是系统繁忙或安全软件暂时拦截，请稍后重试',
+        );
         log('❌ $lastStartError');
         return false;
       }

--- a/SSRVPN_Windows/lib/services/system_proxy_service.dart
+++ b/SSRVPN_Windows/lib/services/system_proxy_service.dart
@@ -680,7 +680,7 @@ ${_notifyWinInetScript()}
       _transactionQueue.run(() async {
         final lockPath = _transactionLockPath;
         if (lockPath == null) {
-          throw StateError('SystemProxyService has not been initialized');
+          throw StateError('Windows 系统代理服务尚未初始化，请重启 SSRVPN');
         }
         final lockFile = File(lockPath);
         await lockFile.parent.create(recursive: true);
@@ -1135,7 +1135,7 @@ ${_notifyWinInetScript()}
     cancellation?.throwIfRequested();
     final statePath = _statePath;
     if (statePath == null) {
-      throw StateError('SystemProxyService has not been initialized');
+      throw StateError('Windows 系统代理服务尚未初始化，请重启 SSRVPN');
     }
     final file = File(statePath);
     await file.parent.create(recursive: true);
@@ -1402,13 +1402,15 @@ Set-ItemProperty -Path \$backupPath -Name ActivationInProgress -Type DWord -Valu
         utf8Script,
       ],
       timeout: const Duration(seconds: 20),
-      timeoutStderr: '电脑性能不足，请重新连接',
+      timeoutStderr: 'Windows 系统代理 PowerShell 命令响应超时；可能是系统繁忙或安全软件暂时拦截，请稍后重试',
       cancellation: cancellation,
     );
   }
 
   String _formatPowerShellError(String prefix, ProcessResult result) {
-    if (result.exitCode == 124) return '电脑性能不足，请重新连接';
+    if (result.exitCode == 124) {
+      return 'Windows 系统代理 PowerShell 命令响应超时；可能是系统繁忙或安全软件暂时拦截，请稍后重试';
+    }
     final stderr = result.stderr.toString().trim();
     final stdout = result.stdout.toString().trim();
     final detail = stderr.isNotEmpty ? stderr : stdout;

--- a/SSRVPN_Windows/lib/services/update_service.dart
+++ b/SSRVPN_Windows/lib/services/update_service.dart
@@ -255,7 +255,7 @@ class UpdateService {
         builder: (dialogContext) => AlertDialog(
           scrollable: true,
           title: const Text('更新失败'),
-          content: Text(error.toString().replaceFirst('Bad state: ', '')),
+          content: Text(desktopResolutionFailureMessage(error)),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(dialogContext),
@@ -266,4 +266,11 @@ class UpdateService {
       );
     });
   }
+
+  @visibleForTesting
+  static String desktopResolutionFailureMessage(Object error) =>
+      safeUserFacingFailureWithAction(
+        error,
+        '请确认桌面目录可访问后重试。',
+      );
 }

--- a/SSRVPN_Windows/test/clash_service_lifecycle_test.dart
+++ b/SSRVPN_Windows/test/clash_service_lifecycle_test.dart
@@ -16,6 +16,12 @@ ClashService _createTestService() => ClashService(
     );
 
 void main() {
+  test('periodic health timeout covers the Windows ownership probe budget', () {
+    final service = _InspectableHealthTimeoutClashService();
+
+    expect(service.exposedHealthCheckTimeout, const Duration(seconds: 25));
+  });
+
   test('fresh lifecycle reports safe idle diagnostics', () async {
     final service = _createTestService();
 
@@ -78,7 +84,7 @@ void main() {
     final service = _createTestService();
 
     expect(await service.start(), isFalse);
-    expect(service.lastStartError, 'Mihomo service is not initialized');
+    expect(service.lastStartError, contains('尚未初始化'));
   });
 
   test('automatic recovery fails safely before lifecycle initialization',
@@ -86,7 +92,7 @@ void main() {
     final service = _createTestService();
 
     expect(await service.startForAutomaticRecovery(), isFalse);
-    expect(service.lastStartError, 'Mihomo service is not initialized');
+    expect(service.lastStartError, contains('尚未初始化'));
   });
 
   test('stop hook fails closed when proxy cleanup is unavailable', () async {
@@ -133,4 +139,8 @@ void main() {
     expect(service.lastStartError, contains('尚未初始化'));
     expect(service.hasPendingSystemProxyRecovery, isTrue);
   });
+}
+
+class _InspectableHealthTimeoutClashService extends ClashService {
+  Duration get exposedHealthCheckTimeout => healthCheckTimeout;
 }

--- a/SSRVPN_Windows/test/desktop_home_screen_test.dart
+++ b/SSRVPN_Windows/test/desktop_home_screen_test.dart
@@ -313,6 +313,90 @@ void main() {
     expect(find.text('已切换: 新加坡节点'), findsOneWidget);
   });
 
+  testWidgets(
+      'successful connection stays live and warns when node persistence fails',
+      (tester) async {
+    final fixture = (await tester.runAsync(
+      () => _HomeFixture.create(
+        withNodes: true,
+        failSettingsWrites: true,
+      ),
+    ))!;
+    addTearDown(fixture.dispose);
+    fixture.clash
+      ..switchResult = true
+      ..runtimeSelectedNodeName = '东京节点';
+
+    await tester.pumpWidget(fixture.build());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    await tester.tap(find.byKey(const Key('ssrvpn-power-button')));
+    await tester.pump();
+    await _pumpUntil(tester, () => fixture.clash.isRunning);
+    expect(fixture.clash.lastPreferredNodeName, '东京节点');
+    expect(fixture.clash.lastSwitchAttempt, '东京节点');
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump(const Duration(milliseconds: 150));
+    await _pumpUntil(tester, () => find.text('已连接').evaluate().isNotEmpty);
+    await _pumpUntil(
+      tester,
+      () => find.text('已连接，但首选节点保存失败').evaluate().isNotEmpty,
+    );
+
+    expect(fixture.clash.isRunning, isTrue);
+    expect(fixture.settings.settings.lastSelectedNodeName, isNull);
+    expect(find.text('已连接'), findsWidgets);
+    expect(find.textContaining('连接失败'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('ssrvpn-current-node-card')),
+        matching: find.text('东京节点'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets(
+      'successful live switch stays selected and warns when persistence fails',
+      (tester) async {
+    final fixture = (await tester.runAsync(
+      () => _HomeFixture.create(
+        withNodes: true,
+        running: true,
+        failSettingsWrites: true,
+      ),
+    ))!;
+    addTearDown(fixture.dispose);
+    fixture.clash
+      ..switchResult = true
+      ..runtimeSelectedNodeName = '东京节点';
+
+    await tester.pumpWidget(fixture.build());
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('ssrvpn-current-node-card')));
+    await tester.pumpAndSettle();
+    final selector = tester.widget<SsrvpnNodeSelectionPage>(
+      find.byType(SsrvpnNodeSelectionPage),
+    );
+    final node = selector.nodesOf().singleWhere(
+          (candidate) => candidate.name == '新加坡节点',
+        );
+    await tester.runAsync(() => selector.onSelectNode(node));
+    await tester.pump();
+
+    expect(fixture.clash.isRunning, isTrue);
+    expect(fixture.settings.settings.lastSelectedNodeName, isNull);
+    expect(find.text('已切换，但首选节点保存失败: 新加坡节点'), findsOneWidget);
+    expect(find.text('切换失败: 新加坡节点'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('ssrvpn-node-card-新加坡节点')),
+        matching: find.byIcon(Icons.check_circle_rounded),
+      ),
+      findsOneWidget,
+    );
+  });
+
   for (final switchResult in [false, true]) {
     testWidgets(
         'late connected node switch cannot overwrite a disconnected status '
@@ -590,14 +674,18 @@ void main() {
     final singleAction = find.bySemanticsLabel('测试 新加坡节点 延迟');
     expect(singleAction, findsOneWidget);
     expect(tester.getSemantics(singleAction).flagsCollection.isButton, isTrue);
-    final singleRunsBefore = fixture.clash.singleLatencyRuns;
+    final nodeLatencyRunsBefore = fixture.clash.nodeLatencyRuns;
     await _focusSemanticAction(tester, singleAction);
     expect(
       await tester.sendKeyEvent(LogicalKeyboardKey.enter),
       isTrue,
     );
     await tester.pumpAndSettle();
-    expect(fixture.clash.singleLatencyRuns, greaterThan(singleRunsBefore));
+    expect(
+      fixture.clash.nodeLatencyRuns,
+      greaterThan(nodeLatencyRunsBefore),
+    );
+    expect(fixture.clash.lastNodeLatencyName, '新加坡节点');
 
     await _focusSemanticAction(tester, nodeAction);
     expect(
@@ -654,6 +742,7 @@ class _HomeFixture {
     required bool withNodes,
     bool recordBatchLatencyResults = true,
     bool running = false,
+    bool failSettingsWrites = false,
   }) async {
     SubscriptionService.resetInstanceForTesting();
     final directory = Directory.systemTemp.createTempSync('ssrvpn_home_');
@@ -663,7 +752,9 @@ class _HomeFixture {
       settings: AppSettings(),
       dataDir: directory.path,
       settingsPath: '${directory.path}/settings.json',
-      writeSettings: (_) => SynchronousFuture<void>(null),
+      writeSettings: (_) => failSettingsWrites
+          ? Future<void>.error(StateError('disk full'))
+          : SynchronousFuture<void>(null),
       readApiSecret: () async => '',
       writeApiSecret: (_) async {},
     );
@@ -716,8 +807,11 @@ class _FakeClashService extends ClashService {
   bool _running;
   String? lastSwitchAttempt;
   String? lastPreferredNodeName;
+  String? runtimeSelectedNodeName;
   int batchLatencyRuns = 0;
   int singleLatencyRuns = 0;
+  int nodeLatencyRuns = 0;
+  String? lastNodeLatencyName;
   int startCalls = 0;
   int stopCalls = 0;
   Completer<void>? switchStarted;
@@ -776,7 +870,7 @@ class _FakeClashService extends ClashService {
   }
 
   @override
-  Future<String?> currentSelectedProxyName() async => null;
+  Future<String?> currentSelectedProxyName() async => runtimeSelectedNodeName;
 
   @override
   Future<bool> switchSelectedProxy(String nodeName) async {
@@ -800,6 +894,16 @@ class _FakeClashService extends ClashService {
   }) async {
     singleLatencyRuns++;
     return server.endsWith('.1') ? 42 : 68;
+  }
+
+  @override
+  Future<int> testNodeLatency(
+    ProxyNode node, {
+    int timeoutMs = 5000,
+  }) async {
+    nodeLatencyRuns++;
+    lastNodeLatencyName = node.name;
+    return 77;
   }
 
   @override

--- a/SSRVPN_Windows/test/node_edit_screen_test.dart
+++ b/SSRVPN_Windows/test/node_edit_screen_test.dart
@@ -36,6 +36,19 @@ void main() {
 
     expect(find.text('端口必须在 1-65535 之间'), findsOneWidget);
   });
+
+  test('save failure never exposes the private storage path', () {
+    final message = desktopNodeSaveFailureMessage(
+      StateError(
+        'cache write failed token=top-secret '
+        r'path=C:\Users\alice\private-token-cache',
+      ),
+    );
+
+    expect(message, isNot(contains('top-secret')));
+    expect(message, isNot(contains('private-token-cache')));
+    expect(message, contains('原始敏感细节不会显示'));
+  });
 }
 
 ProxyNode _node() {

--- a/SSRVPN_Windows/test/runtime_notice_test.dart
+++ b/SSRVPN_Windows/test/runtime_notice_test.dart
@@ -2,78 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ssrvpn_shared/runtime_notice.dart';
 
 void main() {
-  test('only the exact recovery notice is successful', () {
-    expect(isSuccessfulRuntimeNotice(coreAutoRecoveredRuntimeNotice), isTrue);
-    expect(isSuccessfulRuntimeNotice(' 核心已自动恢复'), isFalse);
-    expect(isSuccessfulRuntimeNotice('核心异常退出，正在自动恢复'), isFalse);
-    expect(isSuccessfulRuntimeNotice(null), isFalse);
-  });
-
-  test('only the exact TUN elevation handoff notice is in progress', () {
+  test('Windows elevation handoff is an explicit progress notice', () {
     expect(
-      isInProgressRuntimeNotice(windowsTunElevationHandoffRuntimeNotice),
-      isTrue,
+      windowsTunElevationHandoffRuntimeNotice.level,
+      RuntimeNoticeLevel.progress,
     );
     expect(
-      isInProgressRuntimeNotice(
-        '$windowsTunElevationHandoffRuntimeNotice ',
-      ),
-      isFalse,
+      windowsTunElevationHandoffRuntimeNotice.message,
+      allOf(contains('管理员'), contains('自动以管理员模式重新打开')),
     );
-    expect(isInProgressRuntimeNotice(coreAutoRecoveredRuntimeNotice), isFalse);
-    expect(isInProgressRuntimeNotice(null), isFalse);
-  });
-
-  testWidgets('successful notice clears after its display duration', (
-    tester,
-  ) async {
-    String? currentMessage = coreAutoRecoveredRuntimeNotice;
-    var clearCount = 0;
-
-    final timer = scheduleSuccessfulRuntimeNoticeClear(
-      message: currentMessage,
-      currentMessage: () => currentMessage,
-      clear: () {
-        clearCount++;
-        currentMessage = null;
-      },
-    );
-
-    expect(timer, isNotNull);
-    await tester.pump(
-      runtimeNoticeSuccessDuration - const Duration(milliseconds: 1),
-    );
-    expect(clearCount, 0);
-
-    await tester.pump(const Duration(milliseconds: 1));
-    expect(clearCount, 1);
-    expect(currentMessage, isNull);
-  });
-
-  testWidgets('old success timer does not clear a newer notice',
-      (tester) async {
-    String? currentMessage = coreAutoRecoveredRuntimeNotice;
-    var clearCount = 0;
-
-    scheduleSuccessfulRuntimeNoticeClear(
-      message: currentMessage,
-      currentMessage: () => currentMessage,
-      clear: () => clearCount++,
-    );
-    currentMessage = '连接已断开：核心自动恢复失败';
-
-    await tester.pump(runtimeNoticeSuccessDuration);
-    expect(clearCount, 0);
-    expect(currentMessage, '连接已断开：核心自动恢复失败');
-  });
-
-  test('error notice is not scheduled for automatic clearing', () {
-    final timer = scheduleSuccessfulRuntimeNoticeClear(
-      message: '连接未完成',
-      currentMessage: () => '连接未完成',
-      clear: () {},
-    );
-
-    expect(timer, isNull);
   });
 }

--- a/SSRVPN_Windows/test/system_proxy_recovery_test.dart
+++ b/SSRVPN_Windows/test/system_proxy_recovery_test.dart
@@ -4,7 +4,11 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart'
-    show ProcessTerminationNotConfirmedException, SystemProxyOwnershipStatus;
+    show
+        AppErrorCode,
+        AppFailure,
+        ProcessTerminationNotConfirmedException,
+        SystemProxyOwnershipStatus;
 import 'package:ssrvpn_windows/services/system_proxy_service.dart';
 
 void main() {
@@ -198,6 +202,14 @@ void main() {
       expect(
         await service.currentSystemProxyOwnershipStatus(),
         SystemProxyOwnershipStatus.unavailable,
+      );
+      expect(
+        service.lastError,
+        contains('系统代理 PowerShell 命令响应超时'),
+      );
+      expect(
+        AppFailure.fromMessage(service.lastError).code,
+        AppErrorCode.proxyRecoveryPending,
       );
     },
   );

--- a/SSRVPN_Windows/test/tun_runtime_health_test.dart
+++ b/SSRVPN_Windows/test/tun_runtime_health_test.dart
@@ -2,11 +2,33 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 import 'package:ssrvpn_windows/services/clash_service.dart';
 import 'package:ssrvpn_windows/services/windows_tun_runtime_probe.dart';
 
 void main() {
+  test('TUN external data-plane failure is warning-only', () async {
+    final service = _AdvisoryTunDataPlaneClashService()
+      ..updateSettings(AppSettings(enableTun: true))
+      ..requestConnectionIntent(true)
+      ..setRunning(true);
+    addTearDown(service.dispose);
+
+    await service.runDataPlaneObservation();
+
+    expect(service.connectivityWarning, contains('external endpoint blocked'));
+    expect(service.isRunning, isTrue);
+    expect(service.connectionDesired, isTrue);
+
+    service.beginNewDataPlaneSession();
+    expect(service.connectivityWarning, isNull);
+    service.nextWarning = null;
+    await service.runDataPlaneObservation();
+    expect(service.connectivityWarning, isNull);
+    expect(service.probeCalls, 2);
+  });
+
   test('TUN health treats the Windows adapter probe as advisory', () async {
     Map<String, dynamic> configs = {};
     var runtimeStatus = WindowsTunRuntimeStatus.adapterMissing;
@@ -138,4 +160,68 @@ void main() {
       await server.close(force: true);
     }
   });
+
+  test(
+      'system proxy health keeps the connection when ownership is temporarily unavailable',
+      () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    final subscription = server.listen((request) async {
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(jsonEncode({'version': 'test'}));
+      await request.response.close();
+    });
+    final service = _UncertainProxyOwnershipClashService()
+      ..updateSettings(AppSettings(apiPort: server.port))
+      ..setRunning(true);
+
+    try {
+      expect(await service.healthCheck(), isTrue);
+      expect(service.isRunning, isTrue);
+      expect(service.lastHealthCheckError, isNull);
+      expect(
+        service.connectivityWarning,
+        allOf(contains('暂时无法确认'), contains('当前连接仍保留')),
+      );
+
+      service.ownershipStatus = SystemProxyOwnershipStatus.owned;
+      expect(await service.healthCheck(), isTrue);
+      expect(service.connectivityWarning, isNull);
+    } finally {
+      service.dispose();
+      await subscription.cancel();
+      await server.close(force: true);
+    }
+  });
+}
+
+class _AdvisoryTunDataPlaneClashService extends ClashService {
+  String? nextWarning = 'external endpoint blocked';
+  int probeCalls = 0;
+
+  Future<void> runDataPlaneObservation() => observeDataPlaneHealth();
+
+  void beginNewDataPlaneSession() => resetTunDataPlaneObservationSession();
+
+  @override
+  Duration get tunDataPlaneObservationInterval => Duration.zero;
+
+  @override
+  Future<String?> verifyUserConnectivity({
+    int maxAttempts = 3,
+    Duration retryDelay = const Duration(seconds: 2),
+    Future<http.Response> Function(Uri uri)? request,
+    bool Function()? shouldContinue,
+  }) async {
+    probeCalls++;
+    return nextWarning;
+  }
+}
+
+class _UncertainProxyOwnershipClashService extends ClashService {
+  SystemProxyOwnershipStatus ownershipStatus =
+      SystemProxyOwnershipStatus.unavailable;
+
+  @override
+  Future<SystemProxyOwnershipStatus> inspectSystemProxyOwnership() async =>
+      ownershipStatus;
 }

--- a/SSRVPN_Windows/test/unexpected_core_exit_recovery_test.dart
+++ b/SSRVPN_Windows/test/unexpected_core_exit_recovery_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:ssrvpn_shared/runtime_notice.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 import 'package:ssrvpn_windows/services/clash_service.dart';
 
@@ -189,7 +192,7 @@ void main() {
   test(
       'API failure plus external proxy takeover disconnects without reacquiring proxy',
       () async {
-    final notices = <String>[];
+    final notices = <RuntimeNotice>[];
     final service = _ExternalProxyTakeoverRecoveryClashService()
       ..onRuntimeNotice = notices.add;
     addTearDown(service.dispose);
@@ -216,15 +219,34 @@ void main() {
     expect(service.connectionDesired, isFalse);
     expect(service.isRunning, isFalse);
     expect(
-      notices.single,
+      notices.single.message,
       allOf(contains('其他程序'), contains('不会覆盖')),
     );
+  });
+
+  test('a stale health probe cannot cancel a newer connection intent',
+      () async {
+    final service = _StaleHealthProbeRecoveryClashService();
+    addTearDown(service.dispose);
+    final oldGeneration = service.requestConnectionIntent(true);
+    service.setRunning(true);
+
+    final recovery = service.recoverAfterHealthCheckFailure(oldGeneration);
+    await service.healthProbeStarted.future;
+    service.requestConnectionIntent(true);
+    service.releaseHealthProbe.complete();
+
+    expect(await recovery, isFalse);
+    expect(service.connectionDesired, isTrue);
+    expect(service.isRunning, isTrue);
+    expect(service.stopCalls, 0);
+    expect(service.proxyOwnershipInspectionCalls, 0);
   });
 
   test(
       'unexpected core exit clears external takeover state without restarting or reacquiring',
       () async {
-    final notices = <String>[];
+    final notices = <RuntimeNotice>[];
     final service = _ExternalProxyTakeoverRecoveryClashService()
       ..onRuntimeNotice = notices.add;
     addTearDown(service.dispose);
@@ -250,7 +272,7 @@ void main() {
     expect(service.connectionDesired, isFalse);
     expect(service.isRunning, isFalse);
     expect(
-      notices.single,
+      notices.single.message,
       allOf(contains('其他程序接管'), contains('取消自动重连'), contains('未覆盖')),
     );
   });
@@ -258,7 +280,7 @@ void main() {
   test(
       'proxy ownership change during health cleanup blocks automatic reacquisition',
       () async {
-    final notices = <String>[];
+    final notices = <RuntimeNotice>[];
     final service = _ProxyChangedDuringCleanupRecoveryClashService()
       ..onRuntimeNotice = notices.add;
     addTearDown(service.dispose);
@@ -283,14 +305,14 @@ void main() {
     expect(service.automaticRecoveryStartCalls, 0);
     expect(service.connectionDesired, isFalse);
     expect(
-      notices.last,
+      notices.last.message,
       allOf(contains('清理期间'), contains('不会重新接管')),
     );
   });
 
   test('proxy ownership change during unexpected-exit cleanup blocks restart',
       () async {
-    final notices = <String>[];
+    final notices = <RuntimeNotice>[];
     final service = _ProxyChangedDuringCleanupRecoveryClashService()
       ..onRuntimeNotice = notices.add;
     addTearDown(service.dispose);
@@ -315,14 +337,14 @@ void main() {
     expect(service.automaticRecoveryStartCalls, 0);
     expect(service.connectionDesired, isFalse);
     expect(
-      notices.single,
+      notices.single.message,
       allOf(contains('清理期间'), contains('取消自动重连')),
     );
   });
 
   test('unavailable proxy ownership disconnects without reacquiring proxy',
       () async {
-    final notices = <String>[];
+    final notices = <RuntimeNotice>[];
     final service = _UnavailableProxyOwnershipRecoveryClashService()
       ..onRuntimeNotice = notices.add;
     addTearDown(service.dispose);
@@ -343,7 +365,10 @@ void main() {
     expect(service.prepareCalls, 0);
     expect(service.automaticRecoveryStartCalls, 0);
     expect(service.connectionDesired, isFalse);
-    expect(notices.single, allOf(contains('无法确认'), contains('不会覆盖')));
+    expect(
+      notices.single.message,
+      allOf(contains('无法确认'), contains('不会覆盖')),
+    );
   });
 
   test('health recovery rebuilds runtime config before automatic start',
@@ -398,6 +423,118 @@ void main() {
       service.calls.where((call) => call == 'recovery-start'),
       hasLength(2),
     );
+  });
+
+  test('unexpected-exit recovery waits for the connection transition queue',
+      () async {
+    final service = _SerializedUnexpectedExitRecoveryClashService();
+    addTearDown(service.dispose);
+    service.rememberDesktopConnectionRecoveryPlan(
+      preferredSettings: AppSettings(),
+      generateConfig: (runtimeSettings, preferredNodeName) async {
+        service.generateStarted.complete();
+        return 'mixed-port: ${runtimeSettings.proxyPort}';
+      },
+      isRevisionCurrent: () => true,
+    );
+    final generation = service.requestConnectionIntent(true);
+    service.setRunning(true);
+    service.setRunning(false);
+
+    final queueEntered = Completer<void>();
+    final releaseQueue = Completer<void>();
+    final occupied = service.runConnectionTransition(() async {
+      queueEntered.complete();
+      await releaseQueue.future;
+    });
+    await queueEntered.future;
+
+    final recovery = service.simulateUnexpectedExit(generation);
+    await Future.any<void>([
+      service.generateStarted.future,
+      Future<void>.delayed(const Duration(milliseconds: 50)),
+    ]);
+    expect(service.generateStarted.isCompleted, isFalse);
+
+    releaseQueue.complete();
+    await occupied;
+    await recovery;
+    expect(service.generateStarted.isCompleted, isTrue);
+    expect(service.isRunning, isTrue);
+  });
+
+  test(
+      'stale queued unexpected exit stays silent and preserves recovery budget',
+      () async {
+    final notices = <RuntimeNotice>[];
+    final oldProgress = Completer<void>();
+    final service = _SerializedUnexpectedExitRecoveryClashService()
+      ..onRuntimeNotice = (notice) {
+        notices.add(notice);
+        if (notice.level == RuntimeNoticeLevel.progress &&
+            !oldProgress.isCompleted) {
+          oldProgress.complete();
+        }
+      };
+    addTearDown(service.dispose);
+    service.rememberDesktopConnectionRecoveryPlan(
+      preferredSettings: AppSettings(),
+      generateConfig: (runtimeSettings, preferredNodeName) async =>
+          'mixed-port: ${runtimeSettings.proxyPort}',
+      isRevisionCurrent: () => true,
+    );
+    final oldGeneration = service.requestConnectionIntent(true);
+    service.setRunning(false);
+
+    final queueEntered = Completer<void>();
+    final releaseQueue = Completer<void>();
+    final occupied = service.runConnectionTransition(() async {
+      queueEntered.complete();
+      await releaseQueue.future;
+    });
+    await queueEntered.future;
+
+    final staleRecovery = service.simulateUnexpectedExit(oldGeneration);
+    await Future.any<void>([
+      oldProgress.future,
+      Future<void>.delayed(const Duration(milliseconds: 50)),
+    ]);
+    final currentGeneration = service.requestConnectionIntent(true);
+
+    releaseQueue.complete();
+    await occupied;
+    await staleRecovery;
+
+    expect(notices, isEmpty);
+    expect(service.automaticRecoveryStartCalls, 0);
+
+    await service.simulateUnexpectedExit(currentGeneration);
+    expect(service.automaticRecoveryStartCalls, 1);
+    expect(service.isRunning, isTrue);
+
+    service.setRunning(false);
+    await service.simulateUnexpectedExit(currentGeneration);
+    expect(service.automaticRecoveryStartCalls, 2);
+    expect(service.isRunning, isTrue);
+  });
+
+  test('stale TUN teardown timeout cannot cancel the newer intent', () async {
+    final notices = <RuntimeNotice>[];
+    final service = _SerializedUnexpectedExitRecoveryClashService()
+      ..onRuntimeNotice = notices.add;
+    addTearDown(service.dispose);
+    final oldGeneration = service.requestConnectionIntent(true);
+    service.setRunning(false);
+
+    final recovery = service.simulateUnexpectedTunExit(oldGeneration);
+    await service.tunTeardownStarted.future;
+    service.requestConnectionIntent(true);
+    service.tunTeardownResult.complete(false);
+    await recovery;
+
+    expect(service.connectionDesired, isTrue);
+    expect(service.automaticRecoveryStartCalls, 0);
+    expect(notices, isEmpty);
   });
 }
 
@@ -458,6 +595,19 @@ class _UnavailableProxyOwnershipRecoveryClashService
   }
 }
 
+class _StaleHealthProbeRecoveryClashService
+    extends _ExternalProxyTakeoverRecoveryClashService {
+  final Completer<void> healthProbeStarted = Completer<void>();
+  final Completer<void> releaseHealthProbe = Completer<void>();
+
+  @override
+  Future<bool> healthCheck() async {
+    healthProbeStarted.complete();
+    await releaseHealthProbe.future;
+    return false;
+  }
+}
+
 class _ProxyChangedDuringCleanupRecoveryClashService
     extends _ExternalProxyTakeoverRecoveryClashService {
   @override
@@ -505,6 +655,52 @@ class _PlannedHealthRecoveryClashService extends ClashService {
   @override
   Future<bool> startForAutomaticRecovery() async {
     calls.add('recovery-start');
+    setRunning(true);
+    return true;
+  }
+}
+
+class _SerializedUnexpectedExitRecoveryClashService extends ClashService {
+  final Completer<void> generateStarted = Completer<void>();
+  final Completer<void> tunTeardownStarted = Completer<void>();
+  final Completer<bool> tunTeardownResult = Completer<bool>();
+  int automaticRecoveryStartCalls = 0;
+
+  Future<void> simulateUnexpectedExit(int generation) =>
+      runUnexpectedExitRecovery(generation: generation, exitCode: 17);
+
+  Future<void> simulateUnexpectedTunExit(int generation) =>
+      runUnexpectedExitRecovery(
+        generation: generation,
+        exitCode: 17,
+        usedTun: true,
+      );
+
+  @override
+  Future<SystemProxyOwnershipStatus> inspectSystemProxyOwnership() async =>
+      SystemProxyOwnershipStatus.owned;
+
+  @override
+  Future<bool> clearSystemProxyAfterUnexpectedExit() async => true;
+
+  @override
+  Future<bool> waitForUnexpectedExitTunTeardown() {
+    tunTeardownStarted.complete();
+    return tunTeardownResult.future;
+  }
+
+  @override
+  Future<AppSettings> prepareForStart(AppSettings preferred) async {
+    updateSettings(preferred);
+    return preferred;
+  }
+
+  @override
+  Future<void> writeConfig(String configContent) async {}
+
+  @override
+  Future<bool> startForAutomaticRecovery() async {
+    automaticRecoveryStartCalls++;
     setRunning(true);
     return true;
   }

--- a/SSRVPN_Windows/test/update_service_dialog_test.dart
+++ b/SSRVPN_Windows/test/update_service_dialog_test.dart
@@ -11,6 +11,19 @@ import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 import 'package:ssrvpn_windows/services/update_service.dart';
 
 void main() {
+  test('desktop resolution failure copy hides raw internal details', () {
+    final message = UpdateService.desktopResolutionFailureMessage(
+      StateError(
+        'PowerShell failed token=top-secret '
+        r'path=C:\Users\alice\private\desktop.ps1',
+      ),
+    );
+
+    expect(message, isNot(contains('top-secret')));
+    expect(message, isNot(contains('desktop.ps1')));
+    expect(message, contains('请确认桌面目录可访问后重试'));
+  });
+
   test('stale private update artifacts never publish an unverified installer',
       () async {
     final desktop =

--- a/SSRVPN_Windows/test/windows_secret_recovery_dialog_test.dart
+++ b/SSRVPN_Windows/test/windows_secret_recovery_dialog_test.dart
@@ -5,6 +5,19 @@ import 'package:ssrvpn_windows/services/windows_dpapi_secret_store.dart';
 import 'package:ssrvpn_windows/startup/startup_status.dart';
 
 void main() {
+  test('DPAPI recovery failure copy hides raw internal details', () {
+    final message = windowsApiSecretRecoveryFailureMessage(
+      StateError(
+        'DPAPI failed token=top-secret '
+        r'path=C:\Users\alice\private\.api-secret.dpapi',
+      ),
+    );
+
+    expect(message, isNot(contains('top-secret')));
+    expect(message, isNot(contains(r'C:\Users\alice')));
+    expect(message, contains('旧密文和用户数据仍已保留'));
+  });
+
   testWidgets('DPAPI recovery clearly preserves old ciphertext and user data',
       (tester) async {
     await tester.binding.setSurfaceSize(const Size(320, 360));

--- a/packages/ssrvpn_shared/lib/controllers/home_node_controller.dart
+++ b/packages/ssrvpn_shared/lib/controllers/home_node_controller.dart
@@ -61,11 +61,15 @@ class HomeNodeController {
     }
     final selectable = runnable
         .where(
-          (node) => NodeDisplayPolicy.isSelectableLatency(node.latency),
+          (node) =>
+              node.latency != null &&
+              NodeDisplayPolicy.isSelectableLatency(node.latency),
         )
         .toList();
-    if (selectable.isEmpty) return null;
-    return selectable.first;
+    if (selectable.isNotEmpty) return selectable.first;
+    // Unknown/failed latency is guidance, not a hard gate. This also gives a
+    // fresh UDP/QUIC-only subscription a deterministic default node.
+    return runnable.isEmpty ? null : runnable.first;
   }
 
   static ProxyNode? resolveRuntimeSelectedNodeFrom(
@@ -105,12 +109,9 @@ class HomeNodeController {
 
   static bool canSelectNode(
     ProxyNode node,
-    Map<String, int> latencies,
+    Map<String, int> _,
   ) {
-    return NodeDisplayPolicy.isSelectableLatency(
-          latencies[node.name] ?? node.latency,
-        ) &&
-        ProxyNodeUsagePolicy.isRunnableNode(node);
+    return ProxyNodeUsagePolicy.isRunnableNode(node);
   }
 
   static List<ProxyNode> timeoutLast(

--- a/packages/ssrvpn_shared/lib/desktop_ui/desktop_app_shell_part.dart
+++ b/packages/ssrvpn_shared/lib/desktop_ui/desktop_app_shell_part.dart
@@ -11,7 +11,7 @@ class _DesktopAppShell extends StatelessWidget {
 
   final bool safeMode;
   final List<String> startupFailureMessages;
-  final String? runtimeNotice;
+  final RuntimeNotice? runtimeNotice;
   final int currentIndex;
   final ValueChanged<int> onIndexChanged;
 
@@ -59,23 +59,29 @@ class _DesktopAppShell extends StatelessWidget {
   Widget build(BuildContext context) {
     final availableUpdate =
         context.watch<UpdateAvailabilityController>().availableUpdate;
-    final runtimeNoticeSuccessful = isSuccessfulRuntimeNotice(runtimeNotice);
-    final runtimeNoticeInProgress = isInProgressRuntimeNotice(runtimeNotice);
-    final runtimeNoticeIcon = runtimeNoticeSuccessful
-        ? Icons.check_circle_outline
-        : runtimeNoticeInProgress
-            ? Icons.admin_panel_settings_outlined
-            : Icons.error_outline;
-    final runtimeNoticeColor = runtimeNoticeSuccessful
-        ? AppTheme.success
-        : runtimeNoticeInProgress
-            ? AppTheme.primary
-            : AppTheme.error;
-    final runtimeNoticeTitle = runtimeNoticeSuccessful
-        ? '连接已恢复'
-        : runtimeNoticeInProgress
-            ? '正在切换管理员模式'
-            : '连接未完成';
+    final (runtimeNoticeIcon, runtimeNoticeColor, runtimeNoticeTitle) =
+        switch (runtimeNotice?.level) {
+      RuntimeNoticeLevel.success => (
+          Icons.check_circle_outline,
+          AppTheme.success,
+          '操作已完成',
+        ),
+      RuntimeNoticeLevel.progress => (
+          Icons.sync_outlined,
+          AppTheme.primary,
+          '正在处理',
+        ),
+      RuntimeNoticeLevel.warning => (
+          Icons.warning_amber_rounded,
+          AppTheme.warning,
+          '需要注意',
+        ),
+      RuntimeNoticeLevel.error || null => (
+          Icons.error_outline,
+          AppTheme.error,
+          '操作未完成',
+        ),
+    };
     final statusBanners = <Widget>[
       if (safeMode)
         const _StartupBanner(
@@ -96,7 +102,7 @@ class _DesktopAppShell extends StatelessWidget {
           icon: runtimeNoticeIcon,
           color: runtimeNoticeColor,
           title: runtimeNoticeTitle,
-          message: runtimeNotice!,
+          message: runtimeNotice!.message,
         ),
     ];
     return Scaffold(

--- a/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_home_background_tasks_part.dart
+++ b/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_home_background_tasks_part.dart
@@ -2,7 +2,7 @@ part of desktop_home_screen;
 
 extension _DesktopHomeBackgroundTasks on _HomeScreenState {
   Future<void> _loadInitialData() async {
-    if (!mounted || _disposed) return;
+    if (!_canUpdateUi) return;
     final subService = context.read<SubscriptionService>();
     final clashService = context.read<ClashService>();
     if (!identical(_clashService, clashService)) {
@@ -14,7 +14,7 @@ extension _DesktopHomeBackgroundTasks on _HomeScreenState {
     final wasRunning = clashService.isRunning;
     final runtimeSelectedNodeName =
         wasRunning ? await clashService.currentSelectedProxyName() : null;
-    if (!mounted || _disposed || !identical(_subscriptionService, subService)) {
+    if (!_canUpdateUi || !identical(_subscriptionService, subService)) {
       return;
     }
     final nodes = HomeNodeController.runnableNodesFrom(subService.allNodes);
@@ -36,13 +36,12 @@ extension _DesktopHomeBackgroundTasks on _HomeScreenState {
         }
       });
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted ||
-            _disposed ||
+        if (!_canUpdateUi ||
             !identical(_subscriptionService, subService) ||
             subService.revision != revision) {
           return;
         }
-        unawaited(_autoTestAllNodes());
+        unawaited(_runBatchLatencyTest());
       });
     }
     if (statusIsCurrent && wasRunning) {
@@ -61,7 +60,7 @@ extension _DesktopHomeBackgroundTasks on _HomeScreenState {
 
   void _handleClashStatusChanged() {
     final clashService = _clashService;
-    if (clashService == null || !mounted || _disposed) return;
+    if (clashService == null || !_canUpdateUi) return;
     final running = clashService.isRunning;
     final connectivityWarning =
         running ? clashService.connectivityWarning : null;
@@ -101,13 +100,12 @@ extension _DesktopHomeBackgroundTasks on _HomeScreenState {
 
   Future<void> _syncSelectedNodeFromRuntime(int statusEpoch) async {
     final clashService = _clashService;
-    if (clashService == null || !mounted || _disposed || !_isConnected) return;
+    if (clashService == null || !_canUpdateUi || !_isConnected) return;
     final runtimeSelectedNode = await _resolveRuntimeSelectedNode(
       clashService,
       _nodes,
     );
-    if (!mounted ||
-        _disposed ||
+    if (!_canUpdateUi ||
         !_isConnected ||
         statusEpoch != _connectionStatusEpoch ||
         !identical(_clashService, clashService)) {
@@ -140,7 +138,7 @@ extension _DesktopHomeBackgroundTasks on _HomeScreenState {
   }
 
   void _flushPendingLatencies(int generation) {
-    if (!_latencyController.hasPending || !mounted || _disposed) return;
+    if (!_latencyController.hasPending || !_canUpdateUi) return;
     if (_latencyBatchGeneration != generation ||
         !_latencyController.isCurrentBatch(generation)) {
       return;
@@ -175,7 +173,7 @@ extension _DesktopHomeBackgroundTasks on _HomeScreenState {
   }
 
   Future<void> _checkForUpdate() async {
-    if (!mounted || _disposed || !_isConnected || _updateCheckInProgress) {
+    if (!_canUpdateUi || !_isConnected || _updateCheckInProgress) {
       return;
     }
     _updateCheckInProgress = true;
@@ -184,7 +182,7 @@ extension _DesktopHomeBackgroundTasks on _HomeScreenState {
     try {
       const currentVersion = UpdateService.appVersion;
       final update = await UpdateService.checkForUpdate(currentVersion);
-      if (update != null && mounted && !_disposed && _isConnected) {
+      if (update != null && _canUpdateUi && _isConnected) {
         context.read<UpdateAvailabilityController>().publish(update);
       }
       _updateCheckCompleted = _isConnected;
@@ -194,7 +192,7 @@ extension _DesktopHomeBackgroundTasks on _HomeScreenState {
     } finally {
       _updateCheckInProgress = false;
     }
-    if (shouldRetry && mounted && !_disposed && _isConnected) {
+    if (shouldRetry && _canUpdateUi && _isConnected) {
       _checkUpdateDelayed(delay: const Duration(minutes: 1));
     }
   }

--- a/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_home_initial_subscription_part.dart
+++ b/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_home_initial_subscription_part.dart
@@ -78,12 +78,12 @@ extension _DesktopHomeInitialSubscriptionActions on _HomeScreenState {
                     setState(() {
                       _nodes = nodes;
                       _lastRevision = subService.revision;
-                      _selectedNode = _resolveDefaultNode(
+                      _selectedNode = HomeNodeController.resolveDefaultNodeFrom(
                         nodes,
                         settingsService.settings.lastSelectedNodeName,
                       );
                     });
-                    unawaited(_autoTestAllNodes());
+                    unawaited(_runBatchLatencyTest());
 
                     if (navigator.canPop()) navigator.pop();
                     messenger.showSnackBar(
@@ -95,9 +95,8 @@ extension _DesktopHomeInitialSubscriptionActions on _HomeScreenState {
                     );
                   } catch (e) {
                     if (!mounted || _disposed) return;
-                    final msg = e.toString().replaceFirst('Exception: ', '');
                     setDialogState(() {
-                      inputError = '更新失败: $msg';
+                      inputError = safeSubscriptionFailureMessage(e);
                       isSubmitting = false;
                     });
                   }

--- a/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_home_runtime_actions_part.dart
+++ b/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_home_runtime_actions_part.dart
@@ -22,7 +22,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
         });
         return;
       }
-      final preferredNode = _resolveDefaultNode(
+      final preferredNode = HomeNodeController.resolveDefaultNodeFrom(
         nodes,
         settingsService.settings.lastSelectedNodeName,
       );
@@ -58,21 +58,17 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
             readRuntimeNotice: () =>
                 clashService.lastRuntimePortAdjustmentMessage,
             switchPreferredNode: () async {
+              var switched = true;
               if (preferredNode != null) {
-                final switched = await clashService.switchSelectedProxy(
+                switched = await clashService.switchSelectedProxy(
                   preferredNode.name,
                 );
-                runtimeSelectedNode = await _resolveRuntimeSelectedNode(
-                  clashService,
-                  nodes,
-                );
-                return switched;
               }
               runtimeSelectedNode = await _resolveRuntimeSelectedNode(
                 clashService,
                 nodes,
               );
-              return true;
+              return switched;
             },
           );
         },
@@ -120,7 +116,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
           preferredNodeName: runtimeSelectedNode?.name ?? preferredNode?.name,
         );
       }
-      if (mounted && !_disposed) {
+      if (_canUpdateUi) {
         if (!success) {
           clashService.requestConnectionIntent(false);
           clashService.interruptPendingStart();
@@ -134,7 +130,12 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
           if (!success) _resetPublicIpState();
         });
         if (success) {
-          _showRuntimePortAdjustmentNotice(connectionResult.runtimeNotice);
+          final nodeWarning = connectionResult.preferredNodeSwitchWarning(
+            preferredNodeName: preferredNode?.name,
+            runtimeNodeName: runtimeSelectedNode?.name,
+          );
+          final notice = nodeWarning ?? connectionResult.runtimeNotice;
+          _showRuntimePortAdjustmentNotice(notice);
           _scheduleExitCountryResolution();
           _schedulePublicIpRefresh();
         }
@@ -150,8 +151,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
             connected: true,
           ),
         );
-        if (mounted &&
-            !_disposed &&
+        if (_canUpdateUi &&
             clashService.isConnectionIntentCurrent(
               connectionGeneration,
               connected: true,
@@ -174,16 +174,13 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
         clashService.requestConnectionIntent(false);
         clashService.interruptPendingStart();
       }
-      if (mounted && !_disposed) {
-        final msg = e
-            .toString()
-            .replaceFirst('Exception: ', '')
-            .replaceFirst('Bad state: ', '');
+      if (_canUpdateUi) {
         setState(() {
           _isConnected = stillRunning;
           _isConnecting = false;
-          _errorMessage =
-              stillRunning ? '连接重载失败，已保留当前连接: $msg' : '连接重载失败: $msg';
+          _errorMessage = stillRunning
+              ? '网络设置未能应用，当前连接仍保留。请重试；持续失败请重新连接并运行诊断。'
+              : '网络设置重载失败，连接已停止。请重新连接；持续失败请运行诊断。';
           if (!stillRunning) _resetPublicIpState();
         });
       }
@@ -203,18 +200,26 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     setState(() => _testingNodeName = nodeName);
     final clashService = context.read<ClashService>();
     final settings = context.read<SettingsService>().settings;
-    final measuredLatency = await clashService.testLatency(
-      server,
-      port,
-      timeoutMs: settings.latencyTestTimeout,
-    );
+    final nodeUnderTest = _nodes
+        .where(
+          (node) =>
+              node.name == nodeName &&
+              node.server == server &&
+              node.port == port,
+        )
+        .firstOrNull;
+    final measuredLatency = nodeUnderTest == null
+        ? -1
+        : await clashService.testNodeLatency(
+            nodeUnderTest,
+            timeoutMs: settings.latencyTestTimeout,
+          );
     final latency = PrivateNodeLatencyPolicy.displayLatencyForNode(
       nodeName,
       measuredLatency,
       random: math.Random(),
     );
-    final isCurrent = mounted &&
-        !_disposed &&
+    final isCurrent = _canUpdateUi &&
         generation == _singleLatencyGeneration &&
         subscriptionService.revision == subscriptionRevision &&
         _nodes.any(
@@ -229,8 +234,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
         _latencyController.applyNow(_nodes, nodeName, latency);
       });
       _sortNodesByLatency();
-    } else if (mounted &&
-        !_disposed &&
+    } else if (_canUpdateUi &&
         generation == _singleLatencyGeneration &&
         _testingNodeName == nodeName) {
       setState(() => _testingNodeName = null);
@@ -238,11 +242,11 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
   }
 
   Future<void> _handleSelectNode(ProxyNode node) async {
-    if (!mounted || _disposed || _isConnecting) return;
+    if (!_canUpdateUi || _isConnecting) return;
     if (!_isConnected) {
       setState(() => _disconnectedPreferredNodeName = node.name);
       final saved = await _rememberSelectedNode(node);
-      if (!mounted || _disposed) return;
+      if (!_canUpdateUi) return;
       if (!saved && _disconnectedPreferredNodeName == node.name) {
         setState(() => _disconnectedPreferredNodeName = null);
       }
@@ -261,8 +265,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     final statusEpoch = _connectionStatusEpoch;
 
     bool isCurrent() =>
-        mounted &&
-        !_disposed &&
+        _canUpdateUi &&
         _isConnected &&
         !_isConnecting &&
         clashService.isRunning &&
@@ -281,9 +284,10 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     _exitCountryResolveGeneration++;
     final ok = await clashService.switchSelectedProxy(node.name);
     if (!isCurrent()) return;
+    var nodePersisted = true;
     if (ok) {
       if (!isCurrent()) return;
-      await _rememberSelectedNode(node);
+      nodePersisted = await _rememberSelectedNode(node);
       if (!isCurrent()) return;
       setState(() => _selectedNode = node);
       if (!isCurrent()) return;
@@ -294,8 +298,14 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     if (!isCurrent()) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text(ok ? '已切换: ${node.name}' : '切换失败: ${node.name}'),
-        duration: const Duration(seconds: 1),
+        content: Text(
+          !ok
+              ? '切换失败: ${node.name}'
+              : nodePersisted
+                  ? '已切换: ${node.name}'
+                  : '已切换，但首选节点保存失败: ${node.name}',
+        ),
+        duration: Duration(seconds: ok && !nodePersisted ? 3 : 1),
       ),
     );
   }
@@ -330,13 +340,6 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     ).push<bool>(MaterialPageRoute(builder: (_) => NodeEditScreen(node: node)));
   }
 
-  ProxyNode? _resolveDefaultNode(
-    List<ProxyNode> nodes,
-    String? rememberedNodeName,
-  ) {
-    return HomeNodeController.resolveDefaultNodeFrom(nodes, rememberedNodeName);
-  }
-
   Future<ProxyNode?> _resolveRuntimeSelectedNode(
     ClashService clashService,
     List<ProxyNode> nodes,
@@ -347,10 +350,6 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
       runtimeNodeName,
     );
   }
-
-  Future<void> _autoTestAllNodes() => _runBatchLatencyTest();
-
-  Future<void> _handleTestAllLatency() => _runBatchLatencyTest();
 
   Future<void> _runBatchLatencyTest() async {
     if (_nodes.isEmpty) return;
@@ -365,8 +364,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     setState(() => _isBatchTesting = true);
 
     bool isCurrent() =>
-        mounted &&
-        !_disposed &&
+        _canUpdateUi &&
         _latencyBatchGeneration == generation &&
         _latencyController.isCurrentBatch(generation) &&
         subscriptionService.revision == subscriptionRevision;
@@ -388,7 +386,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     }
     _latencyBatchTimer?.cancel();
     if (!isCurrent()) {
-      if (mounted && !_disposed && _latencyBatchGeneration == generation) {
+      if (_canUpdateUi && _latencyBatchGeneration == generation) {
         setState(_cancelLatencyBatch);
       } else if (_latencyBatchGeneration == generation) {
         _cancelLatencyBatch();
@@ -411,7 +409,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
   }
 
   void _scheduleExitCountryResolution() {
-    if (!_isConnected || _nodes.isEmpty || !mounted || _disposed) return;
+    if (!_isConnected || _nodes.isEmpty || !_canUpdateUi) return;
     if (_isResolvingExitCountries) {
       _pendingExitCountryResolution = true;
       return;
@@ -426,9 +424,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     final generation = ++_exitCountryResolveGeneration;
 
     bool shouldContinue() {
-      return mounted &&
-          !_disposed &&
-          generation == _exitCountryResolveGeneration;
+      return _canUpdateUi && generation == _exitCountryResolveGeneration;
     }
 
     try {
@@ -446,7 +442,7 @@ extension _DesktopHomeRuntimeActions on _HomeScreenState {
     } finally {
       _isResolvingExitCountries = false;
 
-      if (_pendingExitCountryResolution && mounted && !_disposed) {
+      if (_pendingExitCountryResolution && _canUpdateUi) {
         _pendingExitCountryResolution = false;
         _scheduleExitCountryResolution();
       }

--- a/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_home_screen_part.dart
+++ b/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_home_screen_part.dart
@@ -47,6 +47,8 @@ class _HomeScreenState extends State<HomeScreen> {
   bool _updateCheckCompleted = false;
   int _updateCheckAttempts = 0;
 
+  bool get _canUpdateUi => mounted && !_disposed;
+
   bool _isConnectionTransitionActive(ClashService clashService) =>
       _isConnecting ||
       (!clashService.isRunning && clashService.connectionDesired);
@@ -61,7 +63,7 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || _disposed) return;
+      if (!_canUpdateUi) return;
       unawaited(_loadInitialData());
     });
   }
@@ -83,7 +85,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   void _handleSubscriptionServiceChanged() {
     final subService = _subscriptionService;
-    if (subService == null || !mounted || _disposed) return;
+    if (subService == null || !_canUpdateUi) return;
     if (_onSubscriptionChanged(subService)) {
       setState(() {});
     }
@@ -116,11 +118,11 @@ class _HomeScreenState extends State<HomeScreen> {
       return true;
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || _disposed) return;
+      if (!_canUpdateUi) return;
       if (!sync.isFirstSync && _isConnected) {
         unawaited(_reloadConfig());
       } else {
-        unawaited(_autoTestAllNodes());
+        unawaited(_runBatchLatencyTest());
       }
     });
     return true;
@@ -146,7 +148,7 @@ class _HomeScreenState extends State<HomeScreen> {
     if (_lastEmptySubscriptionPromptRevision == subService.revision) return;
     _lastEmptySubscriptionPromptRevision = subService.revision;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted && !_disposed) unawaited(_showInitialSubscriptionDialog());
+      if (_canUpdateUi) unawaited(_showInitialSubscriptionDialog());
     });
   }
 
@@ -195,7 +197,7 @@ class _HomeScreenState extends State<HomeScreen> {
       transactionCommitted = true;
       if (wasConnected) _resetPublicIpState();
 
-      if (!mounted || _disposed) return;
+      if (!_canUpdateUi) return;
       setState(() {
         _isConnected = false;
         _selectedNode = null;
@@ -204,14 +206,14 @@ class _HomeScreenState extends State<HomeScreen> {
       });
     } catch (error, stack) {
       recordDesktopConnectionFailure('更新网络设置失败', error: error, stack: stack);
-      if (mounted && !_disposed) {
+      if (_canUpdateUi) {
         setState(() {
           _isConnected = clashService.isRunning;
           _errorMessage = '更新网络设置失败，请重试';
         });
       }
     } finally {
-      if (mounted && !_disposed) {
+      if (_canUpdateUi) {
         setState(() => _isConnecting = false);
       }
     }
@@ -219,8 +221,7 @@ class _HomeScreenState extends State<HomeScreen> {
     final reconnectGeneration = automaticReconnectGeneration;
     if (transactionCommitted &&
         reconnectGeneration != null &&
-        mounted &&
-        !_disposed &&
+        _canUpdateUi &&
         clashService.isConnectionIntentCurrent(
           reconnectGeneration,
           connected: false,
@@ -241,7 +242,7 @@ class _HomeScreenState extends State<HomeScreen> {
       context,
       savedSites: savedSites,
     );
-    if (sites == null || !mounted || _disposed) return;
+    if (sites == null || !_canUpdateUi) return;
     await _applyForceProxySites(sites);
   }
 
@@ -255,12 +256,11 @@ class _HomeScreenState extends State<HomeScreen> {
     var reloadSucceeded = false;
     if (shouldReload) {
       await _reloadConfig();
-      reloadSucceeded = mounted &&
-          !_disposed &&
+      reloadSucceeded = _canUpdateUi &&
           _isConnected &&
           context.read<ClashService>().isRunning;
     }
-    if (!mounted || _disposed) return;
+    if (!_canUpdateUi) return;
 
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -294,14 +294,13 @@ class _HomeScreenState extends State<HomeScreen> {
         stopSucceeded = true;
       } catch (error, stack) {
         recordDesktopConnectionFailure('取消连接失败', error: error, stack: stack);
-        if (mounted && !_disposed) {
+        if (_canUpdateUi) {
           setState(() {
-            _errorMessage =
-                '取消连接失败：${error.toString().replaceFirst('StateError: ', '')}';
+            _errorMessage = '取消连接未完成：当前运行状态已重新核对。请稍后重试；持续失败请运行诊断。';
           });
         }
       } finally {
-        if (mounted && !_disposed) {
+        if (_canUpdateUi) {
           setState(() {
             _isConnected = clashService.isRunning;
             _isConnecting = false;
@@ -316,7 +315,7 @@ class _HomeScreenState extends State<HomeScreen> {
         stopSucceeded: stopSucceeded,
         isRunning: clashService.isRunning,
       );
-      if (notice != null && mounted && !_disposed) {
+      if (notice != null && _canUpdateUi) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(notice)),
         );
@@ -333,7 +332,7 @@ class _HomeScreenState extends State<HomeScreen> {
       });
       try {
         await clashService.runConnectionTransition(clashService.stop);
-        if (!mounted || _disposed) return;
+        if (!_canUpdateUi) return;
         setState(() {
           _isConnected = false;
           _latencyController.clear();
@@ -342,16 +341,14 @@ class _HomeScreenState extends State<HomeScreen> {
         });
       } catch (error, stack) {
         recordDesktopConnectionFailure('断开连接失败', error: error, stack: stack);
-        if (mounted && !_disposed) {
+        if (_canUpdateUi) {
           setState(() {
             _isConnected = clashService.isRunning;
-            _errorMessage =
-                '断开连接失败：${error.toString().replaceFirst('StateError: ', '')}。'
-                '请再次点击连接按钮重试恢复系统代理';
+            _errorMessage = '断开未完全完成：核心或系统代理仍在清理。请再次点击断开；持续失败请运行诊断。';
           });
         }
       } finally {
-        if (mounted && !_disposed) {
+        if (_canUpdateUi) {
           setState(() => _isConnecting = false);
         }
       }
@@ -365,7 +362,7 @@ class _HomeScreenState extends State<HomeScreen> {
       try {
         if (clashService.hasPendingSystemProxyRecovery) {
           final recovered = await clashService.recoverPendingSystemProxy();
-          if (!mounted || _disposed) return;
+          if (!_canUpdateUi) return;
           if (!clashService.isConnectionIntentCurrent(
             connectionGeneration,
             connected: true,
@@ -381,7 +378,7 @@ class _HomeScreenState extends State<HomeScreen> {
             );
             setState(() {
               _isConnecting = false;
-              _errorMessage = '连接失败: $reason';
+              _errorMessage = AppFailure.fromMessage(reason).userMessage;
               _resetPublicIpState();
             });
             return;
@@ -411,7 +408,7 @@ class _HomeScreenState extends State<HomeScreen> {
           });
           return;
         }
-        final autoSelect = _resolveDefaultNode(
+        final autoSelect = HomeNodeController.resolveDefaultNodeFrom(
           nodes,
           _disconnectedPreferredNodeName ??
               settingsService.settings.lastSelectedNodeName,
@@ -445,21 +442,17 @@ class _HomeScreenState extends State<HomeScreen> {
             readRuntimeNotice: () =>
                 clashService.lastRuntimePortAdjustmentMessage,
             switchPreferredNode: () async {
+              var switched = true;
               if (autoSelect != null) {
-                final switched = await clashService.switchSelectedProxy(
+                switched = await clashService.switchSelectedProxy(
                   autoSelect.name,
                 );
-                runtimeSelectedNode = await _resolveRuntimeSelectedNode(
-                  clashService,
-                  nodes,
-                );
-                return switched;
               }
               runtimeSelectedNode = await _resolveRuntimeSelectedNode(
                 clashService,
                 nodes,
               );
-              return true;
+              return switched;
             },
           ),
         );
@@ -477,18 +470,18 @@ class _HomeScreenState extends State<HomeScreen> {
         }
         if (!connectionResult.connected) {
           final reason = connectionResult.failureReason ?? '无法启动核心';
+          final failure = AppFailure.fromMessage(reason);
           final elevationRelaunch =
               clashService.consumeTunElevationRelaunchRequest();
           recordDesktopConnectionFailure(
             'Connection failed: $reason',
-            expected: AppFailure.fromMessage(reason).code ==
-                AppErrorCode.permissionRequired,
+            expected: failure.code == AppErrorCode.permissionRequired,
           );
-          if (!mounted || _disposed) return;
+          if (!_canUpdateUi) return;
           setState(() {
             _isConnected = false;
             _isConnecting = false;
-            _errorMessage = '连接失败: $reason';
+            _errorMessage = failure.userMessage;
             _resetPublicIpState();
           });
           if (elevationRelaunch) {
@@ -496,6 +489,7 @@ class _HomeScreenState extends State<HomeScreen> {
           }
           return;
         }
+        var nodePersistenceFailed = false;
         if (autoSelect != null &&
             connectionResult.preferredNodeSwitchSucceeded == true &&
             runtimeSelectedNode?.name == autoSelect.name &&
@@ -505,15 +499,15 @@ class _HomeScreenState extends State<HomeScreen> {
               connectionGeneration,
               connected: true,
             )) {
-          await _rememberSelectedNode(autoSelect);
+          nodePersistenceFailed = !await _rememberSelectedNode(autoSelect);
         }
-        if (!mounted || _disposed) return;
+        if (!_canUpdateUi) return;
         if (!clashService.isRunning ||
             !clashService.isConnectionIntentCurrent(
               connectionGeneration,
               connected: true,
             )) {
-          if (mounted && !_disposed) {
+          if (_canUpdateUi) {
             setState(() {
               _isConnected = false;
               _isConnecting = false;
@@ -544,10 +538,17 @@ class _HomeScreenState extends State<HomeScreen> {
           _selectedNode = runtimeSelectedNode;
           _disconnectedPreferredNodeName = null;
         });
-        _showRuntimePortAdjustmentNotice(connectionResult.runtimeNotice);
+        final nodeWarning = connectionResult.preferredNodeSwitchWarning(
+          preferredNodeName: autoSelect?.name,
+          runtimeNodeName: runtimeSelectedNode?.name,
+        );
+        final notice = nodePersistenceFailed
+            ? '已连接，但首选节点保存失败'
+            : nodeWarning ?? connectionResult.runtimeNotice;
+        _showRuntimePortAdjustmentNotice(notice);
         _scheduleExitCountryResolution();
         _schedulePublicIpRefresh();
-        unawaited(_autoTestAllNodes());
+        unawaited(_runBatchLatencyTest());
         _checkUpdateDelayed();
 
         // TUN data-plane observations belong to the service lifecycle. The
@@ -560,8 +561,7 @@ class _HomeScreenState extends State<HomeScreen> {
               connected: true,
             ),
           );
-          if (!mounted ||
-              _disposed ||
+          if (!_canUpdateUi ||
               !clashService.isRunning ||
               !clashService.isConnectionIntentCurrent(
                 connectionGeneration,
@@ -590,12 +590,8 @@ class _HomeScreenState extends State<HomeScreen> {
           stack: stack,
         );
         if (!mounted) return;
-        final msg = e
-            .toString()
-            .replaceFirst('Exception: ', '')
-            .replaceFirst('Bad state: ', '');
         setState(() {
-          _errorMessage = '连接失败: $msg';
+          _errorMessage = AppFailure.fromMessage(e).userMessage;
           _isConnecting = false;
           _resetPublicIpState();
         });
@@ -604,7 +600,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _showRuntimePortAdjustmentNotice(String? message) {
-    if (message == null || message.isEmpty || !mounted || _disposed) return;
+    if (message == null || message.isEmpty || !_canUpdateUi) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message),
@@ -701,7 +697,7 @@ class _HomeScreenState extends State<HomeScreen> {
               !_isConnected || _latencyController.canSelect(node),
           onClose: () => Navigator.of(routeContext).pop(),
           onRefresh: _loadInitialData,
-          onTestAll: _handleTestAllLatency,
+          onTestAll: _runBatchLatencyTest,
           onTestLatency: (node) =>
               _handleTestLatency(node.name, node.server, node.port),
           onSelectNode: _handleSelectNode,
@@ -725,7 +721,7 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       ),
     );
-    if (mounted && !_disposed) setState(() {});
+    if (_canUpdateUi) setState(() {});
   }
 }
 

--- a/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_node_edit_screen_part.dart
+++ b/packages/ssrvpn_shared/lib/desktop_ui/screens/desktop_node_edit_screen_part.dart
@@ -1,5 +1,9 @@
 part of desktop_node_edit_screen;
 
+@visibleForTesting
+String desktopNodeSaveFailureMessage(Object error) =>
+    safeUserFacingFailureMessage(error);
+
 class NodeEditScreen extends StatefulWidget {
   const NodeEditScreen({super.key, required this.node});
 
@@ -253,7 +257,7 @@ class _NodeEditScreenState extends State<NodeEditScreen> {
   }
 
   String _readableError(Object error) {
-    return error.toString().replaceFirst('Exception: ', '');
+    return desktopNodeSaveFailureMessage(error);
   }
 
   void _showError(String message) {

--- a/packages/ssrvpn_shared/lib/models/app_diagnostics.dart
+++ b/packages/ssrvpn_shared/lib/models/app_diagnostics.dart
@@ -20,6 +20,32 @@ enum AppErrorCode {
   final String wireName;
 }
 
+const _trustedUserFacingFailureMessages = <String>{
+  '客户端仍在初始化，请稍后重试',
+  '请先添加并刷新订阅',
+  '订阅已更新，请重新连接以使用最新配置',
+  '托盘连接失败，请重试或查看日志',
+  '无法安全断开当前连接，已阻止打开更新安装包',
+};
+
+String safeUserFacingFailureMessage(Object? error) {
+  final text = error?.toString().trim() ?? '';
+  var trustedText = text;
+  if (error is StateError) {
+    trustedText = error.message.toString().trim();
+  }
+  if (_trustedUserFacingFailureMessages.contains(trustedText)) {
+    return trustedText;
+  }
+  return AppFailure.fromMessage(error).userMessage;
+}
+
+String safeUserFacingFailureWithAction(Object? error, String action) =>
+    '${safeUserFacingFailureMessage(error)}\n${action.trim()}';
+
+String safeSubscriptionFailureMessage(Object? error) =>
+    safeUserFacingFailureMessage(error);
+
 class AppFailure {
   const AppFailure({
     required this.code,
@@ -32,6 +58,8 @@ class AppFailure {
   final String title;
   final String message;
   final String recommendedAction;
+
+  String get userMessage => '$title：$message $recommendedAction';
 
   static AppFailure fromMessage(Object? error) {
     final text = error?.toString().trim().toLowerCase() ?? '';
@@ -58,9 +86,9 @@ class AppFailure {
         ),
       AppErrorCode.dataPlaneDegraded => const AppFailure(
           code: AppErrorCode.dataPlaneDegraded,
-          title: '节点连接正在恢复',
-          message: '核心与系统网络接管仍正常，节点或外部网络暂时不可用。',
-          recommendedAction: '请等待自动切换；若持续失败，可手动切换节点。',
+          title: '连接质量提示',
+          message: '核心与系统网络接管仍在运行，但当前验证站点暂时不可达。',
+          recommendedAction: '如界面已显示连接，当前连接仍保留；若实际无法上网，请稍后重试或手动切换节点。',
         ),
       AppErrorCode.portOccupied => const AppFailure(
           code: AppErrorCode.portOccupied,
@@ -103,8 +131,8 @@ class AppFailure {
       AppErrorCode.configInvalid => const AppFailure(
           code: AppErrorCode.configInvalid,
           title: '配置不可用',
-          message: '生成或导入的配置未通过格式验证。',
-          recommendedAction: '请刷新订阅；若持续失败，请运行诊断。',
+          message: '节点或订阅配置未通过格式验证。',
+          recommendedAction: '请检查节点名称、服务器、端口和认证信息，或刷新订阅后重试。',
         ),
       AppErrorCode.updateFailed => const AppFailure(
           code: AppErrorCode.updateFailed,
@@ -124,6 +152,19 @@ class AppFailure {
   static AppErrorCode _classify(String text) {
     bool hasAny(Iterable<String> values) => values.any(text.contains);
 
+    if (text.contains('找不到生成的 mihomo 配置文件')) {
+      return AppErrorCode.configInvalid;
+    }
+    if (text.contains('电脑性能不足或配置校验超时，请重新连接')) {
+      return AppErrorCode.coreStartTimeout;
+    }
+    if (hasAny(const [
+      'mihomo 提前退出（退出码',
+      'tun 核心启动失败',
+      'mihomo 启动后未通过就绪检查',
+    ])) {
+      return AppErrorCode.coreUnavailable;
+    }
     if (hasAny(const ['address already in use', 'port occupied', '端口被占用']) ||
         (text.contains('bind') && text.contains('port'))) {
       return AppErrorCode.portOccupied;
@@ -135,6 +176,8 @@ class AppFailure {
       '权限不足',
       '需要管理员',
       '需要授权',
+      '授权失败',
+      '管理员授权',
       '以管理员身份运行',
     ])) {
       return AppErrorCode.permissionRequired;
@@ -144,6 +187,8 @@ class AppFailure {
       '代理待恢复',
       'proxy recovery',
       'restore proxy',
+      '系统代理 powershell 命令响应超时',
+      '系统代理命令响应超时',
     ])) {
       return AppErrorCode.proxyRecoveryPending;
     }
@@ -157,9 +202,24 @@ class AppFailure {
     ])) {
       return AppErrorCode.subscriptionChanged;
     }
-    if (hasAny(const ['订阅', 'subscription']) &&
-        hasAny(const ['失败', 'failed', 'invalid', '无可用'])) {
+    if ((hasAny(const ['订阅', 'subscription']) &&
+            hasAny(const ['失败', 'failed', 'invalid', '无可用'])) ||
+        hasAny(const ['请先添加并刷新订阅', '请先刷新订阅', '未获取到可用节点'])) {
       return AppErrorCode.subscriptionFailed;
+    }
+    if (hasAny(const [
+      '节点备注名',
+      '服务器地址无效',
+      '端口必须是',
+      '节点缺少',
+      '没有可编辑的订阅配置',
+      '找不到要修改的节点',
+      '订阅配置中没有有效的节点列表',
+      '修改后的订阅不包含可运行节点',
+      '字段清理后名称冲突',
+      '运行时保留名称',
+    ])) {
+      return AppErrorCode.configInvalid;
     }
     if (hasAny(const ['配置', 'config', 'yaml']) &&
         hasAny(const ['失败', 'invalid', '无效', '验证'])) {
@@ -179,6 +239,24 @@ class AppFailure {
     }
     if (hasAny(const ['mihomo api', '核心连接', 'core unavailable', '核心退出'])) {
       return AppErrorCode.coreUnavailable;
+    }
+    if (hasAny(const [
+      'mihomo service is not initialized',
+      'core is not initialized',
+      '核心未初始化',
+      '连接服务尚未初始化',
+      '客户端仍在初始化',
+      '无法启动核心',
+    ])) {
+      return AppErrorCode.coreUnavailable;
+    }
+    if (hasAny(const [
+      'data plane',
+      'data-plane',
+      '数据通道',
+      '网络验证失败',
+    ])) {
+      return AppErrorCode.dataPlaneDegraded;
     }
     return AppErrorCode.unknown;
   }

--- a/packages/ssrvpn_shared/lib/runtime_notice.dart
+++ b/packages/ssrvpn_shared/lib/runtime_notice.dart
@@ -1,27 +1,50 @@
 import 'dart:async';
 
-const coreAutoRecoveredRuntimeNotice = '核心已自动恢复';
+enum RuntimeNoticeLevel { success, progress, warning, error }
+
+class RuntimeNotice {
+  const RuntimeNotice(this.message, {required this.level});
+
+  const RuntimeNotice.success(String message)
+      : this(message, level: RuntimeNoticeLevel.success);
+
+  const RuntimeNotice.progress(String message)
+      : this(message, level: RuntimeNoticeLevel.progress);
+
+  const RuntimeNotice.warning(String message)
+      : this(message, level: RuntimeNoticeLevel.warning);
+
+  const RuntimeNotice.error(String message)
+      : this(message, level: RuntimeNoticeLevel.error);
+
+  final String message;
+  final RuntimeNoticeLevel level;
+}
+
+const coreAutoRecoveredRuntimeNotice = RuntimeNotice.success('核心已自动恢复');
 const runtimeNoticeSuccessDuration = Duration(seconds: 3);
-const windowsTunElevationHandoffRuntimeNotice =
-    '管理员授权已通过。SSRVPN 将暂时关闭当前窗口，并自动以管理员模式重新打开、继续连接 TUN；'
-    '请耐心等待，不要重复启动软件。';
+const windowsTunElevationHandoffRuntimeNotice = RuntimeNotice.progress(
+  '管理员授权已通过。SSRVPN 将暂时关闭当前窗口，并自动以管理员模式重新打开、继续连接 TUN；'
+  '请耐心等待，不要重复启动软件。',
+);
 const windowsTunElevationHandoffNoticeDuration = Duration(seconds: 3);
 
-bool isSuccessfulRuntimeNotice(String? message) =>
-    message == coreAutoRecoveredRuntimeNotice;
-
-bool isInProgressRuntimeNotice(String? message) =>
-    message == windowsTunElevationHandoffRuntimeNotice;
-
 Timer? scheduleSuccessfulRuntimeNoticeClear({
-  required String message,
-  required String? Function() currentMessage,
+  required RuntimeNotice notice,
+  required RuntimeNotice? Function() currentNotice,
   required void Function() clear,
   Duration delay = runtimeNoticeSuccessDuration,
 }) {
-  if (!isSuccessfulRuntimeNotice(message)) return null;
+  if (notice.level != RuntimeNoticeLevel.success) return null;
 
   return Timer(delay, () {
-    if (currentMessage() == message) clear();
+    if (identical(currentNotice(), notice)) clear();
   });
 }
+
+bool shouldClearRuntimeNoticeOnRunningEdge({
+  required bool wasRunning,
+  required bool isRunning,
+  required RuntimeNotice? notice,
+}) =>
+    notice != null && !wasRunning && isRunning;

--- a/packages/ssrvpn_shared/lib/services/clash_service_base.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_base.dart
@@ -13,6 +13,7 @@ import '../models/app_settings.dart';
 import '../models/proxy_node.dart';
 import '../models/proxy_group.dart';
 import '../models/public_ip_info.dart';
+import '../runtime_notice.dart';
 import 'clash_config_generator.dart';
 import '../utils/log_redactor.dart';
 import '../utils/private_node_latency_policy.dart';
@@ -28,6 +29,9 @@ part 'clash_service_diagnostics.dart';
 part 'clash_service_runtime_support.dart';
 part 'clash_service_data_plane_support.dart';
 part 'clash_service_health_monitor.dart';
+part 'clash_service_latency_support.dart';
+
+enum RuntimeLogLevel { debug, info, warning, error }
 
 /// Clash API 交互的公共逻辑基类
 ///
@@ -43,10 +47,12 @@ abstract class ClashServiceBase
         _ClashRuntimeSupport,
         _ClashDataPlaneSupport,
         _ClashDiagnosticsSupport,
-        _ClashHealthSupport {
+        _ClashHealthSupport,
+        _ClashLatencySupport {
+  static int _nextLogSession = 0;
+
   // ── 状态 ──
   bool _isRunning = false;
-  bool _healthCheckInProgress = false;
   int _consecutiveHealthCheckFailures = 0;
   String? _lastHealthCheckError;
   String? _lastStartError;
@@ -62,6 +68,9 @@ abstract class ClashServiceBase
   String _configDir = '';
   String _configPath = '';
   String _logBuffer = '';
+  late final String _logSessionId =
+      '${DateTime.now().toUtc().microsecondsSinceEpoch.toRadixString(36)}-'
+      '${(_nextLogSession++).toRadixString(36)}';
   // ── HTTP 客户端 ──
   HttpClient? _directHttpClient;
   http.Client? _apiClient;
@@ -69,7 +78,7 @@ abstract class ClashServiceBase
   // ── 回调 ──
   void Function()? onStatusChanged;
   void Function()? onProcessExit;
-  void Function(String message)? onRuntimeNotice;
+  void Function(RuntimeNotice notice)? onRuntimeNotice;
   void Function(String message)? onLog;
   final Set<void Function()> _statusListeners = {};
 
@@ -81,6 +90,7 @@ abstract class ClashServiceBase
 
   /// Subclasses can use this to make direct HTTP calls to the Clash API.
   @protected
+  @override
   http.Client? get apiClient => _apiClient;
 
   @protected
@@ -109,7 +119,7 @@ abstract class ClashServiceBase
   @protected
   @override
   void setLastHealthCheckError(String? value) {
-    _lastHealthCheckError = value;
+    if (_canPublishHealthCheckResult) _lastHealthCheckError = value;
   }
 
   @override
@@ -262,11 +272,13 @@ abstract class ClashServiceBase
 
   // ── Clash API ──
 
+  @override
   String _apiUrl(String path) {
     final cleanPath = path.startsWith('/') ? path.substring(1) : path;
     return 'http://127.0.0.1:${_settings.apiPort}/$cleanPath';
   }
 
+  @override
   Map<String, String> apiHeaders({bool json = false}) {
     final apiSecret = RuntimeConfigNamePolicy.canonicalApiSecret(
       _settings.apiSecret,
@@ -377,7 +389,11 @@ abstract class ClashServiceBase
       }
       return false;
     } catch (e) {
-      log('切换代理失败: $e');
+      log(
+        '切换代理失败: $e',
+        level: RuntimeLogLevel.warning,
+        event: 'proxy_switch',
+      );
       return false;
     }
   }
@@ -484,7 +500,14 @@ abstract class ClashServiceBase
   Future<bool> _switchProxyGroup(String groupName, String nodeName) async {
     try {
       final client = _apiClient;
-      if (client == null) return false;
+      if (client == null) {
+        log(
+          '切换代理组失败: 本地 API 客户端未初始化',
+          level: RuntimeLogLevel.warning,
+          event: 'proxy_switch',
+        );
+        return false;
+      }
       final url = _apiUrl('/proxies/${Uri.encodeComponent(groupName)}');
       final response = await client
           .put(
@@ -493,9 +516,22 @@ abstract class ClashServiceBase
             body: jsonEncode({'name': nodeName}),
           )
           .timeout(const Duration(seconds: 5));
-      return response.statusCode == 200 || response.statusCode == 204;
+      final accepted = response.statusCode == 200 || response.statusCode == 204;
+      if (!accepted) {
+        log(
+          '切换代理组未被核心接受: group=$groupName, '
+          'HTTP ${response.statusCode}',
+          level: RuntimeLogLevel.warning,
+          event: 'proxy_switch',
+        );
+      }
+      return accepted;
     } catch (e) {
-      log('切换代理组失败 $groupName -> $nodeName: $e');
+      log(
+        '切换代理组失败 $groupName -> $nodeName: $e',
+        level: RuntimeLogLevel.warning,
+        event: 'proxy_switch',
+      );
       return false;
     }
   }
@@ -534,7 +570,12 @@ abstract class ClashServiceBase
       if (lastSeen == expectedNodeName) return true;
       await Future<void>.delayed(const Duration(milliseconds: 40));
     }
-    log('代理组状态未生效 $groupName: expected=$expectedNodeName, actual=$lastSeen');
+    log(
+      '代理组状态未生效 $groupName: '
+      'expected=$expectedNodeName, actual=$lastSeen',
+      level: RuntimeLogLevel.warning,
+      event: 'proxy_switch',
+    );
     return false;
   }
 
@@ -548,10 +589,24 @@ abstract class ClashServiceBase
       final client = _apiClient;
       if (client == null) return;
       final connUrl = _apiUrl('/connections');
-      await client
+      final response = await client
           .delete(Uri.parse(connUrl), headers: apiHeaders())
           .timeout(const Duration(seconds: 3));
-    } catch (_) {}
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        log(
+          '节点已切换，但旧连接清理请求未被核心接受: '
+          'HTTP ${response.statusCode}',
+          level: RuntimeLogLevel.warning,
+          event: 'connection_cleanup',
+        );
+      }
+    } catch (error) {
+      log(
+        '节点已切换，但旧连接清理未完成: $error',
+        level: RuntimeLogLevel.warning,
+        event: 'connection_cleanup',
+      );
+    }
   }
 
   Future<int> _countActiveConnections() async {
@@ -568,89 +623,6 @@ abstract class ClashServiceBase
       }
     } catch (_) {}
     return -1;
-  }
-
-  // ── 延迟测试 ──
-
-  /// 测试节点延迟（直连 TCP）
-  Future<int> testLatency(
-    String server,
-    int port, {
-    int timeoutMs = 5000,
-  }) async {
-    final stopwatch = Stopwatch()..start();
-    try {
-      final socket = await Socket.connect(
-        server,
-        port,
-        timeout: Duration(milliseconds: timeoutMs),
-      );
-      socket.destroy();
-      stopwatch.stop();
-      return stopwatch.elapsedMilliseconds;
-    } catch (_) {
-      return -1;
-    }
-  }
-
-  /// 批量测试节点延迟
-  Future<void> testAllLatencies(
-    List<ProxyNode> nodes,
-    void Function(String name, int latency) onResult, {
-    int concurrency = 10,
-    int timeoutMs = 5000,
-    bool Function()? shouldContinue,
-  }) async {
-    final random = Random();
-    for (var i = 0; i < nodes.length; i += concurrency) {
-      if (shouldContinue?.call() == false) return;
-      final batch = nodes.skip(i).take(concurrency).toList();
-      final results = await Future.wait(
-        batch.map(
-          (node) => testLatency(node.server, node.port, timeoutMs: timeoutMs),
-        ),
-      );
-      for (var j = 0; j < batch.length; j++) {
-        if (shouldContinue?.call() == false) return;
-        final latency = PrivateNodeLatencyPolicy.displayLatencyForNode(
-          batch[j].name,
-          results[j],
-          random: random,
-        );
-        onResult(batch[j].name, latency);
-      }
-    }
-  }
-
-  @override
-  String _localHttpProxyConfig() => 'PROXY 127.0.0.1:${_settings.proxyPort}';
-  @visibleForTesting
-  @override
-  String userConnectivityProxyConfig() =>
-      _settings.enableTun ? 'DIRECT' : _localHttpProxyConfig();
-
-  // ── 健康检查 ──
-
-  /// 健康检查（HTTP 请求验证 API 可用性）
-  @override
-  Future<bool> healthCheck() async {
-    try {
-      final client = _apiClient;
-      if (client == null) return false;
-      final response = await client
-          .get(Uri.parse(_apiUrl('/version')), headers: apiHeaders())
-          .timeout(const Duration(seconds: 2));
-      if (response.statusCode == 200) {
-        _lastHealthCheckError = null;
-        return true;
-      }
-      _lastHealthCheckError =
-          'API 返回 HTTP ${response.statusCode}，端口 ${_settings.apiPort}';
-      return false;
-    } catch (e) {
-      _lastHealthCheckError = '无法连接 127.0.0.1:${_settings.apiPort} ($e)';
-      return false;
-    }
   }
 
   // ── 状态监控 ──
@@ -678,15 +650,42 @@ abstract class ClashServiceBase
   static const bool _kReleaseMode = bool.fromEnvironment('dart.vm.product');
 
   @override
-  void log(String message) {
-    final sanitized = LogRedactor.sanitize(message);
-    _logBuffer = '$sanitized\n$_logBuffer';
-    if (_logBuffer.length > 10000) _logBuffer = _logBuffer.substring(0, 10000);
-    onLog?.call(sanitized);
+  void log(
+    String message, {
+    RuntimeLogLevel level = RuntimeLogLevel.info,
+    String event = 'runtime',
+  }) {
+    final sanitized = LogRedactor.sanitize(message).replaceAll(
+      RegExp(r'[\r\n]+'),
+      ' ↩ ',
+    );
+    final normalizedEvent = event.trim().toLowerCase();
+    final safeEvent =
+        RegExp(r'^[a-z0-9][a-z0-9_.-]{0,47}$').hasMatch(normalizedEvent)
+            ? normalizedEvent
+            : 'runtime';
+    final line = '[${DateTime.now().toUtc().toIso8601String()}] '
+        '[${level.name.toUpperCase()}] [$safeEvent] '
+        '[session=$_logSessionId] $sanitized';
+    _logBuffer = '$line\n$_logBuffer';
+    if (_logBuffer.length > 10000) {
+      final completeLineEnd = _logBuffer.lastIndexOf('\n', 9999);
+      _logBuffer = _logBuffer.substring(
+        0,
+        completeLineEnd >= 0 ? completeLineEnd + 1 : 10000,
+      );
+    }
+    writePlatformLog(line);
+    onLog?.call(line);
     if (!_kReleaseMode) {
-      debugLog(sanitized);
+      debugLog(line);
     }
   }
+
+  /// Override for durable platform log files. [line] is already redacted,
+  /// timestamped and normalized to one physical line.
+  @protected
+  void writePlatformLog(String line) {}
 
   /// Override for platform-specific debug output (debugPrint, file logging, etc.)
   @protected
@@ -695,8 +694,11 @@ abstract class ClashServiceBase
   // ── 状态管理 ──
 
   void setRunning(bool running) {
+    if (_isRunning != running) {
+      _invalidateHealthMonitorSession();
+      _resetDataPlaneObservationSession();
+    }
     _isRunning = running;
-    if (!running) clearConnectivityWarningSilently();
   }
 
   /// Records an unexpected core loss. Unlike an intentional stop during an
@@ -705,8 +707,9 @@ abstract class ClashServiceBase
   @protected
   void markConnectionLost() {
     requestConnectionIntent(false);
+    _invalidateHealthMonitorSession();
+    _resetDataPlaneObservationSession();
     _isRunning = false;
-    clearConnectivityWarningSilently();
     _notifyStatusChanged();
   }
 
@@ -739,8 +742,8 @@ abstract class ClashServiceBase
   }
 
   @protected
-  void notifyRuntimeNotice(String message) {
-    onRuntimeNotice?.call(message);
+  void notifyRuntimeNotice(RuntimeNotice notice) {
+    onRuntimeNotice?.call(notice);
   }
 
   // ── 资源释放 ──

--- a/packages/ssrvpn_shared/lib/services/clash_service_data_plane_support.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_data_plane_support.dart
@@ -3,15 +3,22 @@ part of 'clash_service_base.dart';
 /// Advisory node/internet state that is deliberately separate from the
 /// process, service and runtime-configuration lifecycle.
 mixin _ClashDataPlaneSupport {
-  bool _dataPlaneObservationInProgress = false;
+  int _dataPlaneObservationEpoch = 0;
+  int? _activeDataPlaneObservationEpoch;
   String? _connectivityWarning;
 
   bool get isRunning;
   AppSettings get settings;
-  void log(String message);
+  void log(
+    String message, {
+    RuntimeLogLevel level = RuntimeLogLevel.info,
+    String event = 'runtime',
+  });
   void notifyStatusChanged();
-  String _localHttpProxyConfig();
-  String userConnectivityProxyConfig();
+  String _localHttpProxyConfig() => 'PROXY 127.0.0.1:${settings.proxyPort}';
+  @visibleForTesting
+  String userConnectivityProxyConfig() =>
+      settings.enableTun ? 'DIRECT' : _localHttpProxyConfig();
   @protected
   Duration get dataPlaneObservationTimeout => const Duration(seconds: 30);
 
@@ -39,18 +46,32 @@ mixin _ClashDataPlaneSupport {
     _connectivityWarning = null;
   }
 
+  void _resetDataPlaneObservationSession() {
+    _dataPlaneObservationEpoch++;
+    clearConnectivityWarningSilently();
+  }
+
   @protected
   void scheduleDataPlaneObservation() {
-    if (_dataPlaneObservationInProgress || !isRunning) return;
-    _dataPlaneObservationInProgress = true;
+    final observationEpoch = _dataPlaneObservationEpoch;
+    if (_activeDataPlaneObservationEpoch == observationEpoch || !isRunning) {
+      return;
+    }
+    _activeDataPlaneObservationEpoch = observationEpoch;
     final observation = Future<void>.sync(observeDataPlaneHealth);
     // Future.timeout does not cancel its source. Keep the ownership flag until
-    // the real probe settles so a timed-out probe cannot overlap later probes.
+    // the real probe settles so probes cannot overlap within one session.
     unawaited(
       observation.then<void>(
-        (_) => _dataPlaneObservationInProgress = false,
+        (_) {
+          if (_activeDataPlaneObservationEpoch == observationEpoch) {
+            _activeDataPlaneObservationEpoch = null;
+          }
+        },
         onError: (Object _, StackTrace __) {
-          _dataPlaneObservationInProgress = false;
+          if (_activeDataPlaneObservationEpoch == observationEpoch) {
+            _activeDataPlaneObservationEpoch = null;
+          }
         },
       ),
     );
@@ -58,10 +79,15 @@ mixin _ClashDataPlaneSupport {
       observation
           .timeout(dataPlaneObservationTimeout)
           .catchError((Object error, StackTrace stack) {
-        log('数据通道观察失败，不影响核心生命周期: $error');
-        if (isRunning) {
-          setConnectivityWarning('数据通道检查未能完成，请稍后重试或切换节点');
+        if (observationEpoch != _dataPlaneObservationEpoch || !isRunning) {
+          return;
         }
+        log(
+          '数据通道观察失败，不影响核心生命周期: $error',
+          level: RuntimeLogLevel.warning,
+          event: 'data_plane_probe',
+        );
+        setConnectivityWarning('数据通道检查未能完成，请稍后重试或切换节点');
       }),
     );
   }

--- a/packages/ssrvpn_shared/lib/services/clash_service_diagnostics.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_diagnostics.dart
@@ -23,7 +23,11 @@ mixin _ClashDiagnosticsSupport implements ClashPlatformDiagnosticCapability {
   String get configPath;
   @protected
   Duration get diagnosticCheckTimeout => const Duration(seconds: 10);
-  void log(String message);
+  void log(
+    String message, {
+    RuntimeLogLevel level = RuntimeLogLevel.info,
+    String event = 'runtime',
+  });
   String get configDir;
 
   Future<bool> healthCheck();

--- a/packages/ssrvpn_shared/lib/services/clash_service_health_monitor.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_health_monitor.dart
@@ -1,26 +1,88 @@
 part of 'clash_service_base.dart';
 
+final Object _healthMonitorEpochZoneKey = Object();
+
 mixin _ClashHealthSupport {
-  Future<bool> healthCheck();
-  void log(String message);
+  int _healthMonitorEpoch = 0;
+  int? _activeHealthCheckEpoch;
+
+  http.Client? get apiClient;
+  AppSettings get settings;
+  String _apiUrl(String path);
+  Map<String, String> apiHeaders({bool json = false});
+  void log(
+    String message, {
+    RuntimeLogLevel level = RuntimeLogLevel.info,
+    String event = 'runtime',
+  });
   void setLastHealthCheckError(String? value);
+
+  bool get _canPublishHealthCheckResult {
+    final monitorEpoch = Zone.current[_healthMonitorEpochZoneKey] as int?;
+    return monitorEpoch == null || monitorEpoch == _healthMonitorEpoch;
+  }
+
+  /// Verifies that the local core control API is reachable and responsive.
+  Future<bool> healthCheck() async {
+    try {
+      final client = apiClient;
+      if (client == null) return false;
+      final response = await client
+          .get(Uri.parse(_apiUrl('/version')), headers: apiHeaders())
+          .timeout(const Duration(seconds: 2));
+      if (response.statusCode == 200) {
+        setLastHealthCheckError(null);
+        return true;
+      }
+      setLastHealthCheckError(
+        'API 返回 HTTP ${response.statusCode}，端口 ${settings.apiPort}',
+      );
+      return false;
+    } catch (error) {
+      setLastHealthCheckError(
+        '无法连接 127.0.0.1:${settings.apiPort} ($error)',
+      );
+      return false;
+    }
+  }
 
   @protected
   Duration get healthCheckTimeout => const Duration(seconds: 10);
 
   @protected
-  Future<bool> boundedHealthCheck() async {
+  Future<bool> boundedHealthCheck([
+    Future<bool>? source,
+    bool Function()? shouldPublish,
+  ]) async {
     try {
-      return await healthCheck().timeout(healthCheckTimeout);
+      return await (source ?? Future<bool>.sync(healthCheck))
+          .timeout(healthCheckTimeout);
     } on TimeoutException {
-      setLastHealthCheckError('健康检查超时');
-      log('Mihomo 健康检查超时 (${healthCheckTimeout.inSeconds}s)');
+      if (shouldPublish?.call() == false) return false;
+      setLastHealthCheckError('运行状态检查超时');
+      log(
+        '运行状态检查超时 (${healthCheckTimeout.inSeconds}s)',
+        level: RuntimeLogLevel.warning,
+        event: 'health_check',
+      );
       return false;
     } catch (error) {
-      setLastHealthCheckError('健康检查异常');
-      log('Mihomo 健康检查异常: $error');
+      if (shouldPublish?.call() == false) return false;
+      setLastHealthCheckError('运行状态检查异常');
+      log(
+        '运行状态检查异常: $error',
+        level: RuntimeLogLevel.warning,
+        event: 'health_check',
+      );
       return false;
     }
+  }
+
+  @protected
+  void onPeriodicHealthCheckResult(bool healthy) {}
+
+  void _invalidateHealthMonitorSession() {
+    _healthMonitorEpoch++;
   }
 }
 
@@ -32,36 +94,78 @@ extension ClashServiceHealthMonitor on ClashServiceBase {
       _statusTimer = null;
       return;
     }
+    final monitorEpoch = _healthMonitorEpoch;
     _statusTimer = Timer.periodic(statusMonitorInterval, (_) async {
-      if (!_isRunning || _healthCheckInProgress) return;
-      _healthCheckInProgress = true;
-      try {
-        final healthy = await boundedHealthCheck();
-        if (healthy) {
-          _consecutiveHealthCheckFailures = 0;
-          scheduleDataPlaneObservation();
-        } else if (_isRunning) {
-          _consecutiveHealthCheckFailures++;
-          this.log(
-            'Mihomo 健康检查失败 ($_consecutiveHealthCheckFailures/'
-            '$maxConsecutiveHealthCheckFailures): $_lastHealthCheckError',
-          );
-          if (_consecutiveHealthCheckFailures >=
-              maxConsecutiveHealthCheckFailures) {
-            final recoveryGeneration = captureAutomaticRestartIntent();
-            stopStatusMonitor();
-            _notifyStatusChanged();
-            this.log('Mihomo 控制面持续失联，进入串行恢复');
-            if (recoveryGeneration != null &&
-                isConnectionIntentCurrent(
-                  recoveryGeneration,
-                  connected: true,
-                )) {
-              notifyRuntimeNotice('Mihomo 暂时失去响应，正在自动恢复连接…');
+      if (!_isRunning ||
+          monitorEpoch != _healthMonitorEpoch ||
+          _activeHealthCheckEpoch == monitorEpoch) {
+        return;
+      }
+      _activeHealthCheckEpoch = monitorEpoch;
+      var sourceSettled = false;
+      final source = runZoned<Future<bool>>(
+        () => Future<bool>.sync(healthCheck),
+        zoneValues: {_healthMonitorEpochZoneKey: monitorEpoch},
+      );
+      unawaited(
+        source.then<void>(
+          (_) {
+            sourceSettled = true;
+            if (_activeHealthCheckEpoch == monitorEpoch) {
+              _activeHealthCheckEpoch = null;
             }
-            var recovered = false;
-            try {
-              recovered = await runConnectionTransition(() async {
+          },
+          onError: (Object _, StackTrace __) {
+            sourceSettled = true;
+            if (_activeHealthCheckEpoch == monitorEpoch) {
+              _activeHealthCheckEpoch = null;
+            }
+          },
+        ),
+      );
+      final healthy = await boundedHealthCheck(
+        source,
+        () => monitorEpoch == _healthMonitorEpoch && _isRunning,
+      );
+      if (monitorEpoch != _healthMonitorEpoch || !_isRunning) return;
+      if (!sourceSettled) {
+        // An unknown interval is not a stable healthy interval. Platforms may
+        // use this hook to restart a recovery-budget cooldown without treating
+        // the observation timeout itself as a lifecycle failure.
+        onPeriodicHealthCheckResult(false);
+        this.log(
+          '运行状态检查观察超时；底层检查尚未结束，本轮不累计失败',
+          level: RuntimeLogLevel.warning,
+          event: 'health_check',
+        );
+        return;
+      }
+      onPeriodicHealthCheckResult(healthy);
+      if (healthy) {
+        _consecutiveHealthCheckFailures = 0;
+        scheduleDataPlaneObservation();
+      } else if (_isRunning) {
+        _consecutiveHealthCheckFailures++;
+        this.log(
+          '运行状态检查失败 ($_consecutiveHealthCheckFailures/'
+          '$maxConsecutiveHealthCheckFailures): $_lastHealthCheckError',
+          level: RuntimeLogLevel.warning,
+          event: 'health_check',
+        );
+        if (_consecutiveHealthCheckFailures >=
+            maxConsecutiveHealthCheckFailures) {
+          final recoveryGeneration = captureAutomaticRestartIntent();
+          stopStatusMonitor();
+          _notifyStatusChanged();
+          this.log(
+            '运行状态持续异常，进入串行恢复',
+            level: RuntimeLogLevel.warning,
+            event: 'health_recovery',
+          );
+          var recovered = false;
+          try {
+            recovered = await runConnectionTransition(() async {
+              try {
                 if (recoveryGeneration == null ||
                     !isConnectionIntentCurrent(
                       recoveryGeneration,
@@ -70,66 +174,95 @@ extension ClashServiceHealthMonitor on ClashServiceBase {
                   await onStopRequired();
                   return false;
                 }
-                return recoverAfterHealthCheckFailure(recoveryGeneration);
-              });
-            } catch (error) {
-              this.log('Mihomo 失联后的恢复失败: $error');
-            }
-
-            var intentCurrent = recoveryGeneration != null &&
-                isConnectionIntentCurrent(
+                notifyRuntimeNotice(
+                  const RuntimeNotice.progress(
+                    '运行状态暂时异常，正在自动恢复连接…',
+                  ),
+                );
+                final platformRecovered =
+                    await recoverAfterHealthCheckFailure(recoveryGeneration);
+                final intentStillCurrent = isConnectionIntentCurrent(
                   recoveryGeneration,
                   connected: true,
                 );
-            if (recovered && intentCurrent && _isRunning) {
-              _consecutiveHealthCheckFailures = 0;
-              this.log('Mihomo 连接已自动恢复');
-              notifyRuntimeNotice('连接已自动恢复');
-              startStatusMonitor();
-              return;
-            }
-
-            // A disconnect or quit may win while recovery is in flight. If a
-            // late platform restart nevertheless succeeded, stop it before
-            // publishing the final state.
-            if (_isRunning) {
-              try {
-                await runConnectionTransition(onStopRequired);
-              } catch (error) {
-                this.log('取消过期自动恢复时停止核心失败: $error');
+                if ((!platformRecovered || !intentStillCurrent) && _isRunning) {
+                  await onStopRequired();
+                }
+                return platformRecovered && intentStillCurrent;
+              } catch (_) {
+                if (_isRunning) {
+                  try {
+                    await onStopRequired();
+                  } catch (_) {}
+                }
+                rethrow;
               }
-            }
-            intentCurrent = recoveryGeneration != null &&
-                isConnectionIntentCurrent(
-                  recoveryGeneration,
-                  connected: true,
-                );
-            if (_isRunning) {
-              this.log('Mihomo 自动恢复失败，平台仍报告核心或服务正在运行');
-              notifyRuntimeNotice(
+            });
+          } catch (error) {
+            this.log(
+              '运行状态异常后的恢复失败: $error',
+              level: RuntimeLogLevel.error,
+              event: 'health_recovery',
+            );
+          }
+
+          var intentCurrent = recoveryGeneration != null &&
+              isConnectionIntentCurrent(
+                recoveryGeneration,
+                connected: true,
+              );
+          if (recovered && intentCurrent && _isRunning) {
+            _consecutiveHealthCheckFailures = 0;
+            this.log(
+              '连接运行状态已自动恢复',
+              event: 'health_recovery',
+            );
+            notifyRuntimeNotice(
+              const RuntimeNotice.success('连接已自动恢复'),
+            );
+            startStatusMonitor();
+            return;
+          }
+
+          intentCurrent = recoveryGeneration != null &&
+              isConnectionIntentCurrent(
+                recoveryGeneration,
+                connected: true,
+              );
+          if (_isRunning) {
+            this.log(
+              '自动恢复失败，平台仍报告核心或服务正在运行',
+              level: RuntimeLogLevel.error,
+              event: 'health_recovery',
+            );
+            notifyRuntimeNotice(
+              RuntimeNotice.error(
                 intentCurrent
                     ? '自动恢复失败，后台核心仍在运行且清理未完成，请点击断开重试'
                     : '断开尚未完成，后台核心仍在运行，请再次点击断开',
-              );
-              _notifyStatusChanged();
-              return;
-            }
-            if (intentCurrent) {
-              markConnectionLost();
-              notifyRuntimeNotice('连接已断开：Mihomo 自动恢复失败，请重新连接');
-            } else {
-              setRunning(false);
-              _notifyStatusChanged();
-            }
+              ),
+            );
+            _notifyStatusChanged();
+            return;
+          }
+          if (intentCurrent) {
+            markConnectionLost();
+            notifyRuntimeNotice(
+              const RuntimeNotice.error(
+                '连接已断开：自动恢复失败，请重新连接',
+              ),
+            );
+          } else {
+            setRunning(false);
+            _notifyStatusChanged();
           }
         }
-      } finally {
-        _healthCheckInProgress = false;
       }
     });
   }
 
   void stopStatusMonitor() {
+    _invalidateHealthMonitorSession();
     _statusTimer?.cancel();
     _statusTimer = null;
     _ruleProviderRefreshTimer?.cancel();

--- a/packages/ssrvpn_shared/lib/services/clash_service_latency_support.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_latency_support.dart
@@ -1,0 +1,140 @@
+part of 'clash_service_base.dart';
+
+/// Node-aware latency probes and bounded batch orchestration.
+mixin _ClashLatencySupport {
+  bool get isRunning;
+  AppSettings get settings;
+  http.Client? get apiClient;
+  String _apiUrl(String path);
+  Map<String, String> apiHeaders({bool json = false});
+  void log(
+    String message, {
+    RuntimeLogLevel level = RuntimeLogLevel.info,
+    String event = 'runtime',
+  });
+
+  /// Low-level direct TCP probe. Node callers should use [testNodeLatency].
+  Future<int> testLatency(
+    String server,
+    int port, {
+    int timeoutMs = 5000,
+  }) async {
+    final stopwatch = Stopwatch()..start();
+    try {
+      final socket = await Socket.connect(
+        server,
+        port,
+        timeout: Duration(milliseconds: timeoutMs),
+      );
+      socket.destroy();
+      stopwatch.stop();
+      return stopwatch.elapsedMilliseconds;
+    } catch (_) {
+      return -1;
+    }
+  }
+
+  /// Tests a materialized node without treating a TCP handshake as proof for
+  /// UDP/QUIC-only proxy protocols.
+  Future<int> testNodeLatency(
+    ProxyNode node, {
+    int timeoutMs = 5000,
+  }) async {
+    if (isRunning) {
+      final apiLatency = await _testMihomoNodeLatency(node.name, timeoutMs);
+      return apiLatency ?? -1;
+    }
+    if (const {'hysteria', 'hysteria2', 'tuic'}
+        .contains(node.type.trim().toLowerCase())) {
+      return -1;
+    }
+    return testLatency(node.server, node.port, timeoutMs: timeoutMs);
+  }
+
+  Future<int?> _testMihomoNodeLatency(String nodeName, int timeoutMs) async {
+    final client = apiClient;
+    if (client == null) {
+      log(
+        '节点延迟 API 不可用: HTTP 客户端未初始化',
+        level: RuntimeLogLevel.warning,
+        event: 'latency_test',
+      );
+      return null;
+    }
+    try {
+      final uri = Uri.parse(
+        _apiUrl('/proxies/${Uri.encodeComponent(nodeName)}/delay'),
+      ).replace(
+        queryParameters: {
+          'timeout': '$timeoutMs',
+          'url': settings.latencyTestUrl,
+        },
+      );
+      final response = await client
+          .get(uri, headers: apiHeaders())
+          .timeout(Duration(milliseconds: timeoutMs + 1000));
+      if (response.statusCode != 200) {
+        log(
+          '节点延迟 API 请求失败: HTTP ${response.statusCode}',
+          level: RuntimeLogLevel.warning,
+          event: 'latency_test',
+        );
+        return null;
+      }
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map) {
+        log(
+          '节点延迟 API 响应无效: 非对象结果',
+          level: RuntimeLogLevel.warning,
+          event: 'latency_test',
+        );
+        return null;
+      }
+      final delay = decoded['delay'];
+      if (delay is! num) {
+        log(
+          '节点延迟 API 响应无效: 缺少 delay',
+          level: RuntimeLogLevel.warning,
+          event: 'latency_test',
+        );
+        return null;
+      }
+      return delay > 0 ? delay.toInt() : -1;
+    } catch (error) {
+      log(
+        '节点延迟 API 请求异常: $error',
+        level: RuntimeLogLevel.warning,
+        event: 'latency_test',
+      );
+      return null;
+    }
+  }
+
+  Future<void> testAllLatencies(
+    List<ProxyNode> nodes,
+    void Function(String name, int latency) onResult, {
+    int concurrency = 10,
+    int timeoutMs = 5000,
+    bool Function()? shouldContinue,
+  }) async {
+    final random = Random();
+    for (var i = 0; i < nodes.length; i += concurrency) {
+      if (shouldContinue?.call() == false) return;
+      final batch = nodes.skip(i).take(concurrency).toList();
+      final results = await Future.wait(
+        batch.map(
+          (node) => testNodeLatency(node, timeoutMs: timeoutMs),
+        ),
+      );
+      for (var j = 0; j < batch.length; j++) {
+        if (shouldContinue?.call() == false) return;
+        final latency = PrivateNodeLatencyPolicy.displayLatencyForNode(
+          batch[j].name,
+          results[j],
+          random: random,
+        );
+        onResult(batch[j].name, latency);
+      }
+    }
+  }
+}

--- a/packages/ssrvpn_shared/lib/services/clash_service_runtime_support.dart
+++ b/packages/ssrvpn_shared/lib/services/clash_service_runtime_support.dart
@@ -5,7 +5,11 @@ mixin _ClashRuntimeSupport {
   static const int _maxEphemeralPortAttempts = 32;
 
   void updateSettings(AppSettings settings);
-  void log(String message);
+  void log(
+    String message, {
+    RuntimeLogLevel level = RuntimeLogLevel.info,
+    String event = 'runtime',
+  });
   void setRuntimePortAdjustmentMessage(String? message);
 
   Future<void> writeStringAtomically(

--- a/packages/ssrvpn_shared/lib/services/desktop_connection_coordinator.dart
+++ b/packages/ssrvpn_shared/lib/services/desktop_connection_coordinator.dart
@@ -38,6 +38,28 @@ class DesktopConnectionResult {
   final bool? preferredNodeSwitchSucceeded;
 
   bool get connected => failure == null;
+
+  String? preferredNodeSwitchWarning({
+    String? preferredNodeName,
+    String? runtimeNodeName,
+  }) {
+    if (!connected || preferredNodeSwitchSucceeded != false) return null;
+    final preferred = preferredNodeName?.trim();
+    final runtime = runtimeNodeName?.trim();
+    if (preferred != null &&
+        preferred.isNotEmpty &&
+        runtime != null &&
+        runtime.isNotEmpty) {
+      return '未能切换到首选节点“$preferred”，当前连接仍保留，正在使用“$runtime”。';
+    }
+    if (preferred != null && preferred.isNotEmpty) {
+      return '未能切换到首选节点“$preferred”，当前连接仍保留；可稍后手动切换节点。';
+    }
+    if (runtime != null && runtime.isNotEmpty) {
+      return '未能切换首选节点，当前连接仍保留，正在使用“$runtime”。';
+    }
+    return '未能切换首选节点，当前连接仍保留；可稍后手动切换节点。';
+  }
 }
 
 /// Runs the shared, transactional part of a desktop connection attempt.
@@ -124,6 +146,7 @@ class DesktopConnectionCoordinator {
           final reason = readStartFailureReason() ?? '无法启动核心';
           if (attempt == 0 &&
               RuntimePortConflictPolicy.isExplicitBindConflict(reason)) {
+            await stop();
             continue;
           }
           await rollback();

--- a/packages/ssrvpn_shared/lib/services/system_proxy_ownership_status.dart
+++ b/packages/ssrvpn_shared/lib/services/system_proxy_ownership_status.dart
@@ -4,6 +4,9 @@ enum SystemProxyOwnershipStatus {
   unavailable,
 }
 
+const desktopSystemProxyOwnershipUnavailableWarning =
+    '暂时无法确认系统代理状态，当前连接仍保留；请勿同时修改系统代理，如无法上网请运行诊断。';
+
 /// Captures the proxy state observed before unexpected-exit cleanup.
 ///
 /// A null [ownershipBeforeClear] means the exited core used TUN, where system

--- a/packages/ssrvpn_shared/lib/services/update_service.dart
+++ b/packages/ssrvpn_shared/lib/services/update_service.dart
@@ -9,6 +9,7 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
+import '../models/app_diagnostics.dart';
 import 'update_checker.dart';
 import '../utils/app_modal_coordinator.dart';
 
@@ -304,9 +305,7 @@ class SharedUpdateService {
               builder: (dialogContext) => AlertDialog(
                 scrollable: true,
                 title: const Text('更新失败'),
-                content: Text(
-                  error.toString().replaceFirst('Bad state: ', ''),
-                ),
+                content: Text(safeUserFacingFailureMessage(error)),
                 actions: [
                   TextButton(
                     onPressed: () => Navigator.pop(dialogContext),

--- a/packages/ssrvpn_shared/lib/utils/core_recovery_policy.dart
+++ b/packages/ssrvpn_shared/lib/utils/core_recovery_policy.dart
@@ -1,17 +1,46 @@
 class CoreRecoveryPolicy {
-  CoreRecoveryPolicy({required this.maxAttempts})
-      : assert(maxAttempts >= 0, 'maxAttempts must not be negative');
+  CoreRecoveryPolicy({
+    required this.maxAttempts,
+    this.stableHealthWindow = const Duration(minutes: 2),
+  })  : assert(maxAttempts >= 0, 'maxAttempts must not be negative'),
+        assert(
+          !stableHealthWindow.isNegative,
+          'stableHealthWindow must not be negative',
+        );
 
   final int maxAttempts;
+  final Duration stableHealthWindow;
   int _attempts = 0;
+  DateTime? _healthySince;
 
   int get attempts => _attempts;
 
   bool tryAcquire() {
     if (_attempts >= maxAttempts) return false;
+    _healthySince = null;
     _attempts++;
     return true;
   }
 
-  void reset() => _attempts = 0;
+  bool recordHealthy(DateTime now) {
+    if (_attempts == 0) {
+      _healthySince = null;
+      return false;
+    }
+    final healthySince = _healthySince;
+    if (healthySince == null || now.isBefore(healthySince)) {
+      _healthySince = now;
+      return false;
+    }
+    if (now.difference(healthySince) < stableHealthWindow) return false;
+    reset();
+    return true;
+  }
+
+  void recordUnhealthy() => _healthySince = null;
+
+  void reset() {
+    _attempts = 0;
+    _healthySince = null;
+  }
 }

--- a/packages/ssrvpn_shared/lib/utils/log_redactor.dart
+++ b/packages/ssrvpn_shared/lib/utils/log_redactor.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 class LogRedactor {
   static const int maxInputCharacters = 4 * 1024;
   static const _truncatedMarker = '\n... log entry truncated ...';
@@ -19,11 +21,15 @@ class LogRedactor {
     caseSensitive: false,
   );
   static final _httpUrlPattern = RegExp(
-    r'''https?://[^\s<>"']+''',
+    r'''(https?)://[^\s<>"']+''',
     caseSensitive: false,
   );
   static final _ipv4Pattern = RegExp(
     r'(^|[^0-9])((?:[0-9]{1,3}\.){3}[0-9]{1,3})(?![0-9])',
+  );
+  static final _bracketedIpv6Pattern = RegExp(r'\[([0-9A-Fa-f:.]+)\]');
+  static final _ipv6CandidatePattern = RegExp(
+    r'(^|[^0-9A-Fa-f:.])([0-9A-Fa-f:.]*:[0-9A-Fa-f:.]*:[0-9A-Fa-f:.]*)(?=$|[^0-9A-Fa-f:.])',
   );
   static final _urlUserInfoPattern = RegExp(
     r'([a-z][a-z0-9+.-]*://)([^/\s:@?#]+):([^/\s@?#]+)@',
@@ -33,12 +39,20 @@ class LogRedactor {
     '([?&#;](?:$_sensitiveKeyPattern)=)([^\\s&#;]+)',
     caseSensitive: false,
   );
-  static final _jsonAuthorizationPattern = RegExp(
-    '''(["']authorization["']\\s*:\\s*["'])(?:(Bearer|Basic|Token|ApiKey)\\s+)?[^"']+(["'])''',
+  static final _jsonDoubleAuthorizationPattern = RegExp(
+    '''("authorization"\\s*:\\s*")(?:(Bearer|Basic|Token|ApiKey)\\s+)?(?:\\\\.|[^"\\\\])+(")''',
     caseSensitive: false,
   );
-  static final _jsonCredentialPattern = RegExp(
-    '''(["'](?:$_sensitiveKeyPattern)["']\\s*:\\s*["'])[^"']+(["'])''',
+  static final _jsonSingleAuthorizationPattern = RegExp(
+    "('authorization'\\s*:\\s*')(?:(Bearer|Basic|Token|ApiKey)\\s+)?(?:\\\\.|[^'\\\\])+(')",
+    caseSensitive: false,
+  );
+  static final _jsonDoubleCredentialPattern = RegExp(
+    '''("(?:$_sensitiveKeyPattern)"\\s*:\\s*")(?:\\\\.|[^"\\\\])+(")''',
+    caseSensitive: false,
+  );
+  static final _jsonSingleCredentialPattern = RegExp(
+    "('(?:$_sensitiveKeyPattern)'\\s*:\\s*')(?:\\\\.|[^'\\\\])+(')",
     caseSensitive: false,
   );
   static final _authorizationSchemePattern = RegExp(
@@ -53,9 +67,64 @@ class LogRedactor {
     r'''\bBearer\s+[^\s,;"']+''',
     caseSensitive: false,
   );
-  static final _credentialAssignmentPattern = RegExp(
-    '''(^|[\\s,{])\\b($_sensitiveKeyPattern)\\s*[:=]\\s*["']?[^\\s,;"']+["']?''',
+  static final _doubleQuotedAuthorizationAssignmentPattern = RegExp(
+    '''(^|[\\s,{;\\[])\\b(authorization)\\b\\s*[:=]\\s*"(?:\\\\.|[^"\\\\])*"''',
     caseSensitive: false,
+  );
+  static final _singleQuotedAuthorizationAssignmentPattern = RegExp(
+    "(^|[\\s,{;\\[])\\b(authorization)\\b\\s*[:=]\\s*'(?:\\\\.|[^'\\\\])*'",
+    caseSensitive: false,
+  );
+  static final _unterminatedDoubleQuotedAuthorizationAssignmentPattern = RegExp(
+    '''(^|[\\s,{;\\[])\\b(authorization)\\b\\s*[:=]\\s*"(?:\\\\.|[^"\\\\])*\$''',
+    caseSensitive: false,
+  );
+  static final _unterminatedSingleQuotedAuthorizationAssignmentPattern = RegExp(
+    "(^|[\\s,{;\\[])\\b(authorization)\\b\\s*[:=]\\s*'(?:\\\\.|[^'\\\\])*\$",
+    caseSensitive: false,
+  );
+  static final _unterminatedDoubleQuotedJsonAuthorizationPattern = RegExp(
+    '''(^|[\\s,{;\\[])["']\\b(authorization)\\b["']\\s*:\\s*"(?:\\\\.|[^"\\\\])*\$''',
+    caseSensitive: false,
+  );
+  static final _unterminatedSingleQuotedJsonAuthorizationPattern = RegExp(
+    "(^|[\\s,{;\\[])[\"']\\b(authorization)\\b[\"']\\s*:\\s*'(?:\\\\.|[^'\\\\])*\$",
+    caseSensitive: false,
+  );
+  static final _doubleQuotedCredentialAssignmentPattern = RegExp(
+    '''(^|[\\s,{;\\[])\\b($_sensitiveKeyPattern)\\s*[:=]\\s*"(?:\\\\.|[^"\\\\])*"''',
+    caseSensitive: false,
+  );
+  static final _singleQuotedCredentialAssignmentPattern = RegExp(
+    "(^|[\\s,{;\\[])\\b($_sensitiveKeyPattern)\\s*[:=]\\s*'(?:\\\\.|[^'\\\\])*'",
+    caseSensitive: false,
+  );
+  static final _unterminatedDoubleQuotedCredentialAssignmentPattern = RegExp(
+    '''(^|[\\s,{;\\[])\\b($_sensitiveKeyPattern)\\s*[:=]\\s*"(?:\\\\.|[^"\\\\])*\$''',
+    caseSensitive: false,
+  );
+  static final _unterminatedSingleQuotedCredentialAssignmentPattern = RegExp(
+    "(^|[\\s,{;\\[])\\b($_sensitiveKeyPattern)\\s*[:=]\\s*'(?:\\\\.|[^'\\\\])*\$",
+    caseSensitive: false,
+  );
+  static final _unterminatedDoubleQuotedJsonCredentialPattern = RegExp(
+    '''(^|[\\s,{;\\[])["']\\b($_sensitiveKeyPattern)\\b["']\\s*:\\s*"(?:\\\\.|[^"\\\\])*\$''',
+    caseSensitive: false,
+  );
+  static final _unterminatedSingleQuotedJsonCredentialPattern = RegExp(
+    "(^|[\\s,{;\\[])[\"']\\b($_sensitiveKeyPattern)\\b[\"']\\s*:\\s*'(?:\\\\.|[^'\\\\])*\$",
+    caseSensitive: false,
+  );
+  static final _credentialAssignmentPattern = RegExp(
+    '''(^|[\\s,{;\\[])\\b($_sensitiveKeyPattern)\\s*[:=]\\s*["']?[^\\s,;"']+["']?''',
+    caseSensitive: false,
+  );
+  static final _yamlBlockCredentialPattern = RegExp(
+    '^([ \\t]*)\\b(authorization|$_sensitiveKeyPattern)\\b'
+    r'\s*:\s*[>|][+-]?[^\r\n]*'
+    r'(?:(?:\r\n|\n)(?:\1[ \t]+[^\r\n]*|[ \t]*(?=\r?$)))*',
+    caseSensitive: false,
+    multiLine: true,
   );
   static final _unixHomePattern = RegExp(
     r'/(Users|home)/[^/\r\n]+(?=/|$)',
@@ -84,6 +153,19 @@ class LogRedactor {
       (match) => '${match[1]!.toLowerCase()}://***',
     );
 
+    message = message.replaceAllMapped(_httpUrlPattern, (match) {
+      final scheme = match[1]!.toLowerCase();
+      final uri = Uri.tryParse(match[0]!);
+      final rawHost = uri?.host.trim() ?? '';
+      final host = rawHost.isEmpty
+          ? '***'
+          : rawHost.contains(':')
+              ? '[$rawHost]'
+              : rawHost;
+      final port = uri != null && uri.hasPort ? ':${uri.port}' : '';
+      return '$scheme://$host$port/***';
+    });
+
     message = message.replaceAllMapped(
       _urlUserInfoPattern,
       (match) => '${match[1]}***:***@',
@@ -95,20 +177,49 @@ class LogRedactor {
     );
 
     message = message.replaceAllMapped(
-      _jsonAuthorizationPattern,
-      (match) {
+      _yamlBlockCredentialPattern,
+      (match) => '${match[1]}${match[2]}: ***',
+    );
+
+    for (final pattern in [
+      _jsonDoubleAuthorizationPattern,
+      _jsonSingleAuthorizationPattern,
+    ]) {
+      message = message.replaceAllMapped(pattern, (match) {
         final scheme = match[2];
-        final prefix = match[1]!;
         final redactedValue = scheme == null ? '***' : '$scheme ***';
-        return '$prefix$redactedValue${match[3]}';
-      },
-    );
+        return '${match[1]}$redactedValue${match[3]}';
+      });
+    }
+    for (final pattern in [
+      _jsonDoubleCredentialPattern,
+      _jsonSingleCredentialPattern,
+    ]) {
+      message = message.replaceAllMapped(
+        pattern,
+        (match) => '${match[1]}***${match[2]}',
+      );
+    }
 
-    message = message.replaceAllMapped(
-      _jsonCredentialPattern,
-      (match) => '${match[1]}***${match[2]}',
-    );
-
+    for (final pattern in [
+      _doubleQuotedAuthorizationAssignmentPattern,
+      _singleQuotedAuthorizationAssignmentPattern,
+      _unterminatedDoubleQuotedAuthorizationAssignmentPattern,
+      _unterminatedSingleQuotedAuthorizationAssignmentPattern,
+      _unterminatedDoubleQuotedJsonAuthorizationPattern,
+      _unterminatedSingleQuotedJsonAuthorizationPattern,
+      _doubleQuotedCredentialAssignmentPattern,
+      _singleQuotedCredentialAssignmentPattern,
+      _unterminatedDoubleQuotedCredentialAssignmentPattern,
+      _unterminatedSingleQuotedCredentialAssignmentPattern,
+      _unterminatedDoubleQuotedJsonCredentialPattern,
+      _unterminatedSingleQuotedJsonCredentialPattern,
+    ]) {
+      message = message.replaceAllMapped(
+        pattern,
+        (match) => '${match[1]}${match[2]}: ***',
+      );
+    }
     message = message.replaceAllMapped(
       _authorizationSchemePattern,
       (match) => '${match[1]}: ${match[2]} ***',
@@ -136,6 +247,22 @@ class LogRedactor {
           _isPublicIpv4(address) ? '[public-ip-redacted]' : address;
       return '${match[1]}$replacement';
     });
+    message = message.replaceAllMapped(_bracketedIpv6Pattern, (match) {
+      final address = match[1]!;
+      return _isPublicIpv6(address) ? '[public-ip-redacted]' : match[0]!;
+    });
+    message = message.replaceAllMapped(_ipv6CandidatePattern, (match) {
+      final candidate = match[2]!;
+      var addressEnd = candidate.length;
+      while (addressEnd > 0 && candidate.codeUnitAt(addressEnd - 1) == 0x2e) {
+        addressEnd--;
+      }
+      final address = candidate.substring(0, addressEnd);
+      final punctuation = candidate.substring(addressEnd);
+      final replacement =
+          _isPublicIpv6(address) ? '[public-ip-redacted]' : address;
+      return '${match[1]}$replacement$punctuation';
+    });
     return wasTruncated ? '$message$_truncatedMarker' : message;
   }
 
@@ -158,6 +285,32 @@ class LogRedactor {
     if (a == 198 && (b == 18 || b == 19)) return false;
     if (a == 198 && b == 51 && c == 100) return false;
     if (a == 203 && b == 0 && c == 113) return false;
+    return true;
+  }
+
+  static bool _isPublicIpv6(String address) {
+    final parsed = InternetAddress.tryParse(address);
+    if (parsed == null || parsed.type != InternetAddressType.IPv6) return false;
+    final bytes = parsed.rawAddress;
+    if (bytes.every((byte) => byte == 0)) return false;
+    if (bytes.take(15).every((byte) => byte == 0) && bytes[15] == 1) {
+      return false;
+    }
+    if (bytes[0] == 0xff) return false;
+    if (bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80) return false;
+    if ((bytes[0] & 0xfe) == 0xfc) return false;
+    if (bytes[0] == 0x20 &&
+        bytes[1] == 0x01 &&
+        bytes[2] == 0x0d &&
+        bytes[3] == 0xb8) {
+      return false;
+    }
+    final isIpv4Mapped = bytes.take(10).every((byte) => byte == 0) &&
+        bytes[10] == 0xff &&
+        bytes[11] == 0xff;
+    if (isIpv4Mapped) {
+      return _isPublicIpv4(bytes.skip(12).join('.'));
+    }
     return true;
   }
 

--- a/packages/ssrvpn_shared/test/app_diagnostics_test.dart
+++ b/packages/ssrvpn_shared/test/app_diagnostics_test.dart
@@ -46,6 +46,27 @@ void main() {
         AppFailure.fromMessage('network request timed out').code,
         AppErrorCode.unknown,
       );
+      expect(
+        AppFailure.fromMessage('Windows Mihomo 核心启动配置校验响应超时；raw-secret').code,
+        AppErrorCode.coreStartTimeout,
+      );
+      expect(
+        AppFailure.fromMessage('Windows 系统代理 PowerShell 命令响应超时；raw-secret')
+            .code,
+        AppErrorCode.proxyRecoveryPending,
+      );
+      expect(
+        AppFailure.fromMessage('Windows 系统命令响应超时；raw-secret').code,
+        AppErrorCode.unknown,
+      );
+      expect(
+        AppFailure.fromMessage('客户端仍在初始化，请稍后重试').code,
+        AppErrorCode.coreUnavailable,
+      );
+      expect(
+        AppFailure.fromMessage('请先添加并刷新订阅').code,
+        AppErrorCode.subscriptionFailed,
+      );
     });
 
     test('unknown failures do not expose raw internal details', () {
@@ -57,6 +78,14 @@ void main() {
       expect(failure.message, isNot(contains('top-secret')));
       expect(failure.message, isNot(contains('/Users/me')));
       expect(failure.recommendedAction, isNotEmpty);
+
+      final timeout = AppFailure.fromMessage(
+        'Windows 系统代理 PowerShell 命令响应超时；'
+        'script=C:\\private\\secret.ps1',
+      );
+      expect(timeout.code, AppErrorCode.proxyRecoveryPending);
+      expect(timeout.userMessage, contains('系统代理待恢复'));
+      expect(timeout.userMessage, isNot(contains('secret.ps1')));
     });
 
     test('maps Windows TUN administrator failures to relaunch guidance', () {
@@ -69,6 +98,116 @@ void main() {
         expect(failure.code, AppErrorCode.permissionRequired);
         expect(failure.recommendedAction, '请退出 SSRVPN 后，以管理员身份重新运行。');
       }
+    });
+
+    test('maps core and data-plane details to safe actionable copy', () {
+      final core = AppFailure.fromMessage(
+        'Mihomo service is not initialized: token=internal-secret',
+      );
+      expect(core.code, AppErrorCode.coreUnavailable);
+      expect(core.userMessage, contains('本地运行核心'));
+      expect(core.userMessage, isNot(contains('Mihomo')));
+      expect(core.userMessage, isNot(contains('internal-secret')));
+
+      final dataPlane = AppFailure.fromMessage('TUN 数据通道验证失败');
+      expect(dataPlane.code, AppErrorCode.dataPlaneDegraded);
+      expect(dataPlane.userMessage, contains('当前连接仍保留'));
+      expect(dataPlane.userMessage, isNot(contains('自动切换')));
+    });
+
+    test('maps concrete desktop startup failures to actionable categories', () {
+      const cases = <String, AppErrorCode>{
+        '找不到生成的 Mihomo 配置文件': AppErrorCode.configInvalid,
+        '电脑性能不足或配置校验超时，请重新连接': AppErrorCode.coreStartTimeout,
+        'Mihomo 提前退出（退出码 1）': AppErrorCode.coreUnavailable,
+        'TUN 核心启动失败': AppErrorCode.coreUnavailable,
+        'Mihomo 启动后未通过就绪检查：本地 API 不可用': AppErrorCode.coreUnavailable,
+      };
+
+      for (final entry in cases.entries) {
+        expect(
+          AppFailure.fromMessage(entry.key).code,
+          entry.value,
+          reason: entry.key,
+        );
+      }
+    });
+
+    test('maps an empty first subscription result to retry guidance', () {
+      final failure = AppFailure.fromMessage(Exception('未获取到可用节点'));
+
+      expect(failure.code, AppErrorCode.subscriptionFailed);
+      expect(failure.userMessage, contains('订阅刷新失败'));
+      expect(failure.userMessage, contains('检查订阅地址和网络'));
+    });
+
+    test('maps node edit validation failures to safe field guidance', () {
+      for (final error in [
+        const FormatException('节点备注名已存在'),
+        const FormatException('服务器地址无效'),
+        const FormatException('trojan 节点缺少 password'),
+        const FormatException('节点名称“top-secret”属于运行时保留名称'),
+        StateError('当前没有可编辑的订阅配置'),
+      ]) {
+        final failure = AppFailure.fromMessage(error);
+
+        expect(failure.code, AppErrorCode.configInvalid);
+        expect(failure.userMessage, contains('检查节点名称、服务器、端口和认证信息'));
+        expect(failure.userMessage, isNot(contains('top-secret')));
+        expect(failure.userMessage, isNot(contains('password')));
+      }
+    });
+  });
+
+  group('safeUserFacingFailureMessage', () {
+    test('preserves only explicitly trusted product messages', () {
+      for (final message in const [
+        '客户端仍在初始化，请稍后重试',
+        '请先添加并刷新订阅',
+        '订阅已更新，请重新连接以使用最新配置',
+      ]) {
+        expect(safeUserFacingFailureMessage(message), message);
+      }
+      expect(
+        safeUserFacingFailureMessage(
+          StateError('无法安全断开当前连接，已阻止打开更新安装包'),
+        ),
+        '无法安全断开当前连接，已阻止打开更新安装包',
+      );
+    });
+
+    test('never exposes an unknown tray reason', () {
+      final message = safeUserFacingFailureMessage(
+        'PowerShell failed secret=top-secret path=C:\\private\\secret.ps1',
+      );
+
+      expect(message, isNot(contains('top-secret')));
+      expect(message, isNot(contains('secret.ps1')));
+      expect(message, contains('原始敏感细节不会显示'));
+    });
+
+    test('separates a trusted failure from the follow-up action', () {
+      expect(
+        safeUserFacingFailureWithAction(
+          '客户端仍在初始化，请稍后重试',
+          '请稍后再次退出。',
+        ),
+        '客户端仍在初始化，请稍后重试\n请稍后再次退出。',
+      );
+    });
+
+    test('subscription UI copy never echoes a credential-bearing URL', () {
+      final message = safeSubscriptionFailureMessage(
+        Exception(
+          '所有订阅刷新失败: HttpException for '
+          'https://example.com/private/subscription?token=top-secret',
+        ),
+      );
+
+      expect(message, contains('订阅刷新失败'));
+      expect(message, contains('检查订阅地址和网络'));
+      expect(message, isNot(contains('top-secret')));
+      expect(message, isNot(contains('/private/subscription')));
     });
   });
 

--- a/packages/ssrvpn_shared/test/clash_service_base_test.dart
+++ b/packages/ssrvpn_shared/test/clash_service_base_test.dart
@@ -13,6 +13,187 @@ import 'package:ssrvpn_shared/services/clash_service_base.dart';
 import 'package:ssrvpn_shared/utils/runtime_config_name_policy.dart';
 
 void main() {
+  group('ClashServiceBase runtime logs', () {
+    test('records one-line structured redacted entries with a stable session',
+        () {
+      final service = _TestClashService();
+      addTearDown(service.dispose);
+
+      service.log(
+        'switch failed\nrequest token=top-secret',
+        level: RuntimeLogLevel.warning,
+        event: 'proxy_switch',
+      );
+      service.log('retry scheduled', event: 'proxy_switch');
+
+      final lines = service.recentLogs
+          .split('\n')
+          .where((line) => line.isNotEmpty)
+          .toList(growable: false);
+      expect(lines, hasLength(2));
+      final pattern = RegExp(
+        r'^\[([^\]]+)\] \[([A-Z]+)\] \[([^\]]+)\] '
+        r'\[session=([^\]]+)\] (.*)$',
+      );
+      final newest = pattern.firstMatch(lines[0]);
+      final oldest = pattern.firstMatch(lines[1]);
+
+      expect(newest, isNotNull);
+      expect(oldest, isNotNull);
+      expect(DateTime.parse(oldest!.group(1)!).isUtc, isTrue);
+      expect(oldest.group(2), 'WARNING');
+      expect(oldest.group(3), 'proxy_switch');
+      expect(newest!.group(4), oldest.group(4));
+      expect(oldest.group(5), contains('switch failed ↩ request token: ***'));
+      expect(service.recentLogs, isNot(contains('top-secret')));
+    });
+  });
+
+  group('ClashServiceBase node latency', () {
+    test('uses the running Mihomo delay API with the configured timeout',
+        () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final service = _ApiClashService();
+      service.initHttpClient();
+      service.updateSettings(
+        AppSettings(
+          apiPort: server.port,
+          apiSecret: 'latency-secret',
+          latencyTestUrl: 'https://example.com/generate_204',
+        ),
+      );
+      service.publishRunning();
+      addTearDown(service.dispose);
+      addTearDown(server.close);
+
+      final requestSeen = Completer<HttpRequest>();
+      server.listen((request) async {
+        requestSeen.complete(request);
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(jsonEncode({'delay': 47}));
+        await request.response.close();
+      });
+
+      final latency = await service.testNodeLatency(
+        ProxyNode(
+          name: 'Hysteria / Tokyo',
+          type: 'hysteria2',
+          server: '127.0.0.1',
+          port: 9,
+        ),
+        timeoutMs: 8700,
+      );
+      final request = await requestSeen.future;
+
+      expect(latency, 47);
+      expect(
+        request.uri.pathSegments,
+        ['proxies', 'Hysteria / Tokyo', 'delay'],
+      );
+      expect(request.uri.queryParameters['timeout'], '8700');
+      expect(
+        request.uri.queryParameters['url'],
+        'https://example.com/generate_204',
+      );
+      expect(request.headers.value(HttpHeaders.authorizationHeader),
+          'Bearer latency-secret');
+    });
+
+    test('running API rejection returns unknown without a direct TCP fallback',
+        () async {
+      final apiServer = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final target = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final service = _ApiClashService();
+      service.initHttpClient();
+      service.updateSettings(AppSettings(apiPort: apiServer.port));
+      service.publishRunning();
+      addTearDown(service.dispose);
+      addTearDown(apiServer.close);
+      addTearDown(target.close);
+      apiServer.listen((request) async {
+        request.response.statusCode = HttpStatus.serviceUnavailable;
+        await request.response.close();
+      });
+
+      final latency = await service.testNodeLatency(
+        ProxyNode(
+          name: 'TCP node',
+          type: 'ss',
+          server: InternetAddress.loopbackIPv4.address,
+          port: target.port,
+        ),
+      );
+
+      expect(latency, -1);
+      expect(service.recentLogs, contains('节点延迟 API 请求失败: HTTP 503'));
+    });
+
+    test('running API exception returns unknown and records the failure',
+        () async {
+      final unavailable =
+          await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final unavailablePort = unavailable.port;
+      await unavailable.close(force: true);
+      final target = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final service = _ApiClashService();
+      service.initHttpClient();
+      service.updateSettings(AppSettings(apiPort: unavailablePort));
+      service.publishRunning();
+      addTearDown(service.dispose);
+      addTearDown(target.close);
+
+      final latency = await service.testNodeLatency(
+        ProxyNode(
+          name: 'TCP node',
+          type: 'ss',
+          server: InternetAddress.loopbackIPv4.address,
+          port: target.port,
+        ),
+      );
+
+      expect(latency, -1);
+      expect(service.recentLogs, contains('节点延迟 API 请求异常'));
+    });
+
+    test('offline UDP and QUIC-only nodes report unknown latency', () async {
+      final listener = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final service = _TestClashService();
+      addTearDown(listener.close);
+      addTearDown(service.dispose);
+
+      for (final type in const ['hysteria', 'hysteria2', 'tuic']) {
+        final latency = await service.testNodeLatency(
+          ProxyNode(
+            name: type,
+            type: type,
+            server: InternetAddress.loopbackIPv4.address,
+            port: listener.port,
+          ),
+        );
+        expect(latency, -1,
+            reason: '$type must not use a TCP reachability lie');
+      }
+    });
+
+    test('offline TCP nodes retain the direct socket probe', () async {
+      final listener = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final service = _TestClashService();
+      addTearDown(listener.close);
+      addTearDown(service.dispose);
+
+      final latency = await service.testNodeLatency(
+        ProxyNode(
+          name: 'Shadowsocks',
+          type: 'ss',
+          server: InternetAddress.loopbackIPv4.address,
+          port: listener.port,
+        ),
+      );
+
+      expect(latency, greaterThanOrEqualTo(0));
+    });
+  });
+
   group('ClashServiceBase batch latency', () {
     test('stops delivering a stale batch before starting another chunk',
         () async {
@@ -387,6 +568,42 @@ void main() {
       expect(await service.currentSelectedProxyName(), 'Node B');
       expect(api.closeConnectionCalls, 1);
       expect(statusNotifications, 1);
+    });
+
+    test('logs a rejected proxy-group mutation without dropping the session',
+        () async {
+      final api = await _ProxyApiServer.start(
+        proxyNow: 'Node A',
+        putStatusCode: HttpStatus.serviceUnavailable,
+      );
+      addTearDown(api.close);
+      final service = _ApiClashService();
+      addTearDown(service.dispose);
+      service.initHttpClient();
+      service.updateSettings(AppSettings(apiPort: api.port));
+
+      expect(await service.switchSelectedProxy('Node B'), isFalse);
+      expect(await service.currentSelectedProxyName(), 'Node A');
+      expect(service.recentLogs, contains('[WARNING] [proxy_switch]'));
+      expect(service.recentLogs, contains('HTTP 503'));
+    });
+
+    test('connection cleanup rejection stays advisory after a confirmed switch',
+        () async {
+      final api = await _ProxyApiServer.start(
+        proxyNow: 'Node A',
+        deleteStatusCode: HttpStatus.serviceUnavailable,
+      );
+      addTearDown(api.close);
+      final service = _ApiClashService();
+      addTearDown(service.dispose);
+      service.initHttpClient();
+      service.updateSettings(AppSettings(apiPort: api.port));
+
+      expect(await service.switchSelectedProxy('Node B'), isTrue);
+      expect(await service.currentSelectedProxyName(), 'Node B');
+      expect(service.recentLogs, contains('[WARNING] [connection_cleanup]'));
+      expect(service.recentLogs, contains('HTTP 503'));
     });
 
     test('resolves effective selected node through GLOBAL to PROXY', () async {
@@ -840,6 +1057,30 @@ proxies:
     expect(service.stopCalls, 2);
   });
 
+  test('stale health recovery cleanup finishes before a queued reconnect',
+      () async {
+    final service = _CancellableHealthRecoveryClashService();
+    addTearDown(service.dispose);
+    service.requestConnectionIntent(true);
+    service.setRunning(true);
+
+    service.startStatusMonitor();
+    await service.recoveryStarted.future.timeout(const Duration(seconds: 1));
+    service.requestConnectionIntent(true);
+    final newConnection = service.runConnectionTransition(() async {
+      service.setRunning(true);
+    });
+
+    service.allowRecovery.complete();
+    await service.recoveryFinished.future.timeout(const Duration(seconds: 1));
+    await newConnection;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(service.connectionDesired, isTrue);
+    expect(service.isRunning, isTrue);
+    expect(service.stopCalls, 2);
+  });
+
   test('status monitor keeps advisory data-plane failures connected', () async {
     final service = _AdvisoryDataPlaneClashService();
     addTearDown(service.dispose);
@@ -855,18 +1096,54 @@ proxies:
     expect(service.stopCalls, 0);
   });
 
-  test('status monitor bounds a health check that never completes', () async {
-    final service = _HangingHealthClashService();
+  test('status monitor never overlaps a timed-out source health check',
+      () async {
+    final service = _SlowHealthClashService();
     addTearDown(service.dispose);
     service.requestConnectionIntent(true);
     service.setRunning(true);
 
     service.startStatusMonitor();
-    await service.stopped.future.timeout(const Duration(seconds: 1));
+    await service.firstTimeout.future.timeout(const Duration(seconds: 1));
+    await Future<void>.delayed(const Duration(milliseconds: 30));
 
-    expect(service.healthCalls, greaterThanOrEqualTo(2));
-    expect(service.isRunning, isFalse);
-    expect(service.recentLogs, contains('健康检查超时'));
+    expect(service.healthCalls, 1);
+    expect(service.isRunning, isTrue);
+    expect(service.recentLogs, contains('运行状态检查超时'));
+    expect(service.periodicHealthResults, [false]);
+
+    service.firstHealthCheck.complete(true);
+    await service.nextHealthCheck.future.timeout(const Duration(seconds: 1));
+    expect(service.healthCalls, 2);
+    expect(service.isRunning, isTrue);
+  });
+
+  test('a stale health check cannot block or fail a newer session', () async {
+    final service = _SessionHealthClashService();
+    addTearDown(service.dispose);
+    service.requestConnectionIntent(true);
+    service.setRunning(true);
+    service.startStatusMonitor();
+    await service.firstHealthStarted.future;
+
+    service.stopStatusMonitor();
+    service.setRunning(false);
+    service.requestConnectionIntent(true);
+    service.setRunning(true);
+    service.startStatusMonitor();
+
+    await service.secondHealthStarted.future
+        .timeout(const Duration(seconds: 1));
+    service.firstHealth.complete(false);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(service.periodicHealthResults, isEmpty);
+    expect(service.lastHealthCheckError, isNull);
+    expect(service.isRunning, isTrue);
+    expect(service.connectionDesired, isTrue);
+
+    service.stopStatusMonitor();
+    service.secondHealth.complete(true);
   });
 
   test('data-plane observation timeout becomes an advisory warning', () async {
@@ -884,6 +1161,29 @@ proxies:
     expect(service.connectionDesired, isTrue);
     expect(service.connectivityWarning, contains('未能完成'));
     expect(service.observationCalls, 1);
+  });
+
+  test('a stale data-plane probe cannot block or warn a newer session',
+      () async {
+    final service = _SessionDataPlaneClashService();
+    addTearDown(service.dispose);
+    service.requestConnectionIntent(true);
+    service.setRunning(true);
+
+    service.scheduleObservationForTest();
+    await service.firstObservationStarted.future;
+
+    service.setRunning(false);
+    service.requestConnectionIntent(true);
+    service.setRunning(true);
+    service.scheduleObservationForTest();
+
+    await service.secondObservationStarted.future
+        .timeout(const Duration(seconds: 1));
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+
+    expect(service.observationCalls, 2);
+    expect(service.connectivityWarning, isNull);
   });
 
   group('ClashServiceBase diagnostics', () {
@@ -1066,6 +1366,8 @@ class _ProxyApiServer {
     required this.globalNow,
     required this.updateProxyOnPut,
     required this.putDelayByTarget,
+    required this.putStatusCode,
+    required this.deleteStatusCode,
   }) {
     _server.listen(_handle);
   }
@@ -1075,6 +1377,8 @@ class _ProxyApiServer {
   String globalNow;
   final bool updateProxyOnPut;
   final Map<String, Duration> putDelayByTarget;
+  final int putStatusCode;
+  final int deleteStatusCode;
   int closeConnectionCalls = 0;
 
   int get port => _server.port;
@@ -1084,6 +1388,8 @@ class _ProxyApiServer {
     String globalNow = 'PROXY',
     bool updateProxyOnPut = true,
     Map<String, Duration> putDelayByTarget = const {},
+    int putStatusCode = HttpStatus.noContent,
+    int deleteStatusCode = HttpStatus.noContent,
   }) async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     return _ProxyApiServer._(
@@ -1092,6 +1398,8 @@ class _ProxyApiServer {
       globalNow: globalNow,
       updateProxyOnPut: updateProxyOnPut,
       putDelayByTarget: putDelayByTarget,
+      putStatusCode: putStatusCode,
+      deleteStatusCode: deleteStatusCode,
     );
   }
 
@@ -1120,19 +1428,21 @@ class _ProxyApiServer {
       final target = decoded['name']?.toString() ?? '';
       final delay = putDelayByTarget[target];
       if (delay != null) await Future<void>.delayed(delay);
-      if (segments.last == 'PROXY') {
-        if (updateProxyOnPut) proxyNow = target;
-      } else if (segments.last == 'GLOBAL') {
-        globalNow = target;
+      if (putStatusCode >= 200 && putStatusCode < 300) {
+        if (segments.last == 'PROXY') {
+          if (updateProxyOnPut) proxyNow = target;
+        } else if (segments.last == 'GLOBAL') {
+          globalNow = target;
+        }
       }
-      request.response.statusCode = HttpStatus.noContent;
+      request.response.statusCode = putStatusCode;
       await request.response.close();
       return;
     }
 
     if (request.method == 'DELETE' && request.uri.path == '/connections') {
       closeConnectionCalls++;
-      request.response.statusCode = HttpStatus.noContent;
+      request.response.statusCode = deleteStatusCode;
       await request.response.close();
       return;
     }
@@ -1169,6 +1479,8 @@ Future<void> _recordRequests(
 
 class _ApiClashService extends ClashServiceBase
     with _ExplicitTestDiagnosticCapability {
+  void publishRunning() => setRunning(true);
+
   Future<void> runRuleProviderRefresh() => refreshRuleProvidersOnce();
 
   Future<bool> runDesktopRecovery(int generation) =>
@@ -1441,9 +1753,12 @@ class _AdvisoryDataPlaneClashService extends _TestClashService {
   }
 }
 
-class _HangingHealthClashService extends ClashServiceBase
+class _SlowHealthClashService extends ClashServiceBase
     with _ExplicitTestDiagnosticCapability {
-  final Completer<void> stopped = Completer<void>();
+  final Completer<bool> firstHealthCheck = Completer<bool>();
+  final Completer<void> firstTimeout = Completer<void>();
+  final Completer<void> nextHealthCheck = Completer<void>();
+  final List<bool> periodicHealthResults = <bool>[];
   int healthCalls = 0;
 
   @override
@@ -1453,18 +1768,69 @@ class _HangingHealthClashService extends ClashServiceBase
   Duration get healthCheckTimeout => const Duration(milliseconds: 10);
 
   @override
-  int get maxConsecutiveHealthCheckFailures => 1;
+  int get maxConsecutiveHealthCheckFailures => 3;
 
   @override
   Future<bool> healthCheck() {
     healthCalls++;
-    return Completer<bool>().future;
+    if (healthCalls == 1) return firstHealthCheck.future;
+    if (!nextHealthCheck.isCompleted) nextHealthCheck.complete();
+    return Future<bool>.value(true);
   }
 
   @override
-  Future<void> onStopRequired() async {
-    setRunning(false);
-    if (!stopped.isCompleted) stopped.complete();
+  void onPeriodicHealthCheckResult(bool healthy) {
+    periodicHealthResults.add(healthy);
+  }
+
+  @override
+  void log(
+    String message, {
+    RuntimeLogLevel level = RuntimeLogLevel.info,
+    String event = 'runtime',
+  }) {
+    super.log(message, level: level, event: event);
+    if (message.contains('运行状态检查超时') && !firstTimeout.isCompleted) {
+      firstTimeout.complete();
+    }
+  }
+
+  @override
+  Future<void> onStopRequired() async => setRunning(false);
+}
+
+class _SessionHealthClashService extends _TestClashService {
+  final Completer<void> firstHealthStarted = Completer<void>();
+  final Completer<void> secondHealthStarted = Completer<void>();
+  final Completer<bool> firstHealth = Completer<bool>();
+  final Completer<bool> secondHealth = Completer<bool>();
+  final List<bool> periodicHealthResults = <bool>[];
+  int healthCalls = 0;
+
+  @override
+  Duration get statusMonitorInterval => const Duration(milliseconds: 1);
+
+  @override
+  Duration get healthCheckTimeout => const Duration(seconds: 2);
+
+  @override
+  Future<bool> healthCheck() async {
+    healthCalls++;
+    if (healthCalls == 1) {
+      firstHealthStarted.complete();
+      final healthy = await firstHealth.future;
+      setLastHealthCheckError(healthy ? null : 'stale first-session error');
+      return healthy;
+    }
+    secondHealthStarted.complete();
+    final healthy = await secondHealth.future;
+    setLastHealthCheckError(healthy ? null : 'second-session error');
+    return healthy;
+  }
+
+  @override
+  void onPeriodicHealthCheckResult(bool healthy) {
+    periodicHealthResults.add(healthy);
   }
 }
 
@@ -1493,6 +1859,29 @@ class _HangingDataPlaneClashService extends _TestClashService {
     if (connectivityWarning != null && !warningPublished.isCompleted) {
       warningPublished.complete();
     }
+  }
+}
+
+class _SessionDataPlaneClashService extends _TestClashService {
+  final Completer<void> firstObservationStarted = Completer<void>();
+  final Completer<void> secondObservationStarted = Completer<void>();
+  final Completer<void> firstObservation = Completer<void>();
+  int observationCalls = 0;
+
+  @override
+  Duration get dataPlaneObservationTimeout => const Duration(milliseconds: 10);
+
+  void scheduleObservationForTest() => scheduleDataPlaneObservation();
+
+  @override
+  Future<void> observeDataPlaneHealth() {
+    observationCalls++;
+    if (observationCalls == 1) {
+      firstObservationStarted.complete();
+      return firstObservation.future;
+    }
+    secondObservationStarted.complete();
+    return Future<void>.value();
   }
 }
 

--- a/packages/ssrvpn_shared/test/core_recovery_policy_test.dart
+++ b/packages/ssrvpn_shared/test/core_recovery_policy_test.dart
@@ -11,4 +11,47 @@ void main() {
     policy.reset();
     expect(policy.tryAcquire(), isTrue);
   });
+
+  test('a stable healthy window restores the automatic recovery budget', () {
+    final policy = CoreRecoveryPolicy(
+      maxAttempts: 2,
+      stableHealthWindow: const Duration(minutes: 2),
+    );
+    final startedAt = DateTime.utc(2026, 8, 21, 12);
+
+    expect(policy.tryAcquire(), isTrue);
+    expect(policy.recordHealthy(startedAt), isFalse);
+    expect(
+      policy.recordHealthy(startedAt.add(const Duration(seconds: 119))),
+      isFalse,
+    );
+    expect(policy.attempts, 1);
+
+    expect(
+      policy.recordHealthy(startedAt.add(const Duration(minutes: 2))),
+      isTrue,
+    );
+    expect(policy.attempts, 0);
+    expect(policy.tryAcquire(), isTrue);
+  });
+
+  test('an unhealthy sample restarts the stable health window', () {
+    final policy = CoreRecoveryPolicy(
+      maxAttempts: 1,
+      stableHealthWindow: const Duration(minutes: 1),
+    );
+    final startedAt = DateTime.utc(2026, 8, 21, 12);
+
+    expect(policy.tryAcquire(), isTrue);
+    policy.recordHealthy(startedAt);
+    policy.recordUnhealthy();
+    expect(
+      policy.recordHealthy(startedAt.add(const Duration(minutes: 1))),
+      isFalse,
+    );
+    expect(
+      policy.recordHealthy(startedAt.add(const Duration(minutes: 2))),
+      isTrue,
+    );
+  });
 }

--- a/packages/ssrvpn_shared/test/desktop_connection_coordinator_test.dart
+++ b/packages/ssrvpn_shared/test/desktop_connection_coordinator_test.dart
@@ -162,6 +162,96 @@ void main() {
       expect(calls, isNot(contains('cancel-intent')));
     });
 
+    test('waits for failed-start cleanup before retrying a bind clash',
+        () async {
+      final calls = <String>[];
+      final firstStartFinished = Completer<void>();
+      final releaseCleanup = Completer<void>();
+      var startCalls = 0;
+      String? startError;
+
+      final connection = const DesktopConnectionCoordinator().connect(
+        preferredSettings: AppSettings(),
+        prepareForStart: (settings) async {
+          calls.add('prepare');
+          return settings;
+        },
+        generateConfig: (_) async => 'mixed-port: 7890',
+        writeConfig: (_) async {},
+        start: () async {
+          startCalls++;
+          calls.add('start:$startCalls');
+          if (startCalls == 1) {
+            startError = 'bind: address already in use';
+            firstStartFinished.complete();
+            return false;
+          }
+          startError = null;
+          return true;
+        },
+        stop: () async {
+          calls.add('stop');
+          await releaseCleanup.future;
+        },
+        isRevisionCurrent: () => true,
+        isIntentCurrent: () => true,
+        shouldRollbackStaleIntent: () => true,
+        cancelIntent: () => calls.add('cancel-intent'),
+        readStartFailureReason: () => startError,
+      );
+
+      await firstStartFinished.future;
+      await Future<void>.delayed(Duration.zero);
+      expect(calls, contains('stop'));
+      expect(startCalls, 1);
+
+      releaseCleanup.complete();
+      expect((await connection).connected, isTrue);
+      expect(calls, containsAllInOrder(['start:1', 'stop', 'start:2']));
+    });
+
+    test('a failed bind-clash cleanup aborts retry and cancels intent',
+        () async {
+      final calls = <String>[];
+      var startCalls = 0;
+      var intentCurrent = true;
+
+      final connection = const DesktopConnectionCoordinator().connect(
+        preferredSettings: AppSettings(),
+        prepareForStart: (settings) async {
+          calls.add('prepare');
+          return settings;
+        },
+        generateConfig: (_) async => 'mixed-port: 7890',
+        writeConfig: (_) async {},
+        start: () async {
+          calls.add('start');
+          startCalls++;
+          return false;
+        },
+        stop: () async {
+          calls.add('stop');
+          throw StateError('failed-start cleanup did not complete');
+        },
+        isRevisionCurrent: () => true,
+        isIntentCurrent: () => intentCurrent,
+        shouldRollbackStaleIntent: () => true,
+        cancelIntent: () {
+          calls.add('cancel-intent');
+          intentCurrent = false;
+        },
+        readStartFailureReason: () => 'bind: address already in use',
+      );
+
+      await expectLater(
+        connection,
+        throwsA(isA<StateError>()),
+      );
+      expect(startCalls, 1);
+      expect(intentCurrent, isFalse);
+      expect(calls, ['prepare', 'start', 'stop', 'cancel-intent']);
+    });
+
     test(
         'automatic recovery rebuilds config and retries one explicit bind clash',
         () async {
@@ -229,6 +319,13 @@ void main() {
       expect(result.connected, isTrue);
       expect(result.preferredNodeSwitchSucceeded, isFalse);
       expect(
+        result.preferredNodeSwitchWarning(
+          preferredNodeName: '东京节点',
+          runtimeNodeName: '新加坡节点',
+        ),
+        '未能切换到首选节点“东京节点”，当前连接仍保留，正在使用“新加坡节点”。',
+      );
+      expect(
         harness.calls,
         [
           'prepare',
@@ -239,6 +336,22 @@ void main() {
         ],
       );
       expect(harness.running, isTrue);
+    });
+
+    test('preferred-node warning is absent unless a connected switch failed',
+        () {
+      expect(
+        const DesktopConnectionResult.connected(
+          preferredNodeSwitchSucceeded: true,
+        ).preferredNodeSwitchWarning(preferredNodeName: '东京节点'),
+        isNull,
+      );
+      expect(
+        const DesktopConnectionResult.failed(
+          DesktopConnectionFailure.startFailed,
+        ).preferredNodeSwitchWarning(preferredNodeName: '东京节点'),
+        isNull,
+      );
     });
 
     test('generation failure cancels only this intent before core startup',

--- a/packages/ssrvpn_shared/test/home_latency_controller_test.dart
+++ b/packages/ssrvpn_shared/test/home_latency_controller_test.dart
@@ -41,7 +41,7 @@ void main() {
       ]);
     });
 
-    test('canSelect reflects current latency state', () {
+    test('canSelect ignores failed or unknown latency for runnable nodes', () {
       final node = ProxyNode(
         name: 'A',
         type: 'ss',
@@ -52,7 +52,9 @@ void main() {
 
       expect(controller.canSelect(node), isTrue);
       controller.applyNow([node], 'A', 65535);
-      expect(controller.canSelect(node), isFalse);
+      expect(controller.canSelect(node), isTrue);
+      controller.applyNow([node], 'A', -1);
+      expect(controller.canSelect(node), isTrue);
     });
 
     test('a newer batch rejects callbacks and completion from an older batch',

--- a/packages/ssrvpn_shared/test/home_node_controller_test.dart
+++ b/packages/ssrvpn_shared/test/home_node_controller_test.dart
@@ -65,6 +65,32 @@ void main() {
       );
     });
 
+    test('falls back to the first runnable node when all latencies are unknown',
+        () {
+      final nodes = [
+        node('套餐到期：长期有效', latency: 30),
+        node('HY2', type: 'hysteria2', latency: -1),
+        node('TUIC', type: 'tuic', latency: 65535),
+      ];
+
+      expect(
+        HomeNodeController.resolveDefaultNodeFrom(nodes, null)?.name,
+        'HY2',
+      );
+    });
+
+    test('prefers a successfully measured node over an untested node', () {
+      final nodes = [
+        node('Untested'),
+        node('Measured', latency: 30),
+      ];
+
+      expect(
+        HomeNodeController.resolveDefaultNodeFrom(nodes, null)?.name,
+        'Measured',
+      );
+    });
+
     test('resolves runtime selected node from Mihomo state', () {
       final nodes = [
         node('A'),
@@ -134,7 +160,7 @@ void main() {
       expect(controller.nodes.map((node) => node.name), ['Real Node']);
     });
 
-    test('applies latency batch and moves only timed-out nodes to bottom', () {
+    test('latency only sorts nodes and never blocks manual selection', () {
       final nodes = [
         node('A'),
         node('B'),
@@ -152,7 +178,10 @@ void main() {
 
       expect(sorted.map((node) => node.name), ['A', 'C', 'B', 'D']);
       expect(HomeNodeController.canSelectNode(sorted[0], latencies), isTrue);
-      expect(HomeNodeController.canSelectNode(sorted[2], latencies), isFalse);
+      expect(HomeNodeController.canSelectNode(sorted[2], latencies), isTrue);
+      expect(HomeNodeController.canSelectNode(sorted[3], latencies), isTrue);
+      expect(
+          HomeNodeController.canSelectNode(node('Unknown'), const {}), isTrue);
     });
   });
 }

--- a/packages/ssrvpn_shared/test/log_redactor_test.dart
+++ b/packages/ssrvpn_shared/test/log_redactor_test.dart
@@ -28,17 +28,216 @@ void main() {
     expect(sanitized, isNot(contains('hidden')));
   });
 
+  test('redacts quoted credential assignments without consuming later fields',
+      () {
+    final sanitized = LogRedactor.sanitize(
+      '''password="alpha beta gamma" status=ready, token='delta epsilon'; apiSecret="zeta eta" node=usable''',
+    );
+
+    expect(sanitized, contains('password: ***'));
+    expect(sanitized, contains('token: ***'));
+    expect(sanitized, contains('apiSecret: ***'));
+    expect(sanitized, contains('status=ready'));
+    expect(sanitized, contains('node=usable'));
+    expect(sanitized, isNot(contains('alpha beta gamma')));
+    expect(sanitized, isNot(contains('delta epsilon')));
+    expect(sanitized, isNot(contains('zeta eta')));
+  });
+
+  test('fails safely for an unterminated quoted credential', () {
+    final sanitized = LogRedactor.sanitize(
+      'token="secret value that never closes',
+    );
+
+    expect(sanitized, 'token: ***');
+    expect(sanitized, isNot(contains('secret value')));
+  });
+
+  test('redacts quoted authorization values containing spaces', () {
+    final sanitized = LogRedactor.sanitize(
+      'authorization="Bearer alpha beta" status=ready',
+    );
+
+    expect(sanitized, contains('authorization: ***'));
+    expect(sanitized, contains('status=ready'));
+    expect(sanitized, isNot(contains('alpha beta')));
+  });
+
+  test('fails closed for unterminated quoted authorization values', () {
+    for (final input in const [
+      'authorization="Bearer alpha beta',
+      "authorization='Basic dXNlcjpwYXNz extra",
+      '{"authorization":"Bearer alpha beta',
+      "{'authorization':'Token alpha beta",
+    ]) {
+      final sanitized = LogRedactor.sanitize(input);
+
+      expect(sanitized, isNot(contains('alpha')));
+      expect(sanitized, isNot(contains('beta')));
+      expect(sanitized, isNot(contains('dXNlcjpwYXNz')));
+      expect(sanitized, isNot(contains('extra')));
+      expect(sanitized, contains('authorization: ***'));
+    }
+  });
+
+  test('redacts multiline quoted credentials and preserves later fields', () {
+    for (final input in const [
+      'password="alpha\nbeta"\nstatus=ready',
+      'authorization="Bearer alpha\r\nbeta"\r\nstatus=ready',
+    ]) {
+      final sanitized = LogRedactor.sanitize(input);
+
+      expect(sanitized, isNot(contains('alpha')));
+      expect(sanitized, isNot(contains('beta')));
+      expect(sanitized, contains('status=ready'));
+    }
+  });
+
+  test('redacts closed multiline JSON credentials and preserves later fields',
+      () {
+    const cases = {
+      '{"password":"alpha\nbeta","status":"ready"}': '"status":"ready"',
+      '{"authorization":"Bearer alpha\r\nbeta","status":"ready"}':
+          '"status":"ready"',
+      "{'password':'alpha\r\nbeta','status':'ready'}": "'status':'ready'",
+      "{'authorization':'Token alpha\nbeta','status':'ready'}":
+          "'status':'ready'",
+    };
+    for (final entry in cases.entries) {
+      final sanitized = LogRedactor.sanitize(entry.key);
+
+      expect(sanitized, isNot(contains('alpha')));
+      expect(sanitized, isNot(contains('beta')));
+      expect(sanitized, contains(entry.value));
+    }
+  });
+
+  test('fails closed for unterminated multiline quoted credentials', () {
+    for (final input in const [
+      'password="alpha\nbeta',
+      'authorization="Bearer alpha\r\nbeta',
+    ]) {
+      final sanitized = LogRedactor.sanitize(input);
+
+      expect(sanitized, isNot(contains('alpha')));
+      expect(sanitized, isNot(contains('beta')));
+      expect(sanitized, contains('***'));
+    }
+  });
+
+  test('redacts YAML block credentials without consuming dedented fields', () {
+    for (final input in const [
+      'password: |-\n  alpha\n  beta\nstatus: ready',
+      'authorization: >+\r\n  Bearer alpha\r\n  beta\r\nstatus: ready',
+    ]) {
+      final sanitized = LogRedactor.sanitize(input);
+
+      expect(sanitized, isNot(contains('alpha')));
+      expect(sanitized, isNot(contains('beta')));
+      expect(sanitized, contains('status: ready'));
+    }
+  });
+
+  test('redacts escaped quotes inside credential values', () {
+    final sanitized = LogRedactor.sanitize(
+      r'''password="alpha\"beta gamma" status=ready''',
+    );
+
+    expect(sanitized, contains('password: ***'));
+    expect(sanitized, contains('status=ready'));
+    expect(sanitized, isNot(contains('beta gamma')));
+  });
+
+  test('fails safely for an unterminated JSON credential', () {
+    final sanitized = LogRedactor.sanitize(
+      '{"token":"json secret value that never closes',
+    );
+
+    expect(sanitized, contains('token: ***'));
+    expect(sanitized, isNot(contains('json secret value')));
+  });
+
+  test('redacts escaped quotes inside JSON credential values', () {
+    final sanitized = LogRedactor.sanitize(
+      r'''{"token":"alpha\" beta","status":"ready"}''',
+    );
+
+    expect(sanitized, contains('"status":"ready"'));
+    expect(sanitized, isNot(contains('alpha')));
+    expect(sanitized, isNot(contains(' beta')));
+  });
+
+  test('recognizes semicolons as credential assignment boundaries', () {
+    final sanitized = LogRedactor.sanitize(
+      'status=x;password="alpha beta";node=ready',
+    );
+
+    expect(sanitized, contains('status=x'));
+    expect(sanitized, contains('password: ***'));
+    expect(sanitized, contains('node=ready'));
+    expect(sanitized, isNot(contains('alpha beta')));
+  });
+
+  test('redacts public IPv6 while preserving useful local and reserved ranges',
+      () {
+    final sanitized = LogRedactor.sanitize(
+      'egress=[2606:4700:4700::1111]:443 alternate=2404:6800:4005:80a::200e '
+      'loopback=::1 link=fe80::1234 private=fd12:3456::1 docs=2001:db8::1',
+    );
+
+    expect(sanitized, isNot(contains('2606:4700:4700::1111')));
+    expect(sanitized, isNot(contains('2404:6800:4005:80a::200e')));
+    expect(sanitized, contains('[public-ip-redacted]:443'));
+    expect(sanitized, contains('::1'));
+    expect(sanitized, contains('fe80::1234'));
+    expect(sanitized, contains('fd12:3456::1'));
+    expect(sanitized, contains('2001:db8::1'));
+  });
+
+  test('redacts a public IPv6 address before trailing punctuation', () {
+    final sanitized = LogRedactor.sanitize('egress=2001:4860:4860::8888.');
+
+    expect(sanitized, 'egress=[public-ip-redacted].');
+  });
+
   test('redacts credentials embedded in URLs', () {
     final sanitized = LogRedactor.sanitize(
       'GET https://user:pass@example.com/path?token=tok&access_token=access#api_key=key',
     );
 
-    expect(sanitized, contains('https://***:***@example.com/path'));
-    expect(sanitized, contains('token=***'));
-    expect(sanitized, contains('access_token=***'));
-    expect(sanitized, contains('api_key=***'));
+    expect(sanitized, contains('https://example.com/***'));
     expect(sanitized, isNot(contains('user:pass')));
-    expect(sanitized, isNot(contains('access#')));
+    expect(sanitized, isNot(contains('/path')));
+    expect(sanitized, isNot(contains('access_token')));
+  });
+
+  test('redacts HTTP URL paths and fragments while retaining the origin', () {
+    final sanitized = LogRedactor.sanitize(
+      'request failed for '
+      'https://api.example.com/client/private-token/refresh#session-secret',
+    );
+
+    expect(sanitized, contains('https://api.example.com/***'));
+    expect(sanitized, isNot(contains('private-token')));
+    expect(sanitized, isNot(contains('session-secret')));
+  });
+
+  test('retains explicit ports and brackets IPv6 origins', () {
+    final sanitized = LogRedactor.sanitize(
+      'ipv4=https://127.0.0.1:9090/version '
+      'ipv6=http://[::1]:9090/connections',
+    );
+
+    expect(sanitized, contains('https://127.0.0.1:9090/***'));
+    expect(sanitized, contains('http://[::1]:9090/***'));
+    expect(sanitized, isNot(contains('/version')));
+    expect(sanitized, isNot(contains('/connections')));
+  });
+
+  test('does not rewrite ordinary non-URL diagnostic text', () {
+    const message = 'core ready route=/connections status=healthy';
+
+    expect(LogRedactor.sanitize(message), message);
   });
 
   test('redacts non-standard authorization header forms', () {

--- a/packages/ssrvpn_shared/test/runtime_notice_test.dart
+++ b/packages/ssrvpn_shared/test/runtime_notice_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ssrvpn_shared/runtime_notice.dart';
+
+void main() {
+  test('notice level is independent from its user-facing text', () {
+    expect(
+      const RuntimeNotice.success('连接未完成').level,
+      RuntimeNoticeLevel.success,
+    );
+    expect(
+      const RuntimeNotice.error('核心已自动恢复').level,
+      RuntimeNoticeLevel.error,
+    );
+    expect(
+      windowsTunElevationHandoffRuntimeNotice.level,
+      RuntimeNoticeLevel.progress,
+    );
+  });
+
+  testWidgets('a dynamic success notice clears after its display duration', (
+    tester,
+  ) async {
+    final notice = RuntimeNotice.success('端口已自动调整');
+    RuntimeNotice? currentNotice = notice;
+    var clearCount = 0;
+
+    final timer = scheduleSuccessfulRuntimeNoticeClear(
+      notice: notice,
+      currentNotice: () => currentNotice,
+      clear: () {
+        clearCount++;
+        currentNotice = null;
+      },
+    );
+
+    expect(timer, isNotNull);
+    await tester.pump(runtimeNoticeSuccessDuration);
+    expect(clearCount, 1);
+    expect(currentNotice, isNull);
+  });
+
+  testWidgets('an old success timer never clears a newer notice', (
+    tester,
+  ) async {
+    final oldNotice = RuntimeNotice.success('端口已自动调整');
+    RuntimeNotice? currentNotice = oldNotice;
+    var clearCount = 0;
+
+    scheduleSuccessfulRuntimeNoticeClear(
+      notice: oldNotice,
+      currentNotice: () => currentNotice,
+      clear: () => clearCount++,
+    );
+    currentNotice = const RuntimeNotice.warning('外部网络检查暂时不可用');
+
+    await tester.pump(runtimeNoticeSuccessDuration);
+    expect(clearCount, 0);
+    expect(currentNotice.level, RuntimeNoticeLevel.warning);
+  });
+
+  test('only success notices are scheduled for automatic clearing', () {
+    const notice = RuntimeNotice.error('连接未完成');
+    final timer = scheduleSuccessfulRuntimeNoticeClear(
+      notice: notice,
+      currentNotice: () => notice,
+      clear: () {},
+    );
+
+    expect(timer, isNull);
+  });
+
+  test('a successful disconnected-to-running edge clears an old failure', () {
+    expect(
+      shouldClearRuntimeNoticeOnRunningEdge(
+        wasRunning: false,
+        isRunning: true,
+        notice: const RuntimeNotice.error('上一次连接失败'),
+      ),
+      isTrue,
+    );
+  });
+
+  test('an already-running refresh keeps a newer cleanup failure visible', () {
+    expect(
+      shouldClearRuntimeNoticeOnRunningEdge(
+        wasRunning: true,
+        isRunning: true,
+        notice: const RuntimeNotice.error('系统代理清理状态无法确认'),
+      ),
+      isFalse,
+    );
+  });
+}

--- a/packages/ssrvpn_shared/test/update_service_dialog_test.dart
+++ b/packages/ssrvpn_shared/test/update_service_dialog_test.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:ssrvpn_shared/services/update_service.dart';
+import 'package:http/testing.dart';
+import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 
 void main() {
   testWidgets('desktop update dialog fits 1920x1080 at 150 percent scaling', (
@@ -74,5 +77,68 @@ void main() {
       'https://example.com/SSRVPN_Setup.exe',
       'https://github.com/Elegying/SSRVPN/releases/download/v9.9.9/SSRVPN_Setup.exe',
     ]);
+  });
+
+  testWidgets('download failure dialog never exposes raw internal details', (
+    tester,
+  ) async {
+    final output = Directory.systemTemp.createTempSync('ssrvpn-update-ui-');
+    addTearDown(() {
+      if (output.existsSync()) output.deleteSync(recursive: true);
+    });
+    late BuildContext context;
+    late Future<void> task;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (value) {
+            context = value;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+
+    await tester.runAsync(() async {
+      task = SharedUpdateService.downloadVerifiedUpdateWithProgress(
+        context,
+        const AppUpdateInfo(
+          version: '9.9.9',
+          downloadUrl: 'https://example.com/SSRVPN_Setup.exe',
+          changelog: '',
+          sha256:
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        ),
+        fileName: 'SSRVPN_Setup.exe',
+        outputDirectory: output,
+        client: MockClient(
+          (_) async => throw StateError(
+            'download failed token=top-secret for '
+            'https://example.com/private/update/path',
+          ),
+        ),
+        progressDescription: '正在下载',
+        onVerified: (_) async {},
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    });
+    for (var attempt = 0;
+        attempt < 100 && find.text('更新失败').evaluate().isEmpty;
+        attempt++) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 10)),
+      );
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+
+    expect(find.text('更新失败'), findsOneWidget);
+    expect(find.textContaining('top-secret'), findsNothing);
+    expect(find.textContaining('/private/update/path'), findsNothing);
+    expect(find.textContaining('当前版本仍可使用'), findsOneWidget);
+
+    await tester.tap(find.text('知道了'));
+    await tester.pumpAndSettle();
+    await tester.runAsync(() => task.timeout(const Duration(seconds: 5)));
   });
 }

--- a/scripts/check-android-native-bridge-guards.sh
+++ b/scripts/check-android-native-bridge-guards.sh
@@ -31,6 +31,8 @@ VPN_PROTECT_MONITOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn
 NOTIFICATION_SUPPORT="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/VpnNotificationSupport.kt"
 NOTIFICATION_GATE="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NotificationGenerationGate.kt"
 CORE_LIVENESS_MONITOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreLivenessMonitor.kt"
+CORE_RECOVERY_COORDINATOR="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreRecoveryCoordinator.kt"
+CORE_RECOVERY_POLICY="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreRecoveryPolicy.kt"
 CORE_PORT_RELEASE_VERIFIER="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CorePortReleaseVerifier.kt"
 CORE_STOP_DECISION="$ROOT/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/CoreStopDecision.kt"
 CORE_ELF_VERIFIER="$ROOT/scripts/verify_android_core_elf.py"
@@ -142,8 +144,8 @@ if grep -Fq "syncSettings" "$STARTUP_ORCHESTRATOR"; then
   exit 1
 fi
 
-require_text "BRIDGE_START_TIMEOUT_MS"
-require_text "PENDING_START_CANCEL_GRACE_MS = 1_000L"
+require_text "bridgeThread.join(VpnStartBudget.BRIDGE_MS)"
+require_text "SystemClock.elapsedRealtime() + VpnStartBudget.CANCEL_GRACE_MS"
 require_text "serviceStartInProgress.compareAndSet(false, true)"
 require_text "processTerminationPending.get()"
 require_text "processTerminationPending.set(true)"
@@ -159,19 +161,45 @@ grep -Fq "fun connectionState(): Map<String, Any?>" "$NATIVE_SESSION_COORDINATOR
   exit 1
 }
 require_text "NativeConnectionSession.publishRunning(configPath)"
-require_text "NativeVpnSessionCoordinator.reserveRecovery(request.configPath)"
+require_file_text "$CORE_RECOVERY_COORDINATOR" "NativeVpnSessionCoordinator.reserveRecovery(request.configPath)"
 require_text "NativeConnectionSession.clearRunning()"
 require_text "if (stopDecision.clearRunningSession)"
 require_text "NativeConnectionSession.clearRecovery()"
-require_text "CoreRecoveryPolicy.nextAttempt(request.attempt)"
-require_text "stopForRecovery"
-require_text "showCoreRecoveryFailedNotification"
+require_file_text "$CORE_RECOVERY_COORDINATOR" "nextAttemptAfterUnexpectedExit(request.attempt)"
+require_file_text "$CORE_RECOVERY_COORDINATOR" "CoreRecoveryPolicy.nextAttempt(currentAttempt)"
+require_file_text "$CORE_RECOVERY_POLICY" "stableHealthMillis: Long = 120_000L"
+require_file_text "$CORE_RECOVERY_POLICY" "fun observeHealth(isHealthy: Boolean?, monotonicMillis: Long)"
+require_file_text "$CORE_LIVENESS_MONITOR" "recoveryBudget.observeHealth("
+require_file_text "$CORE_LIVENESS_MONITOR" "bridgeRunning == true && protectMonitorRunning && apiHealthy"
+require_file_text "$CORE_LIVENESS_MONITOR" "monotonicMillis: () -> Long"
+require_text "internal fun stopForRecovery"
+require_text "stopInternal(false, true)"
+require_text "stopAllOnWorker(removeForeground = !preserveForegroundUi)"
+require_file_text "$CORE_RECOVERY_COORDINATOR" "service.stopForRecovery {"
+require_file_text "$CORE_RECOVERY_COORDINATOR" "service.startService(restartIntent)"
+require_text "internal fun showCoreRecoveryFailedNotification()"
+require_file_text "$CORE_RECOVERY_COORDINATOR" "service.showCoreRecoveryFailedNotification()"
 require_text "EXTRA_RECOVERY_ATTEMPT"
 require_text "EXTRA_RECOVERY_TOKEN"
-require_text "CoreRecoveryPolicy.shouldAcceptRestart("
+require_file_text "$CORE_RECOVERY_COORDINATOR" "CoreRecoveryPolicy.shouldAcceptRestart("
+require_file_text "$CORE_RECOVERY_COORDINATOR" "CoreRecoveryPolicy.retryAfterStartFailure(recoveryAttempt)"
+require_file_text "$CORE_RECOVERY_COORDINATOR" "handler.postDelayed("
+require_file_text "$CORE_RECOVERY_COORDINATOR" "CoreRecoveryPolicy.retryDelayMillis(nextAttempt)"
+require_file_text "$CORE_RECOVERY_COORDINATOR" "private val recoveryGeneration = AtomicLong(0)"
+require_text "CoreRecoveryCoordinator.shouldAcceptRestart("
+require_text "CoreRecoveryCoordinator.stopAfterStartFailure("
+require_text "CoreRecoveryCoordinator.cancelPendingRecovery()"
 require_text "VpnServiceRestartStore.shouldAcceptStickyRestart(this)"
 require_text "VpnServiceRestartStore.recordExplicitStart(this)"
 require_text "VpnServiceRestartStore.recordManualStop(this)"
+require_tile_text "VpnStartBudget.RESULT_MS"
+require_activity_text '"OPEN_URL_FAILED", "无法打开链接，请稍后重试", null'
+require_activity_text '"INSTALL_UPDATE_FAILED"'
+require_activity_text '"无法打开安装界面，请重新下载安装包后重试"'
+if grep -Eq '"(OPEN_URL_FAILED|INSTALL_UPDATE_FAILED)",[[:space:]]*error\.message' "$MAIN_ACTIVITY"; then
+  echo "Android native action errors must not expose raw exception messages" >&2
+  exit 1
+fi
 require_file_text "$VPN_RESTART_STORE" "internal object StickyVpnRestartPolicy"
 require_file_text "$VPN_RESTART_STORE" "editor.commit()"
 
@@ -231,27 +259,59 @@ if "_isConnecting = false" not in core_down or "连接已中断" not in core_dow
     raise SystemExit(
         "Android home must clear the spinner when the core stops during node persistence"
     )
+if "preferredNodePersisted = await _rememberSelectedNode(" not in source:
+    raise SystemExit("Android successful connections do not isolate node preference save failures")
+if "已连接，但首选节点保存失败" not in source:
+    raise SystemExit("Android successful connection lost its preference-save warning")
 PY
-python3 - "${HOME_PARTS[1]}" <<'PY'
+python3 - "${HOME_PARTS[1]}" "$HOME_DART" <<'PY'
 import sys
 from pathlib import Path
 
 source = Path(sys.argv[1]).read_text(encoding="utf-8")
+home = Path(sys.argv[2]).read_text(encoding="utf-8")
+registration = source[
+    source.index("void _registerClashService("):
+    source.index("bool _onSubscriptionChanged(")
+]
+for needle in (
+    "clashService.onStatusChanged = _onClashStatusChanged",
+    "clashService.onRuntimeNotice = _onClashRuntimeNotice",
+    "identical(previous.onRuntimeNotice, _onClashRuntimeNotice)",
+):
+    if needle not in registration:
+        raise SystemExit(f"Android home service registration is missing: {needle}")
+if "_registerClashService(context.watch<ClashService>())" not in home:
+    raise SystemExit("Android home does not rebind callbacks when service identity changes")
+if "identical(clashService.onRuntimeNotice, _onClashRuntimeNotice)" not in home:
+    raise SystemExit("Android home dispose no longer clears its runtime notice callback")
 load = source[source.index("Future<void> _loadInitialData() async") :]
-register = load.index("clashService.onStatusChanged = _onClashStatusChanged")
 runtime_query = load.index("await clashService.currentSelectedProxyName()")
 node_capture = load.index("HomeNodeController.runnableNodesFrom(subService.allNodes)")
-if not (register < runtime_query < node_capture):
+if runtime_query >= node_capture:
     raise SystemExit(
-        "Android home must register status recovery before awaits and capture nodes afterwards"
+        "Android home must query the runtime node before capturing the subscription snapshot"
     )
 for needle in (
     "final statusEpoch = _connectionStatusEpoch",
     "statusEpoch == _connectionStatusEpoch",
-    "final statusEpoch = ++_connectionStatusEpoch",
+    "final applicationEpoch = ++_statusApplicationEpoch",
+    "applicationEpoch != _statusApplicationEpoch",
+    "_observedNativeSessionGeneration != nativeSessionGeneration",
 ):
     if needle not in load:
         raise SystemExit(f"Android home status reconciliation is missing: {needle}")
+if "final statusEpoch = ++_connectionStatusEpoch" in load:
+    raise SystemExit("Android home invalidates live node switches on every status refresh")
+for needle in (
+    "case RuntimeNoticeLevel.progress:",
+    "case RuntimeNoticeLevel.warning:",
+    "_connectionNotice = notice.message",
+    "case RuntimeNoticeLevel.error:",
+    "_errorMessage = notice.message",
+):
+    if needle not in source:
+        raise SystemExit(f"Android runtime notice presentation is missing: {needle}")
 PY
 python3 - "${HOME_PARTS[2]}" <<'PY'
 import sys
@@ -277,6 +337,13 @@ if persist >= remember:
     raise SystemExit("Android node preference is published before the session-bound snapshot")
 if "await clashService.currentSelectedProxyName()" not in perform:
     raise SystemExit("Android node selection lacks a runtime fallback after persistence failure")
+for needle in (
+    "Future<bool> _rememberSelectedNode(",
+    "preferredNodePersisted =",
+    "已切换，但首选节点保存失败",
+):
+    if needle not in source:
+        raise SystemExit(f"Android live switch persistence warning is missing: {needle}")
 PY
 require_text "waitForPendingStart()"
 require_text "VPN is already running; reusing the active session"
@@ -344,8 +411,8 @@ require_text "SSRVPN-bridge-start"
 require_text "SSRVPN-bridge-stop"
 require_text "SSRVPN-bridge-is-running"
 require_text "private fun monitorCoreRunning("
-require_text "recoverFromUnexpectedCoreExit("
-require_text "ContextCompat.startForegroundService(this, restartIntent)"
+require_text "CoreRecoveryCoordinator.recoverFromUnexpectedCoreExit("
+require_file_text "$CORE_RECOVERY_COORDINATOR" "service.startService(restartIntent)"
 
 require_count "bridge.Bridge.init(configDir, \"config.yaml\")" 1
 require_count "bridge.Bridge.start(configPath, tunFd)" 1
@@ -388,11 +455,13 @@ for throwable_guard in (
 if "return bridgeFdTerminationRequired.get() || stopDecision.terminateProcess" not in source:
     raise SystemExit("Android stop can ignore ambiguous Bridge.start fd ownership")
 stop_internal = source[
-    source.index("private fun stopInternal("):source.index("private fun stopAllOnWorker()")
+    source.index("private fun stopInternal("):source.index("private fun stopAllOnWorker(")
 ]
 runner_call = stop_internal.index("StopOperationRunner.run(")
 initial = stop_internal.index("bridgeFdTerminationRequired.get()", runner_call)
-cleanup = stop_internal.index("::stopAllOnWorker", initial)
+cleanup = stop_internal.index(
+    "stopAllOnWorker(removeForeground = !preserveForegroundUi)", initial
+)
 handoff = stop_internal.index("processTerminationPending.set(true)", cleanup)
 complete = stop_internal.index("stopOperation::complete", handoff)
 schedule = stop_internal.index("notificationHandler.postDelayed(", complete)
@@ -477,7 +546,7 @@ if "return null" not in running_check:
     )
 if "isBridgeRunningWithTimeout() == false" not in stop:
     raise SystemExit("Android stop treats an unknown Bridge probe as stopped")
-if "{ isBridgeRunningWithTimeout() != false }" not in source:
+if "isBridgeRunning = ::isBridgeRunningWithTimeout" not in source:
     raise SystemExit("Android liveness monitor no longer fails open on probe errors")
 PY
 
@@ -738,8 +807,10 @@ require_route_text "addRoute(route.address, route.prefixLength)"
 require_route_text "VpnIpv6Config.defaultRoute"
 require_text "builder.setBlocking(false)"
 require_text "VpnAppExclusionInstaller.install(builder)"
-require_text "VpnDataPlaneProbe.isStartupHealthy("
-require_text '"VPN 数据通道不可用，请切换节点或重试"'
+require_text "VpnDataPlaneProbe.startupOutcome("
+require_file_text "$VPN_DATA_PLANE_PROBE" '"VPN 数据通道不可用，请切换节点或重试"'
+require_file_text "$VPN_DATA_PLANE_PROBE" '"previous_probe_still_running"'
+require_file_text "$VPN_DATA_PLANE_PROBE" '"上次 VPN 联网检查仍在结束，请稍后重试；若持续出现请重启应用"'
 require_file_text "$VPN_DATA_PLANE_PROBE" '"https://www.gstatic.com/generate_204"'
 require_file_text "$VPN_DATA_PLANE_PROBE" '"https://www.youtube.com/generate_204"'
 require_file_text "$VPN_DATA_PLANE_PROBE" '"https://cp.cloudflare.com/generate_204"'
@@ -763,7 +834,7 @@ if ! grep -Fq "Looper.myLooper() != handler.looper" "$NOTIFICATION_GATE"; then
   exit 1
 fi
 require_text "notificationGeneration.publishLatest("
-require_text "CoreRecoveryPolicy.shouldPublishRecovery("
+require_file_text "$CORE_RECOVERY_COORDINATOR" "CoreRecoveryPolicy.shouldPublishRecovery("
 require_activity_text "NATIVE_SNAPSHOT_UPDATE_FAILED"
 
 for needle in \
@@ -816,6 +887,8 @@ for needle in \
     exit 1
   }
 done
+require_file_text "$CLASH_NATIVE_BRIDGE" \
+  '连接服务意外停止，请点击连接重试；如仍失败，请查看运行日志。'
 for needle in \
   '"PERMISSION_DENIED"' \
   'Unable to request VPN permission' \
@@ -933,7 +1006,7 @@ wait_start = source.index("private fun waitForPendingStart(): Boolean")
 wait_end = source.index("private fun stopBridgeWithTimeout()", wait_start)
 if "BRIDGE_START_TIMEOUT_MS" in source[wait_start:wait_end]:
     raise SystemExit("Android cancellation still waits for the full bridge start timeout")
-stop_all_start = source.index("private fun stopAllOnWorker(): Boolean")
+stop_all_start = source.index("private fun stopAllOnWorker(removeForeground: Boolean): Boolean")
 stop_all_end = source.index("private fun waitForProtectMonitor", stop_all_start)
 stop_all = source[stop_all_start:stop_all_end]
 if "pendingStartStopped && stopBridgeWithTimeout()" in stop_all:
@@ -951,6 +1024,15 @@ monitor_end = source.index("private fun isBridgeRunningWithTimeout", monitor_sta
 monitor = source[monitor_start:monitor_end]
 if "CoreLivenessMonitor.waitForUnexpectedExit" not in monitor:
     raise SystemExit("Android VPN service does not delegate core liveness monitoring")
+for required in (
+    "recoveryAttempt = request.attempt",
+    "isBridgeRunning = ::isBridgeRunningWithTimeout",
+    "request.copy(attempt = liveness.recoveryAttempt)",
+):
+    if required not in monitor:
+        raise SystemExit(f"Android native recovery budget wiring is missing: {required}")
+if "isBridgeRunningWithTimeout() != false" in monitor:
+    raise SystemExit("Android unknown bridge health incorrectly counts as stable health")
 if "startToken != currentGeneration()" not in liveness_source:
     raise SystemExit("Android core monitor is not scoped to its start generation")
 routes = [
@@ -990,17 +1072,23 @@ if line_count > 30:
     )
 PY
 
-python3 - "$SERVICE" "$NOTIFICATION_SUPPORT" <<'PY'
+python3 - "$SERVICE" "$NOTIFICATION_SUPPORT" "$CORE_RECOVERY_COORDINATOR" <<'PY'
 import sys
 from pathlib import Path
 
 service = Path(sys.argv[1])
 support = Path(sys.argv[2])
+recovery = Path(sys.argv[3])
 line_count = len(service.read_text(encoding="utf-8").splitlines())
 if line_count > 970:
     raise SystemExit(f"{service}: VPN service grew to {line_count} lines")
 if "fun formatBytes(bytes: Long)" not in support.read_text(encoding="utf-8"):
     raise SystemExit(f"{support}: missing notification byte formatter")
+recovery_line_count = len(recovery.read_text(encoding="utf-8").splitlines())
+if recovery_line_count > 180:
+    raise SystemExit(
+        f"{recovery}: core recovery coordinator grew to {recovery_line_count} lines"
+    )
 PY
 
 python3 - "$SERVICE" <<'PY'
@@ -1034,7 +1122,7 @@ recovery = Path(sys.argv[4]).read_text(encoding="utf-8")
 service_boundaries = (
     ("override fun onStartCommand(", "private fun currentNotificationState()"),
     ("private fun notifyCurrentState(", "private fun startNotificationUpdates()"),
-    ("private fun showCoreRecoveryFailedNotification()", "private fun isBridgeRunningWithTimeout()"),
+    ("internal fun showCoreRecoveryFailedNotification()", "private fun isBridgeRunningWithTimeout()"),
 )
 for start_marker, end_marker in service_boundaries:
     start = service.index(start_marker)
@@ -1054,6 +1142,37 @@ for source, needle in (
 ):
     if needle not in source:
         raise SystemExit(f"Android system callback crash boundary is missing: {needle}")
+PY
+
+python3 - "$SERVICE" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+start_begin = source.index("override fun onStartCommand(")
+start_end = source.index("private fun currentNotificationState()", start_begin)
+start = source[start_begin:start_end]
+if start.count("serviceStopGate.acceptStart(startId)") != 3:
+    raise SystemExit(
+        "Android VPN service must accept only disconnect, reused, or claimed starts"
+    )
+if "serviceStopGate.includeRejectedStart(startId)" not in start:
+    raise SystemExit("Android cleanup rejection no longer joins the pending stop")
+
+stop_begin = source.index("private fun stopInternal(")
+stop_end = source.index("private fun stopAllOnWorker(", stop_begin)
+stop = source[stop_begin:stop_end]
+for required in (
+    "val stopToken = serviceStopGate.beginOrJoinStop()",
+    "val stopStartId = serviceStopGate.finishStop(stopToken)",
+    "stopSelfResult(stopStartId)",
+):
+    if required not in stop:
+        raise SystemExit(
+            f"Android VPN stop completion is not startId-scoped: {required}"
+        )
+if "stopSelf()" in stop:
+    raise SystemExit("Android VPN stop completion can stop a newer service start")
 PY
 
 echo "Android native bridge guard check passed."

--- a/scripts/test_windows_proxy_shutdown_recovery.py
+++ b/scripts/test_windows_proxy_shutdown_recovery.py
@@ -368,7 +368,10 @@ class WindowsProxyShutdownRecoveryTest(unittest.TestCase):
             shared_home.index("final reason = clashService.lastStartError") :
             shared_home.index("} catch (e, stack)")
         ]
-        self.assertIn("AppFailure.fromMessage(reason).code", expected_failure)
+        self.assertIn(
+            "final failure = AppFailure.fromMessage(reason);", expected_failure
+        )
+        self.assertIn("expected: failure.code", expected_failure)
         self.assertIn("AppErrorCode.permissionRequired", expected_failure)
         caught_exception = shared_home[
             shared_home.index("} catch (e, stack)") :
@@ -473,12 +476,25 @@ class WindowsProxyShutdownRecoveryTest(unittest.TestCase):
                 "void _clearStartOperation"
             )
         ]
-        intent = recovery.index("isConnectionIntentCurrent")
-        teardown = recovery.index("!await _waitForTunTeardown()", intent)
-        budget = recovery.index("_unexpectedExitRecoveryPolicy.tryAcquire()", teardown)
+        intent_helper = lifecycle[
+            lifecycle.index("bool _hasActiveUnexpectedExitRecoveryIntent") :
+            lifecycle.index("Future<void> _recoverFromUnexpectedExit")
+        ]
+        self.assertIn("isConnectionIntentCurrent", intent_helper)
+        intent = recovery.index("_hasActiveUnexpectedExitRecoveryIntent")
+        teardown = recovery.index(
+            "await waitForUnexpectedExitTunTeardown()", intent
+        )
+        post_teardown_intent = recovery.index(
+            "_hasActiveUnexpectedExitRecoveryIntent", teardown
+        )
+        timeout = recovery.index("if (!tunTeardownComplete)", post_teardown_intent)
+        budget = recovery.index("_unexpectedExitRecoveryPolicy.tryAcquire()", timeout)
         restart = recovery.index("recoverDesktopConnection(generation!)", budget)
         self.assertLess(intent, teardown)
-        self.assertLess(teardown, budget)
+        self.assertLess(teardown, post_teardown_intent)
+        self.assertLess(post_teardown_intent, timeout)
+        self.assertLess(timeout, budget)
         self.assertLess(budget, restart)
 
     def test_tun_pending_marker_restores_gate_after_app_restart(self) -> None:


### PR DESCRIPTION
## Summary

- Harden latency selection and post-connect health monitoring against stale probes, transient failures, overlapping recovery, and old-generation callbacks.
- Keep external reachability advisory after connection, while preserving fail-closed safety for exact Android HTTP 204 startup validation and ambiguous desktop proxy ownership.
- Replace raw exceptions with actionable, redacted user messages and structured safe diagnostics across Android, macOS, Windows, and shared code.
- Add cross-platform regression coverage for lifecycle races, single-flight probes, timeout budgets, recovery ownership, runtime notices, and log redaction.

## Scope

- [x] Shared package
- [x] Android
- [x] macOS
- [x] Windows
- [x] CI/release/docs

Verification scripts were strengthened; GitHub workflow and release configuration are unchanged.

## Verification

- [x] scripts/check-quality-hygiene.sh
- [x] scripts/check-shared-barrel-imports.sh
- [x] scripts/workspace.sh analyze
- [x] scripts/workspace.sh test
- [x] make verify before merge

Final local make verify exited 0:

- Release tooling: 340 tests
- Shared: 613/613; coverage 84.62%
- Android Flutter: 261/261; native JVM BUILD SUCCESSFUL; coverage 67.82%
- macOS Flutter: 268/268 plus XCTest; coverage 66.99%
- Windows: 234 passed, 8 platform-conditional skips; coverage 51.20%
- All four analyzers, formatting, secret checks, structural guards, and coverage floors passed
- Final independent read-only DeepSeek-V4-Flash High review found no remaining P0/P1/P2

## Security and compatibility

- [x] No secrets, private subscription data, generated artifacts, or untrusted input are logged or committed.
- [x] HTTP subscription compatibility, the tested Android domestic-app bypass policy, IPv4-only routing, and the two-page product surface remain unchanged unless this PR explicitly replaces a documented decision.
- [x] Native lifecycle, system proxy, TUN, installer, or release changes include target-platform evidence.

Explicitly unchanged:

- Private-car nodes retain the required synthetic 24–39 ms latency.
- Desktop subscription cards remain long-press/right-click only; keyboard editing is intentionally out of scope.
- Android startup still requires an exact native HTTP 204 result.
- Desktop API failure with unknown proxy ownership remains fail-closed.

No new physical-device acceptance is claimed by this PR.

## Release Notes

- More tolerant connection health monitoring avoids unnecessary disconnects on transient external failures.
- Connection failures now provide clearer recovery guidance without exposing paths, tokens, raw exceptions, or sensitive diagnostics.
- Recovery and shutdown guards prevent stale work from interrupting a newer connection.
- No tag, GitHub Release, release workflow, or distributable build is part of this PR.

## Risk

- Connection lifecycle code spans native and Flutter boundaries; generation, epoch, ownership, start-id, and single-flight guards are covered by targeted race regressions.
- An operating-system resolver that ignores interruption may keep one probe worker alive until the OS returns. The implementation prevents worker accumulation, shares one total deadline, and reports the busy state clearly.
