### PR TITLE
test(windows): wait for installer cleanup completion

### DIFF
--- a/scripts/test_windows_installer_config.py
+++ b/scripts/test_windows_installer_config.py
@@ -320,9 +320,27 @@ class WindowsInstallerConfigTest(unittest.TestCase):
         )
         marker_wait = smoke.index("Wait-PathAbsent -Path $upgradeMarker")
         residue_check = smoke.index(
-            "Assert-NoCleanupQuarantine -Installer $upgradeInstaller"
+            "Assert-NoCleanupQuarantine -Installer $upgradeInstaller "
+            "-MaxAttempts 560"
         )
         self.assertLess(marker_wait, residue_check)
+        self.assertIn(
+            "[ValidateRange(1, 560)][int]$MaxAttempts = 1", smoke
+        )
+        self.assertEqual(
+            smoke.count("Wait-PathAbsent -Path $upgradeInstaller"), 2
+        )
+        self.assertEqual(
+            smoke.count("Wait-PathAbsent -Path $upgradeMarker"), 2
+        )
+        self.assertLess(
+            residue_check,
+            smoke.rindex("Wait-PathAbsent -Path $upgradeInstaller"),
+        )
+        self.assertLess(
+            residue_check,
+            smoke.rindex("Wait-PathAbsent -Path $upgradeMarker"),
+        )
         self.assertIn("$installInstaller", smoke)
         self.assertIn("$upgradeInstaller", smoke)
         self.assertIn("Assert-InstallerPreserved", smoke)

--- a/scripts/test_windows_installer_package.ps1
+++ b/scripts/test_windows_installer_package.ps1
@@ -363,21 +363,31 @@ function Wait-PathAbsent {
 }
 
 function Assert-NoCleanupQuarantine {
-  param([Parameter(Mandatory = $true)][string]$Installer)
+  param(
+    [Parameter(Mandatory = $true)][string]$Installer,
+    [ValidateRange(1, 560)][int]$MaxAttempts = 1
+  )
 
   $parent = Split-Path -Path $Installer -Parent
   $leaf = [System.IO.Path]::GetFileName($Installer)
-  $residue = @(
-    Get-ChildItem -LiteralPath $parent -Force -File `
-      -Filter ($leaf + '.ssrvpn-cleanup.*') -ErrorAction Stop
-    Get-ChildItem -LiteralPath $parent -Force -File `
-      -Filter ($leaf + '.ssrvpn-verified-update.ssrvpn-cleanup.*') `
-      -ErrorAction Stop
-  )
-  if ($residue.Count -ne 0) {
-    $residuePaths = $residue.FullName -join ', '
-    throw "Post-install cleanup left an isolated installer behind: $residuePaths"
+  $residue = @()
+  for ($attempt = 0; $attempt -lt $MaxAttempts; $attempt++) {
+    $residue = @(
+      Get-ChildItem -LiteralPath $parent -Force -File `
+        -Filter ($leaf + '.ssrvpn-cleanup.*') -ErrorAction Stop
+      Get-ChildItem -LiteralPath $parent -Force -File `
+        -Filter ($leaf + '.ssrvpn-verified-update.ssrvpn-cleanup.*') `
+        -ErrorAction Stop
+    )
+    if ($residue.Count -eq 0) {
+      return
+    }
+    if ($attempt + 1 -lt $MaxAttempts) {
+      Start-Sleep -Milliseconds 250
+    }
   }
+  $residuePaths = $residue.FullName -join ', '
+  throw "Post-install cleanup left an isolated installer behind: $residuePaths"
 }
 
 function New-VerifiedUpdateAuthorization {
@@ -1004,7 +1014,13 @@ try {
       $upgradeOrphanContent) {
     throw 'Verified alternate update cleanup changed the canonical orphan sidecar.'
   }
-  Assert-NoCleanupQuarantine -Installer $upgradeInstaller
+  # The production helper isolates the verified package before deleting it.
+  # Wait for that asynchronous phase instead of treating its random path as
+  # permanent residue the instant the original names disappear. Recheck the
+  # public names because a timed-out deletion safely restores both files.
+  Assert-NoCleanupQuarantine -Installer $upgradeInstaller -MaxAttempts 560
+  Wait-PathAbsent -Path $upgradeInstaller
+  Wait-PathAbsent -Path $upgradeMarker
   Assert-InstallerPreserved -Path $installInstaller
   Assert-SingleMachineShortcut
   Assert-OppositeScopeUninstallEntryRemoved


### PR DESCRIPTION
## Summary

- wait for the asynchronous verified-installer quarantine to reach a terminal state before declaring residue
- recheck the public installer and marker paths after quarantine clears so a safe timeout restoration cannot pass
- keep tamper, replay, and locked-marker guard assertions immediate

## Failure evidence

- release preparation stopped safely in run 32557059932
- PR #148 CI run 32557078305 built, installed, upgraded, and uninstalled successfully, then observed the transient random quarantine paths before the cleanup helper finished

## Verification

- `python3 -m unittest discover -s scripts -p "test_*.py"` — 374 passed
- Windows policy/workflow subset — 47 passed
- `scripts/check-windows-launcher-security.sh` — passed
- `scripts/check-quality-hygiene.sh` — passed
- independent five-axis review — approved, with no production cleanup behavior or trust-boundary change

The Windows runner smoke remains the required timing proof before merge.