### PR TITLE
fix(release): verify OSS cache metadata

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -150,6 +150,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.task == 'oss-rollback'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: release
     concurrency:
       group: ssrvpn-public-release
       cancel-in-progress: false
@@ -163,12 +164,15 @@ jobs:
       ANDROID_RELEASE_CERT_SHA256: ${{ vars.ANDROID_RELEASE_CERT_SHA256 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
 
       - name: Validate rollback target and OSS configuration
         env:
           ROLLBACK_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
           if [[ ! "$ROLLBACK_TAG" =~ ^v[0-9]+(\.[0-9]+){1,3}$ ]]; then
             echo "::error::Invalid rollback tag: $ROLLBACK_TAG"
             exit 1
@@ -228,21 +232,37 @@ jobs:
             --asset "$release_dir/SSRVPN_Setup.exe" \
             --output "$RUNNER_TEMP/rollback-latest.json"
 
-          for name in SSRVPN.apk SSRVPN.dmg SSRVPN_Setup.exe; do
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --connect-timeout 10 --max-time 60 \
+            --max-filesize 1048576 "$base_url/latest.json" \
+            -o "$RUNNER_TEMP/oss-latest.json"
+          cmp "$RUNNER_TEMP/rollback-latest.json" \
+            "$RUNNER_TEMP/oss-latest.json"
+
+          for name in SSRVPN.apk SSRVPN.apk.sha256 SSRVPN.dmg SSRVPN.dmg.sha256 SSRVPN_Setup.exe SSRVPN_Setup.exe.sha256; do
+            case "$name" in
+              *.sha256) max_size=65536 ;;
+              *) max_size=314572800 ;;
+            esac
             curl --fail --silent --show-error --location \
               --proto '=https' --proto-redir '=https' \
               --retry 3 --connect-timeout 10 --max-time 180 \
-              --max-filesize 314572800 "$base_url/$name" \
+              --max-filesize "$max_size" "$base_url/$name" \
               -o "$RUNNER_TEMP/oss-$name"
             cmp "$release_dir/$name" "$RUNNER_TEMP/oss-$name"
           done
 
       - name: Promote OSS public channel
         id: promote_oss
+        env:
+          ROLLBACK_TAG: ${{ inputs.tag }}
         run: |
-          OSS_PRESERVE_BACKUP=1 bash scripts/promote-oss-public-channel.sh \
-            "$RUNNER_TEMP/rollback-release" \
-            "$RUNNER_TEMP/rollback-latest.json"
+          OSS_PRESERVE_BACKUP=1 \
+            OSS_VERSIONED_SOURCE_PREFIX="$OSS_PREFIX/releases/$ROLLBACK_TAG" \
+            bash scripts/promote-oss-public-channel.sh \
+              "$RUNNER_TEMP/rollback-release" \
+              "$RUNNER_TEMP/rollback-latest.json"
 
       - name: Preserve OSS recovery backup
         if: always() && steps.promote_oss.outcome == 'failure'

--- a/scripts/promote-oss-public-channel.sh
+++ b/scripts/promote-oss-public-channel.sh
@@ -120,11 +120,57 @@ fetch_object() {
   local destination="$2"
   local key
   key="$(object_key "$name")"
+  rm -f "$destination" "$destination.headers"
   "$curl_bin" -sS --retry 3 --connect-timeout 10 --max-time 180 \
     --max-filesize "$(download_limit "$name")" -o "$destination" \
+    --dump-header "$destination.headers" \
     -H 'Cache-Control: no-cache' -H 'Pragma: no-cache' \
     -w '%{http_code}' \
     "$public_base/$key?ssrvpn_nocache=$$-$RANDOM-$name" || true
+}
+
+response_has_no_cache_metadata() {
+  local headers="$1"
+  LC_ALL=C awk '
+    BEGIN { cache_control = "" }
+    tolower($0) ~ /^http\// { cache_control = "" }
+    tolower($0) ~ /^cache-control:[[:space:]]*/ {
+      value = $0
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      gsub(/\r/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      cache_control = tolower(value)
+    }
+    END { exit(cache_control == "no-cache" ? 0 : 1) }
+  ' "$headers"
+}
+
+verify_public_object() {
+  local name="$1"
+  local source="$2"
+  local destination="$3"
+  local status
+  status="$(fetch_object "$name" "$destination")"
+  if [ "$status" != 200 ]; then
+    echo "Cannot verify promoted OSS object $name (HTTP ${status:-network error})" >&2
+    return 1
+  fi
+  if ! cmp -s "$source" "$destination"; then
+    echo "Promoted OSS object $name does not match its source" >&2
+    return 1
+  fi
+  if ! response_has_no_cache_metadata "$destination.headers"; then
+    echo "Promoted OSS object $name is missing Cache-Control: no-cache" >&2
+    return 1
+  fi
+}
+
+set_no_cache_metadata() {
+  local name="$1"
+  local key
+  key="$(object_key "$name")"
+  "$ossutil_bin" set-props "oss://$OSS_BUCKET/$key" \
+    --cache-control "no-cache" --metadata-directive update --force
 }
 
 copy_object_authoritatively() {
@@ -522,15 +568,20 @@ for name in "${publish_files[@]}"; do
     upload_source="oss://$OSS_BUCKET/$versioned_source_prefix/$name"
   fi
   key="$(object_key "$name")"
-  "$ossutil_bin" cp "$upload_source" "oss://$OSS_BUCKET/$key" \
-    --force --cache-control "no-cache"
+  case "$upload_source" in
+    oss://*)
+      "$ossutil_bin" cp "$upload_source" "oss://$OSS_BUCKET/$key" --force
+      set_no_cache_metadata "$name"
+      ;;
+    *)
+      "$ossutil_bin" cp "$upload_source" "oss://$OSS_BUCKET/$key" \
+        --force --cache-control "no-cache"
+      ;;
+  esac
   downloaded="$backup_dir/verify-$name"
-  status="$(fetch_object "$name" "$downloaded")"
-  if [ "$status" != 200 ]; then
-    echo "Cannot verify promoted OSS object $name (HTTP ${status:-network error})" >&2
+  if ! verify_public_object "$name" "$source" "$downloaded"; then
     exit 1
   fi
-  cmp "$source" "$downloaded"
 done
 
 retired_marker="$backup_dir/windows-portable-retired.txt"
@@ -552,10 +603,9 @@ for name in "${retired_files[@]}"; do
 
   "$ossutil_bin" cp "$retired_marker" "oss://$OSS_BUCKET/$key" \
     --force --cache-control "no-cache"
-  status="$(fetch_object "$name" "$backup_dir/verify-retired-$name")"
-  if [ "$status" != 200 ] || \
-    ! cmp -s "$retired_marker" "$backup_dir/verify-retired-$name"; then
-    echo "Cannot safely retire OSS object $name (HTTP ${status:-network error})" >&2
+  if ! verify_public_object \
+      "$name" "$retired_marker" "$backup_dir/verify-retired-$name"; then
+    echo "Cannot safely retire OSS object $name" >&2
     exit 1
   fi
 done
@@ -563,12 +613,11 @@ done
 latest_key="$(object_key latest.json)"
 "$ossutil_bin" cp "$manifest" "oss://$OSS_BUCKET/$latest_key" \
   --force --cache-control "no-cache"
-status="$(fetch_object latest.json "$backup_dir/verify-latest.json")"
-if [ "$status" != 200 ]; then
-  echo "Cannot verify promoted latest.json (HTTP ${status:-network error})" >&2
+if ! verify_public_object \
+    latest.json "$manifest" "$backup_dir/verify-latest.json"; then
+  echo "Cannot verify promoted latest.json" >&2
   exit 1
 fi
-cmp "$manifest" "$backup_dir/verify-latest.json"
 
 committed=1
 trap - EXIT

--- a/scripts/test_generate_oss_release_manifest.py
+++ b/scripts/test_generate_oss_release_manifest.py
@@ -75,7 +75,10 @@ class GenerateOssReleaseManifestTest(unittest.TestCase):
             promoter,
         )
         self.assertIn('--cache-control "no-cache"', promoter)
-        self.assertIn('cmp "$source" "$downloaded"', promoter)
+        self.assertIn('cmp -s "$source" "$destination"', promoter)
+        self.assertIn('"$ossutil_bin" set-props', promoter)
+        self.assertIn("--metadata-directive update", promoter)
+        self.assertIn("response_has_no_cache_metadata", promoter)
         for name in (
             "SSRVPN.apk",
             "SSRVPN.dmg",

--- a/scripts/test_promote_oss_public_channel.py
+++ b/scripts/test_promote_oss_public_channel.py
@@ -90,6 +90,7 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
             (self.objects / "ssrvpn" / "latest.json").read_bytes(),
             self.manifest.read_bytes(),
         )
+        self._assert_no_cache_metadata((*PUBLISHED_FILES, "latest.json"))
 
     def test_success_uses_versioned_oss_objects_for_stable_assets(self) -> None:
         result = self._run(
@@ -103,6 +104,34 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                 (self.objects / "ssrvpn" / "downloads" / name).read_bytes(),
                 (self.source / name).read_bytes(),
             )
+        self._assert_no_cache_metadata(PUBLISHED_FILES)
+
+    def test_metadata_update_failure_restores_previous_channel(self) -> None:
+        before = self._snapshot_public_channel()
+
+        result = self._run(
+            versioned_source_prefix=self.versioned_prefix,
+            require_server_side_source=True,
+            set_props_fail_on="SSRVPN.dmg",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self._snapshot_public_channel(), before)
+        self._assert_no_cache_metadata((*MANAGED_FILES, "latest.json"))
+
+    def test_missing_public_no_cache_metadata_fails_closed(self) -> None:
+        before = self._snapshot_public_channel()
+
+        result = self._run(
+            versioned_source_prefix=self.versioned_prefix,
+            require_server_side_source=True,
+            set_props_noop_on="SSRVPN.dmg",
+            stale_response_header_on="SSRVPN.dmg",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Cache-Control: no-cache", result.stderr)
+        self.assertEqual(self._snapshot_public_channel(), before)
 
     def test_rejects_unsafe_versioned_source_prefix_before_mutation(self) -> None:
         before = self._snapshot_public_channel()
@@ -445,6 +474,9 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
         public_missing_on: str = "",
         versioned_source_prefix: str = "",
         require_server_side_source: bool = False,
+        set_props_fail_on: str = "",
+        set_props_noop_on: str = "",
+        stale_response_header_on: str = "",
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -466,6 +498,9 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                 "FAKE_REQUIRE_SERVER_SIDE_SOURCE": (
                     "1" if require_server_side_source else "0"
                 ),
+                "FAKE_SET_PROPS_FAIL_ON": set_props_fail_on,
+                "FAKE_SET_PROPS_NOOP_ON": set_props_noop_on,
+                "FAKE_STALE_RESPONSE_HEADER_ON": stale_response_header_on,
                 "RUNNER_TEMP": str(self.root),
                 "OSS_PRESERVE_BACKUP": "1" if preserve_backup else "0",
             }
@@ -525,6 +560,15 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
             )
             self.assertIn(hashlib.sha256(payload).hexdigest(), checksum.split())
 
+    def _assert_no_cache_metadata(self, names: tuple[str, ...]) -> None:
+        metadata_root = self.objects / ".fake-state" / "metadata" / "ssrvpn"
+        for name in names:
+            relative = Path("downloads", name) if name != "latest.json" else Path(name)
+            self.assertEqual(
+                (metadata_root / relative).read_text(encoding="utf-8"),
+                "no-cache",
+            )
+
     def _snapshot_public_channel(self) -> dict[str, Optional[bytes]]:
         channel = self.objects / "ssrvpn"
         snapshot: dict[str, Optional[bytes]] = {}
@@ -578,6 +622,8 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                 state.mkdir(exist_ok=True)
                 def object_path(value):
                     return root / value.split('/', 3)[3]
+                def metadata_path(value):
+                    return state / 'metadata' / value.split('/', 3)[3]
                 if command == 'cp':
                     source, destination = sys.argv[2], sys.argv[3]
                     if source.startswith('oss://'):
@@ -603,6 +649,14 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                         )
                         target.parent.mkdir(parents=True, exist_ok=True)
                         shutil.copyfile(remote, target)
+                        if destination.startswith('oss://'):
+                            source_metadata = metadata_path(source)
+                            target_metadata = metadata_path(destination)
+                            target_metadata.parent.mkdir(parents=True, exist_ok=True)
+                            if source_metadata.is_file():
+                                shutil.copyfile(source_metadata, target_metadata)
+                            else:
+                                target_metadata.unlink(missing_ok=True)
                         raise SystemExit(0)
                     if (os.environ.get('FAKE_REQUIRE_SERVER_SIDE_SOURCE') == '1'
                             and destination.startswith('oss://')
@@ -627,12 +681,43 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                     target = object_path(destination)
                     target.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copyfile(source, target)
+                    target_metadata = metadata_path(destination)
+                    target_metadata.parent.mkdir(parents=True, exist_ok=True)
+                    if ('--cache-control' in sys.argv
+                            and sys.argv[sys.argv.index('--cache-control') + 1]
+                            == 'no-cache'):
+                        target_metadata.write_text('no-cache')
+                    else:
+                        target_metadata.unlink(missing_ok=True)
                     fail_after_write = os.environ.get(
                         'FAKE_RESTORE_WRITE_THEN_READ_FAIL_ON')
                     triggered = state / ('read-fail-triggered-' + target.name)
                     if fail_after_write == target.name and not triggered.exists():
                         triggered.touch()
                         (state / ('read-fail-' + target.name)).write_text('3')
+                elif command == 'set-props':
+                    destination = sys.argv[2]
+                    target = object_path(destination)
+                    if not target.is_file():
+                        raise SystemExit(12)
+                    failed_name = os.environ.get('FAKE_SET_PROPS_FAIL_ON')
+                    failure_marker = state / ('set-props-failed-' + target.name)
+                    if failed_name == target.name and not failure_marker.exists():
+                        failure_marker.touch()
+                        raise SystemExit(16)
+                    if ('--cache-control' not in sys.argv
+                            or sys.argv[sys.argv.index('--cache-control') + 1]
+                            != 'no-cache'
+                            or '--metadata-directive' not in sys.argv
+                            or sys.argv[sys.argv.index('--metadata-directive') + 1]
+                            != 'update'
+                            or '--force' not in sys.argv):
+                        raise SystemExit(17)
+                    if os.environ.get('FAKE_SET_PROPS_NOOP_ON') == target.name:
+                        raise SystemExit(0)
+                    target_metadata = metadata_path(destination)
+                    target_metadata.parent.mkdir(parents=True, exist_ok=True)
+                    target_metadata.write_text('no-cache')
                 elif command == 'stat':
                     if not object_path(sys.argv[2]).is_file():
                         print('ServerError: code: NoSuchKey', file=sys.stderr)
@@ -643,6 +728,7 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                                 'SSRVPN.zip', 'SSRVPN.zip.sha256'}):
                         raise SystemExit(11)
                     object_path(sys.argv[2]).unlink(missing_ok=True)
+                    metadata_path(sys.argv[2]).unlink(missing_ok=True)
                 else:
                     raise SystemExit(2)
                 """
@@ -656,6 +742,7 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                 #!/usr/bin/env python3
                 import os, pathlib, shutil, sys, urllib.parse
                 root = pathlib.Path(os.environ['FAKE_OSS_ROOT'])
+                state = root / '.fake-state'
                 args = sys.argv[1:]
                 destination = pathlib.Path(args[args.index('-o') + 1])
                 url = next(value for value in reversed(args) if value.startswith('https://'))
@@ -689,10 +776,30 @@ class PromoteOssPublicChannelTest(unittest.TestCase):
                     print('500', end='')
                     raise SystemExit(0)
                 if not path.is_file():
+                    if '--dump-header' in args:
+                        pathlib.Path(args[args.index('--dump-header') + 1]).write_text(
+                            'HTTP/1.1 404 Not Found\\n\\n')
                     print('404', end='')
                     raise SystemExit(0)
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(path, destination)
+                if '--dump-header' in args:
+                    response_headers = ''
+                    if (os.environ.get('FAKE_STALE_RESPONSE_HEADER_ON')
+                            == path.name):
+                        response_headers = (
+                            'HTTP/1.1 503 Service Unavailable\\n'
+                            'Cache-Control: no-cache\\n\\n'
+                        )
+                    response_headers += 'HTTP/1.1 200 OK\\n'
+                    metadata = state / 'metadata' / parsed.path.lstrip('/')
+                    if metadata.is_file():
+                        response_headers += (
+                            'Cache-Control: ' + metadata.read_text() + '\\n'
+                        )
+                    response_headers += '\\n'
+                    pathlib.Path(args[args.index('--dump-header') + 1]).write_text(
+                        response_headers)
                 print('200', end='')
                 """
             ),

--- a/scripts/test_verify_release_transition.py
+++ b/scripts/test_verify_release_transition.py
@@ -406,9 +406,29 @@ class VerifyReleaseTransitionTest(unittest.TestCase):
             SCRIPT.parents[1] / ".github" / "workflows" / "maintenance.yml"
         ).read_text(encoding="utf-8")
         self.assertIn("group: ssrvpn-public-release", rollback)
+        rollback_job = rollback[rollback.index("  oss-rollback:\n") :]
+        self.assertIn("    environment: release\n", rollback_job)
+        self.assertLess(
+            rollback_job.index("    environment: release\n"),
+            rollback_job.index("    steps:\n"),
+        )
+        self.assertIn("          ref: ${{ github.sha }}\n", rollback_job)
+        self.assertIn('test "$GITHUB_REF" = "refs/heads/main"', rollback_job)
         self.assertIn("gh release download", rollback)
         self.assertIn("scripts/check-release-assets.sh", rollback)
         self.assertIn("ANDROID_RELEASE_CERT_SHA256", rollback)
+        self.assertIn(
+            'for name in SSRVPN.apk SSRVPN.apk.sha256 SSRVPN.dmg '
+            'SSRVPN.dmg.sha256 SSRVPN_Setup.exe SSRVPN_Setup.exe.sha256',
+            rollback,
+        )
+        self.assertIn(
+            'OSS_VERSIONED_SOURCE_PREFIX="$OSS_PREFIX/releases/$ROLLBACK_TAG"',
+            rollback,
+        )
+        self.assertIn('"$base_url/latest.json"', rollback)
+        self.assertIn('cmp "$RUNNER_TEMP/rollback-latest.json" \\', rollback)
+        self.assertIn('"$RUNNER_TEMP/oss-latest.json"', rollback)
         self.assertIn("scripts/promote-oss-public-channel.sh", rollback)
         self.assertIn("Preserve OSS recovery backup", rollback)
         self.assertNotIn("Download and verify immutable rollback bundle", rollback)


### PR DESCRIPTION
## Summary

- repair OSS-to-OSS stable alias promotion by applying Cache-Control with ossutil set-props
- fail closed unless the final public response returns Cache-Control: no-cache and the bytes match
- harden same-tag OSS maintenance with release approval, exact-SHA checkout, immutable manifest/asset comparison, and server-side copy reuse
- cover metadata command failures, false-success responses, stale retry headers, and transactional rollback

## Verification

- `bash scripts/test-release-tooling.sh` (376 tests)
- `bash scripts/check-quality-hygiene.sh`
- `shellcheck scripts/promote-oss-public-channel.sh`
- `actionlint .github/workflows/maintenance.yml`
- `bash -n scripts/promote-oss-public-channel.sh`
- independent five-axis review approved