### PR TITLE
ci: skip platform builds for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,38 @@ env:
   FLUTTER_VERSION: '3.44.1'
 
 jobs:
+  changes:
+    name: Classify CI scope
+    runs-on: ubuntu-latest
+    outputs:
+      platform_required: ${{ steps.scope.outputs.platform_required }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          platform_required="$(
+            python3 scripts/classify-ci-scope.py \
+              --event "$EVENT_NAME" \
+              --base "$BASE_SHA" \
+              --head "$HEAD_SHA"
+          )"
+          case "$platform_required" in
+            true|false) ;;
+            *)
+              echo "Invalid CI scope output: $platform_required" >&2
+              exit 1
+              ;;
+          esac
+          echo "platform_required=$platform_required" >> "$GITHUB_OUTPUT"
+
   secret-scan:
     name: Full-history secret scan
     runs-on: ubuntu-latest
@@ -137,7 +169,8 @@ jobs:
 
   macos-native:
     name: macOS native unit tests
-    needs: [core-assets, secret-scan]
+    if: needs.changes.outputs.platform_required == 'true'
+    needs: [changes, core-assets, secret-scan]
     runs-on: macos-15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -162,8 +195,8 @@ jobs:
 
   flutter-app:
     name: ${{ matrix.name }}
-    needs: [core-assets, secret-scan]
-    runs-on: ${{ matrix.os }}
+    needs: [changes, core-assets, secret-scan]
+    runs-on: ${{ needs.changes.outputs.platform_required == 'true' && matrix.os || 'ubuntu-latest' }}
     permissions:
       contents: read
       security-events: write
@@ -180,25 +213,40 @@ jobs:
             os: macos-15
             directory: SSRVPN_MacOS
     steps:
+      - name: Reject invalid CI scope
+        if: needs.changes.outputs.platform_required != 'true' && needs.changes.outputs.platform_required != 'false'
+        run: |
+          echo "Invalid CI scope classification" >&2
+          exit 1
+
+      - name: Skip platform build for documentation-only changes
+        if: needs.changes.outputs.platform_required == 'false'
+        run: echo "Documentation-only change; platform build is not required."
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: needs.changes.outputs.platform_required == 'true'
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        if: needs.changes.outputs.platform_required == 'true'
         with:
           name: core-assets
           path: .
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        if: needs.changes.outputs.platform_required == 'true'
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: stable
           cache: true
 
-      - run: bash scripts/verify-core-assets.sh
+      - if: needs.changes.outputs.platform_required == 'true'
+        run: bash scripts/verify-core-assets.sh
 
-      - run: flutter pub get --enforce-lockfile
+      - if: needs.changes.outputs.platform_required == 'true'
+        run: flutter pub get --enforce-lockfile
 
       - name: Initialize CodeQL
-        if: matrix.directory != 'SSRVPN_MacOS'
+        if: needs.changes.outputs.platform_required == 'true' && matrix.directory != 'SSRVPN_MacOS'
         uses: github/codeql-action/init@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
         with:
           languages: ${{ matrix.codeql_language }}
@@ -206,43 +254,47 @@ jobs:
           queries: security-extended
 
       - name: Cache Gradle dependencies
-        if: matrix.directory == 'SSRVPN_Android'
+        if: needs.changes.outputs.platform_required == 'true' && matrix.directory == 'SSRVPN_Android'
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-provider: basic
           cache-read-only: ${{ github.ref_name != github.event.repository.default_branch }}
 
-      - run: flutter analyze
+      - if: needs.changes.outputs.platform_required == 'true'
+        run: flutter analyze
         working-directory: ${{ matrix.directory }}
 
-      - run: bash scripts/run-flutter-coverage.sh ${{ matrix.directory }}
+      - if: needs.changes.outputs.platform_required == 'true'
+        run: bash scripts/run-flutter-coverage.sh ${{ matrix.directory }}
 
       - name: Android native unit tests
-        if: matrix.directory == 'SSRVPN_Android'
+        if: needs.changes.outputs.platform_required == 'true' && matrix.directory == 'SSRVPN_Android'
         shell: bash
         run: bash scripts/test-android-native.sh
 
-      - run: bash scripts/check-coverage-thresholds.sh ${{ matrix.directory }}
+      - if: needs.changes.outputs.platform_required == 'true'
+        run: bash scripts/check-coverage-thresholds.sh ${{ matrix.directory }}
 
       - name: Build macOS app
-        if: matrix.directory == 'SSRVPN_MacOS'
+        if: needs.changes.outputs.platform_required == 'true' && matrix.directory == 'SSRVPN_MacOS'
         timeout-minutes: 15
         working-directory: SSRVPN_MacOS
         run: flutter build macos --debug
 
       - name: Analyze native code
-        if: matrix.directory != 'SSRVPN_MacOS'
+        if: needs.changes.outputs.platform_required == 'true' && matrix.directory != 'SSRVPN_MacOS'
         uses: github/codeql-action/analyze@988661ebb5e81487b3fb31b2185d2856c0a10679 # v4
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: always()
+        if: always() && needs.changes.outputs.platform_required == 'true'
         with:
           name: coverage-${{ matrix.directory }}
           path: ${{ matrix.directory }}/coverage/lcov.info
 
   windows-policy-tests:
     name: Windows policy tests
-    needs: secret-scan
+    if: needs.changes.outputs.platform_required == 'true'
+    needs: [changes, secret-scan]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -256,7 +308,8 @@ jobs:
 
   windows-build:
     name: Windows build
-    needs: [core-assets, secret-scan]
+    if: needs.changes.outputs.platform_required == 'true'
+    needs: [changes, core-assets, secret-scan]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -339,16 +392,32 @@ jobs:
   windows:
     name: Windows
     if: always()
-    needs: [windows-policy-tests, windows-build]
+    needs: [changes, windows-policy-tests, windows-build]
     runs-on: ubuntu-latest
     steps:
       - name: Require every Windows gate
         env:
+          SCOPE: ${{ needs.changes.outputs.platform_required }}
           POLICY_RESULT: ${{ needs.windows-policy-tests.result }}
           BUILD_RESULT: ${{ needs.windows-build.result }}
         run: |
-          if [ "$POLICY_RESULT" != success ] ||
-             [ "$BUILD_RESULT" != success ]; then
-            echo "Windows gates failed: policy=$POLICY_RESULT build=$BUILD_RESULT" >&2
-            exit 1
+          if [ "$SCOPE" = true ]; then
+            if [ "$POLICY_RESULT" != success ] ||
+               [ "$BUILD_RESULT" != success ]; then
+              echo "Windows gates failed: policy=$POLICY_RESULT build=$BUILD_RESULT" >&2
+              exit 1
+            fi
+            exit 0
           fi
+
+          if [ "$SCOPE" = false ]; then
+            if [ "$POLICY_RESULT" != skipped ] ||
+               [ "$BUILD_RESULT" != skipped ]; then
+              echo "Unexpected docs-only Windows state: policy=$POLICY_RESULT build=$BUILD_RESULT" >&2
+              exit 1
+            fi
+            exit 0
+          fi
+
+          echo "Invalid CI scope classification: $SCOPE" >&2
+          exit 1

--- a/scripts/classify-ci-scope.py
+++ b/scripts/classify-ci-scope.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Decide whether CI must run the platform-specific jobs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable
+
+
+FULL_SHA = re.compile(r"[0-9a-fA-F]{40}")
+
+
+def platform_required(paths: Iterable[str]) -> bool:
+    changed = list(paths)
+    if not changed:
+        return True
+    return any(
+        not (
+            ("/" not in path and path.endswith(".md"))
+            or (path.startswith("docs/") and len(path) > len("docs/"))
+        )
+        for path in changed
+    )
+
+
+def valid_revision(value: str) -> bool:
+    return bool(FULL_SHA.fullmatch(value)) and value != "0" * 40
+
+
+def changed_paths(event: str, base: str, head: str) -> list[str] | None:
+    if not valid_revision(base) or not valid_revision(head):
+        print("CI scope revisions are missing or malformed; running full CI", file=sys.stderr)
+        return None
+
+    separator = "..." if event == "pull_request" else ".."
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--no-renames",
+            "-z",
+            f"{base}{separator}{head}",
+            "--",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        message = result.stderr.decode(errors="replace").strip()
+        print(f"CI scope diff failed; running full CI: {message}", file=sys.stderr)
+        return None
+
+    return [os.fsdecode(path) for path in result.stdout.split(b"\0") if path]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--base", default="")
+    parser.add_argument("--head", default="")
+    args = parser.parse_args()
+
+    if args.event == "workflow_dispatch":
+        print("true")
+        return 0
+    if args.event not in {"pull_request", "push"}:
+        print(f"Unknown CI event {args.event!r}; running full CI", file=sys.stderr)
+        print("true")
+        return 0
+
+    paths = changed_paths(args.event, args.base, args.head)
+    print("true" if paths is None or platform_required(paths) else "false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-release-tooling.sh
+++ b/scripts/test-release-tooling.sh
@@ -16,6 +16,8 @@ python3 -m unittest \
   scripts/test_find_reusable_main_ci.py \
   scripts/test_macos_native_gate.py \
   scripts/test_check_release_assets.py \
+  scripts/test_ci_docs_scope.py \
+  scripts/test_classify_ci_scope.py \
   scripts/test_free_desktop_distribution.py \
   scripts/test_geoip_workflow.py \
   scripts/test_generate_oss_release_manifest.py \

--- a/scripts/test_ci_docs_scope.py
+++ b/scripts/test_ci_docs_scope.py
@@ -1,0 +1,91 @@
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+POLICY = ROOT / ".github" / "main-branch-protection.json"
+
+
+def job(workflow: str, name: str, next_name: str = "") -> str:
+    start = workflow.index(f"  {name}:\n")
+    end = workflow.index(f"  {next_name}:\n", start) if next_name else len(workflow)
+    return workflow[start:end]
+
+
+class CiDocsScopeTest(unittest.TestCase):
+    REQUIRED_CONTEXTS = (
+        "Full-history secret scan",
+        "Dependency review",
+        "CodeQL (Actions)",
+        "Prepare verified core assets",
+        "macOS native unit tests",
+        "Workspace checks",
+        "Android",
+        "macOS",
+        "Windows",
+    )
+
+    def test_protected_context_names_remain_exactly_unchanged(self) -> None:
+        policy = json.loads(POLICY.read_text(encoding="utf-8"))
+        contexts = tuple(
+            check["context"]
+            for check in policy["required_status_checks"]["checks"]
+        )
+
+        self.assertEqual(contexts, self.REQUIRED_CONTEXTS)
+
+    def test_workflow_uses_a_job_classifier_instead_of_path_filtering(self) -> None:
+        workflow = CI.read_text(encoding="utf-8")
+        trigger = workflow[: workflow.index("permissions:\n")]
+        changes = job(workflow, "changes", "secret-scan")
+
+        self.assertNotIn("paths:", trigger)
+        self.assertNotIn("paths-ignore:", trigger)
+        self.assertIn("platform_required: ${{ steps.scope.outputs.platform_required }}", changes)
+        self.assertIn("python3 scripts/classify-ci-scope.py", changes)
+
+    def test_docs_only_keeps_matrix_contexts_but_avoids_macos_runner(self) -> None:
+        workflow = CI.read_text(encoding="utf-8")
+        matrix = job(workflow, "flutter-app", "windows-policy-tests")
+
+        self.assertIn("    name: ${{ matrix.name }}\n", matrix)
+        self.assertIn("    needs: [changes, core-assets, secret-scan]\n", matrix)
+        self.assertIn(
+            "runs-on: ${{ needs.changes.outputs.platform_required == 'true' && matrix.os || 'ubuntu-latest' }}",
+            matrix,
+        )
+        self.assertIn("Skip platform build for documentation-only changes", matrix)
+        self.assertIn("Reject invalid CI scope", matrix)
+        self.assertGreaterEqual(
+            matrix.count("needs.changes.outputs.platform_required == 'true'"),
+            14,
+        )
+
+    def test_native_and_windows_heavy_jobs_are_scope_gated(self) -> None:
+        workflow = CI.read_text(encoding="utf-8")
+        native = job(workflow, "macos-native", "flutter-app")
+        policy = job(workflow, "windows-policy-tests", "windows-build")
+        build = job(workflow, "windows-build", "windows")
+
+        for child in (native, policy, build):
+            with self.subTest(job=child.splitlines()[0].strip()):
+                self.assertIn("needs.changes.outputs.platform_required == 'true'", child)
+                self.assertIn("changes", child.split("    steps:\n", 1)[0])
+
+    def test_windows_required_context_accepts_only_the_expected_child_state(self) -> None:
+        workflow = CI.read_text(encoding="utf-8")
+        aggregate = job(workflow, "windows")
+
+        self.assertIn("    needs: [changes, windows-policy-tests, windows-build]\n", aggregate)
+        self.assertIn("SCOPE: ${{ needs.changes.outputs.platform_required }}", aggregate)
+        self.assertIn('if [ "$SCOPE" = true ]; then', aggregate)
+        self.assertIn('if [ "$SCOPE" = false ]; then', aggregate)
+        self.assertIn('"$POLICY_RESULT" != skipped', aggregate)
+        self.assertIn('"$BUILD_RESULT" != skipped', aggregate)
+        self.assertIn("Invalid CI scope classification", aggregate)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_classify_ci_scope.py
+++ b/scripts/test_classify_ci_scope.py
@@ -1,0 +1,191 @@
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "classify-ci-scope.py"
+
+
+def load_classifier():
+    spec = importlib.util.spec_from_file_location("classify_ci_scope", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ClassifyCiScopeTest(unittest.TestCase):
+    def run_classifier(
+        self,
+        event: str,
+        *,
+        base: str = "",
+        head: str = "",
+        cwd: Path = ROOT,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--event",
+                event,
+                "--base",
+                base,
+                "--head",
+                head,
+            ],
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_only_root_markdown_and_docs_tree_can_skip_platform_jobs(self) -> None:
+        classifier = load_classifier()
+
+        self.assertFalse(classifier.platform_required(["README.md"]))
+        self.assertFalse(
+            classifier.platform_required(
+                ["CHANGELOG.md", "docs/GEOIP_SOURCE.txt", "docs/images/ui.png"]
+            )
+        )
+
+    def test_mixed_or_non_documentation_paths_require_platform_jobs(self) -> None:
+        classifier = load_classifier()
+
+        for paths in (
+            ["README.md", "lib/main.dart"],
+            ["packages/example/README.md"],
+            [".github/workflows/ci.yml"],
+            ["scripts/prepare-release.sh"],
+            [],
+        ):
+            with self.subTest(paths=paths):
+                self.assertTrue(classifier.platform_required(paths))
+
+    def test_workflow_dispatch_and_unknown_events_fail_closed_to_full(self) -> None:
+        for event in ("workflow_dispatch", "schedule", ""):
+            with self.subTest(event=event):
+                result = self.run_classifier(event)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), "true")
+
+    def test_missing_or_malformed_revisions_fail_closed_to_full(self) -> None:
+        cases = (
+            ("pull_request", "", ""),
+            ("pull_request", "not-a-sha", "a" * 40),
+            ("push", "0" * 40, "a" * 40),
+        )
+        for event, base, head in cases:
+            with self.subTest(event=event, base=base, head=head):
+                result = self.run_classifier(event, base=base, head=head)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), "true")
+
+    def test_git_failure_fails_closed_to_full(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            result = self.run_classifier(
+                "push",
+                base="a" * 40,
+                head="b" * 40,
+                cwd=Path(temporary),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "true")
+
+    def test_pull_request_diff_classifies_docs_and_code_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repository = Path(temporary)
+            subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+            subprocess.run(
+                ["git", "config", "user.name", "CI Scope Test"],
+                cwd=repository,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "ci-scope@example.invalid"],
+                cwd=repository,
+                check=True,
+            )
+            (repository / "README.md").write_text("base\n", encoding="utf-8")
+            subprocess.run(["git", "add", "README.md"], cwd=repository, check=True)
+            subprocess.run(["git", "commit", "-qm", "base"], cwd=repository, check=True)
+            base = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=repository, text=True
+            ).strip()
+
+            (repository / "docs").mkdir()
+            (repository / "docs" / "guide.md").write_text("docs\n", encoding="utf-8")
+            subprocess.run(["git", "add", "docs/guide.md"], cwd=repository, check=True)
+            subprocess.run(["git", "commit", "-qm", "docs"], cwd=repository, check=True)
+            docs_head = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=repository, text=True
+            ).strip()
+
+            docs = self.run_classifier(
+                "pull_request", base=base, head=docs_head, cwd=repository
+            )
+            self.assertEqual(docs.returncode, 0, docs.stderr)
+            self.assertEqual(docs.stdout.strip(), "false")
+
+            (repository / "lib.dart").write_text("void main() {}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "lib.dart"], cwd=repository, check=True)
+            subprocess.run(["git", "commit", "-qm", "code"], cwd=repository, check=True)
+            code_head = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=repository, text=True
+            ).strip()
+
+            code = self.run_classifier(
+                "pull_request", base=base, head=code_head, cwd=repository
+            )
+            self.assertEqual(code.returncode, 0, code.stderr)
+            self.assertEqual(code.stdout.strip(), "true")
+
+    def test_code_to_docs_rename_still_requires_platform_jobs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repository = Path(temporary)
+            subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+            subprocess.run(
+                ["git", "config", "user.name", "CI Scope Test"],
+                cwd=repository,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "ci-scope@example.invalid"],
+                cwd=repository,
+                check=True,
+            )
+            (repository / "source.dart").write_text("void main() {}\n", encoding="utf-8")
+            subprocess.run(["git", "add", "source.dart"], cwd=repository, check=True)
+            subprocess.run(["git", "commit", "-qm", "base"], cwd=repository, check=True)
+            base = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=repository, text=True
+            ).strip()
+
+            (repository / "docs").mkdir()
+            subprocess.run(
+                ["git", "mv", "source.dart", "docs/source.md"],
+                cwd=repository,
+                check=True,
+            )
+            subprocess.run(["git", "commit", "-qam", "rename"], cwd=repository, check=True)
+            head = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=repository, text=True
+            ).strip()
+
+            result = self.run_classifier(
+                "pull_request", base=base, head=head, cwd=repository
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "true")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_code_scanning_and_attestations.py
+++ b/scripts/test_code_scanning_and_attestations.py
@@ -42,7 +42,11 @@ class CodeScanningAndAttestationWorkflowTest(unittest.TestCase):
         self.assertNotIn("Prepare macOS dependencies before CodeQL", platform_job)
         self.assertNotIn("Build macOS native target for CodeQL", platform_job)
         self.assertEqual(
-            platform_job.count("if: matrix.directory != 'SSRVPN_MacOS'"), 2
+            platform_job.count(
+                "if: needs.changes.outputs.platform_required == 'true' && "
+                "matrix.directory != 'SSRVPN_MacOS'"
+            ),
+            2,
         )
         self.assertIn("Build macOS app", platform_job)
         self.assertIn("flutter build macos --debug", platform_job)

--- a/scripts/test_find_reusable_main_ci.py
+++ b/scripts/test_find_reusable_main_ci.py
@@ -329,6 +329,18 @@ class FindReusableMainCiTest(unittest.TestCase):
                 result, _ = self._invoke(jobs=jobs)
                 self.assertEqual(result.returncode, 3, result.stderr)
 
+    def test_docs_only_main_ci_is_not_reusable_for_prepare(self) -> None:
+        jobs = self._jobs()
+        next(
+            job
+            for job in jobs["jobs"]
+            if job["name"] == "macOS native unit tests"
+        )["conclusion"] = "skipped"
+
+        result, _ = self._invoke(jobs=jobs)
+
+        self.assertEqual(result.returncode, 3, result.stderr)
+
     def test_no_matching_or_expired_run_has_distinct_fallback_exit(self) -> None:
         no_runs, commands = self._invoke(runs=[])
         self.assertEqual(no_runs.returncode, 3, no_runs.stderr)

--- a/scripts/test_release_tooling_entrypoint.py
+++ b/scripts/test_release_tooling_entrypoint.py
@@ -105,7 +105,7 @@ python3 -m unittest \\
         platform_header = platform_job[: platform_job.index("    steps:\n")]
 
         self.assertIn(
-            "    needs: [core-assets, secret-scan]\n",
+            "    needs: [changes, core-assets, secret-scan]\n",
             platform_header,
         )
         self.assertNotIn("shared", platform_header)
@@ -173,7 +173,11 @@ python3 -m unittest \\
         ).read_text(encoding="utf-8")
 
         self.assertIn(expected_action, ci)
-        self.assertIn("if: matrix.directory == 'SSRVPN_Android'", ci)
+        self.assertIn(
+            "if: needs.changes.outputs.platform_required == 'true' && "
+            "matrix.directory == 'SSRVPN_Android'",
+            ci,
+        )
         self.assertIn(expected_action, release)
         for workflow in (ci, release):
             self.assertIn("cache-provider: basic", workflow)

--- a/scripts/test_windows_workflow_parallelism.py
+++ b/scripts/test_windows_workflow_parallelism.py
@@ -24,8 +24,8 @@ class WindowsWorkflowParallelismTest(unittest.TestCase):
         aggregate = job(workflow, "windows")
 
         self.assertNotIn("          - name: Windows\n", platform)
-        self.assertIn("    needs: secret-scan\n", policy)
-        self.assertIn("    needs: [core-assets, secret-scan]\n", build)
+        self.assertIn("    needs: [changes, secret-scan]\n", policy)
+        self.assertIn("    needs: [changes, core-assets, secret-scan]\n", build)
         for child in (policy, build):
             self.assertIn("    runs-on: windows-latest\n", child)
 
@@ -44,7 +44,10 @@ class WindowsWorkflowParallelismTest(unittest.TestCase):
         self.assert_windows_build_gates(build)
         self.assertIn("    name: Windows\n", aggregate)
         self.assertIn("    if: always()\n", aggregate)
-        self.assertIn("    needs: [windows-policy-tests, windows-build]\n", aggregate)
+        self.assertIn(
+            "    needs: [changes, windows-policy-tests, windows-build]\n",
+            aggregate,
+        )
         self.assertIn("POLICY_RESULT: ${{ needs.windows-policy-tests.result }}", aggregate)
         self.assertIn("BUILD_RESULT: ${{ needs.windows-build.result }}", aggregate)
         self.assertIn('if [ "$POLICY_RESULT" != success ] ||', aggregate)


### PR DESCRIPTION
## Summary
- classify CI scope fail-closed without third-party path filters
- keep all nine protected check names while skipping platform-heavy jobs for docs-only changes
- force workflow dispatch and release preparation to retain full platform validation
- reject unexpected skipped/success states in the Windows aggregate

## Validation
- `bash scripts/test-release-tooling.sh` (390/390)
- related Python tests (37/37)
- `actionlint .github/workflows/ci.yml`
- `python3 -m py_compile ...`
- `git diff --check`

This changes CI only; it does not alter v4.0.17 or trigger a new release.