### PR TITLE
fix: address security and verification audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ macOS 原生核心支持、单实例租约和窗口恢复脱离应用委托；Wi
 
 ## 开发与验证
 
-推荐使用 Flutter `3.44.1` 或兼容 stable 版本。Android 构建还需要 Android SDK、NDK 与 JDK；macOS 需要 Xcode；Windows 需要 Visual Studio 2022 的“使用 C++ 的桌面开发”工作负载，安装器还需要 Inno Setup 6.5 或更高版本。
+项目精确固定 Flutter `3.44.1`，不接受其他 stable 版本代替；`make verify` 会在执行任何依赖解析或测试前按 `.fvmrc` 失败关闭。可使用 `fvm install && fvm exec make verify`，或使用 `mise exec flutter@3.44.1 -- make verify`。Android 构建还需要 Android SDK、NDK 与 JDK；macOS 需要 Xcode；Windows 需要 Visual Studio 2022 的“使用 C++ 的桌面开发”工作负载，安装器还需要 Inno Setup 6.5 或更高版本。
 
 根目录统一入口：
 
@@ -117,7 +117,7 @@ macOS 原生核心支持、单实例租约和窗口恢复脱离应用委托；Wi
 make verify
 ```
 
-它会检查全部受版本控制的 Dart 格式和 ShellCheck、版本与资源、职责边界、Android 内置 Kotlin、免费桌面分发策略、密钥扫描、发布工具、关键路径性能、依赖解析、严格静态分析、四套 Flutter 测试、Android/macOS 原生测试和覆盖率门槛。Windows 原生代理恢复测试会在 GitHub Windows runner 上编译并运行。日常可按需执行：
+它会先校验精确 Flutter 版本，并自动下载和校验所需 Mihomo/GeoIP 核心资产，然后检查全部受版本控制的 Dart 格式和 ShellCheck、版本与资源、职责边界、Android 内置 Kotlin、免费桌面分发策略、密钥扫描、发布工具、关键路径性能、依赖解析、严格静态分析、四套 Flutter 测试、Android/macOS 原生测试和覆盖率门槛。需要提前准备资源时可单独运行 `make assets`；Windows 原生代理恢复测试会在 GitHub Windows runner 上编译并运行。日常可按需执行：
 
 ```bash
 scripts/workspace.sh pub-get

--- a/SSRVPN_Windows/lib/services/clash_service.dart
+++ b/SSRVPN_Windows/lib/services/clash_service.dart
@@ -134,7 +134,7 @@ class ClashService extends ClashServiceBase
       final size = await coreFile.length();
       log('✅ 核心文件存在: ${(size / 1024 / 1024).toStringAsFixed(1)} MB');
       if (!skipCoreProbes) {
-        await _logCoreVersion();
+        await logCoreVersion();
       }
     } else {
       log('❌ 核心文件不存在: $_corePath');

--- a/SSRVPN_Windows/lib/services/clash_service_lifecycle.dart
+++ b/SSRVPN_Windows/lib/services/clash_service_lifecycle.dart
@@ -177,10 +177,7 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
       return;
     }
     if (_unexpectedExitRecoveryPolicy.recordHealthy(DateTime.now())) {
-      log(
-        '连接达到稳定健康观察窗口，自动恢复次数预算已复位',
-        event: 'health_recovery',
-      );
+      log('连接达到稳定健康观察窗口，自动恢复次数预算已复位', event: 'health_recovery');
     }
   }
 
@@ -222,9 +219,7 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
         : proxyRecoveryListenerActive
             ? '本地保护监听'
             : '系统代理';
-    setConnectivityWarning(
-      '连接与 $routeMode 仍在运行；外部网络观察暂未通过，仅供参考：$warning',
-    );
+    setConnectivityWarning('连接与 $routeMode 仍在运行；外部网络观察暂未通过，仅供参考：$warning');
     log(
       '外部网络观察未通过: $warning；未断开连接，未切换节点',
       level: RuntimeLogLevel.warning,
@@ -335,10 +330,7 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
       var ownershipStatus = await inspectSystemProxyOwnership();
       if (ownershipStatus == SystemProxyOwnershipStatus.unavailable) {
         await waitBeforeProxyOwnershipRecoveryRecheck();
-        if (!isConnectionIntentCurrent(
-          connectionGeneration,
-          connected: true,
-        )) {
+        if (!isConnectionIntentCurrent(connectionGeneration, connected: true)) {
           return false;
         }
         ownershipStatus = await inspectSystemProxyOwnership();
@@ -417,7 +409,8 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
     log(reason);
   }
 
-  Future<void> _logCoreVersion() async {
+  @protected
+  Future<void> logCoreVersion() async {
     Process? process;
     try {
       process = await Process.start(_corePath, ['-v']);
@@ -481,7 +474,7 @@ mixin _WindowsCoreLifecycle on ClashServiceBase {
       if (disposition == _VerifiedCoreTermination.wrongInstallation) {
         throw StateError('进程身份记录指向其他安装目录，已拒绝清理');
       }
-      final recordDeleted = await _deleteCorePid(expectedRecord: record);
+      final recordDeleted = await deleteCorePid(expectedRecord: record);
       if (!recordDeleted) {
         throw StateError('进程身份记录在清理期间发生变化，已拒绝删除');
       }
@@ -847,7 +840,7 @@ try {
       _coreIdentityEstablishment = identityEstablishment;
       final startedPidRecord = await identityEstablishment.establish(
         capture: _captureCorePidRecord,
-        persist: _writeCorePid,
+        persist: writeCorePid,
         ensureStartCurrent: () => _ensureStartCurrent(startToken),
       );
       _corePidRecord = startedPidRecord;
@@ -900,7 +893,7 @@ try {
         if (recoveryListenerWasActive) {
           log('⚠️ 系统代理保护监听已退出，重新执行安全恢复');
         }
-        final cleanup = _deleteCorePid(expectedRecord: startedPidRecord)
+        final cleanup = deleteCorePid(expectedRecord: startedPidRecord)
             .then<void>((recordDeleted) {
           final ownsExitedProcess = identical(_coreProcess, startedProcess);
           final ownsPidRecord = identical(_corePidRecord, startedPidRecord);
@@ -1265,9 +1258,7 @@ try {
     if (_coreProcess == null) _coreUsesTun = false;
     var pidRecordCleaned = true;
     if (expectedPidRecord != null) {
-      pidRecordCleaned = await _deleteCorePid(
-        expectedRecord: expectedPidRecord,
-      );
+      pidRecordCleaned = await deleteCorePid(expectedRecord: expectedPidRecord);
       if (pidRecordCleaned && identical(_corePidRecord, expectedPidRecord)) {
         _corePidRecord = null;
       }
@@ -1312,7 +1303,8 @@ try {
     if (startToken != _startGeneration) throw _DesktopStartCancelled();
   }
 
-  Future<void> _writeCorePid(WindowsCorePidRecord record) async {
+  @protected
+  Future<void> writeCorePid(WindowsCorePidRecord record) async {
     final file = File('$configDir${Platform.pathSeparator}mihomo.pid');
     final existingType = await FileSystemEntity.type(
       file.path,
@@ -1364,7 +1356,8 @@ try {
     }
   }
 
-  Future<bool> _deleteCorePid({
+  @protected
+  Future<bool> deleteCorePid({
     required WindowsCorePidRecord expectedRecord,
   }) async {
     final file = File('$configDir${Platform.pathSeparator}mihomo.pid');
@@ -1606,9 +1599,7 @@ try {
       if (!_unexpectedExitRecoveryPolicy.tryAcquire()) {
         markConnectionLost();
         notifyRuntimeNotice(
-          const RuntimeNotice.error(
-            '连接已断开：核心再次异常退出，自动恢复失败，请重新连接',
-          ),
+          const RuntimeNotice.error('连接已断开：核心再次异常退出，自动恢复失败，请重新连接'),
         );
         return false;
       }
@@ -1713,7 +1704,8 @@ $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
   // ── Config validation ──
 
-  Future<bool> _validateConfig(Map<String, String> environment) async {
+  @protected
+  Future<bool> validateConfig(Map<String, String> environment) async {
     log('正在校验 Mihomo 配置...');
     final watch = Stopwatch()..start();
     try {
@@ -1736,9 +1728,7 @@ $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
       }
       if (result.exitCode == 125) throw _DesktopStartCancelled();
       if (result.exitCode == 124) {
-        setLastStartError(
-          'Windows Mihomo 核心启动配置校验响应超时；可能是系统繁忙或安全软件暂时拦截，请稍后重试',
-        );
+        setLastStartError('Windows Mihomo 核心启动配置校验响应超时；可能是系统繁忙或安全软件暂时拦截，请稍后重试');
         log('❌ $lastStartError');
         return false;
       }

--- a/SSRVPN_Windows/lib/services/clash_service_start_preparation.dart
+++ b/SSRVPN_Windows/lib/services/clash_service_start_preparation.dart
@@ -14,9 +14,7 @@ extension _WindowsStartPreparationSupport on _WindowsCoreLifecycle {
       final stoppedSafely = await _stopInternal();
       _ensureStartCurrent(startToken);
       if (!stoppedSafely) {
-        setLastStartError(
-          _lastStopError ?? '现有 Mihomo 连接无法安全停止，已拒绝启动新的核心',
-        );
+        setLastStartError(_lastStopError ?? '现有 Mihomo 连接无法安全停止，已拒绝启动新的核心');
         log('❌ $lastStartError');
         return _WindowsExistingRuntimePreparation.blocked;
       }
@@ -26,9 +24,7 @@ extension _WindowsStartPreparationSupport on _WindowsCoreLifecycle {
       final stoppedSafely = await _stopInternal();
       _ensureStartCurrent(startToken);
       if (!stoppedSafely || _coreProcess != null) {
-        setLastStartError(
-          _lastStopError ?? '上一个 Mihomo 进程尚未退出，已拒绝启动新的核心',
-        );
+        setLastStartError(_lastStopError ?? '上一个 Mihomo 进程尚未退出，已拒绝启动新的核心');
         log('❌ $lastStartError');
         return _WindowsExistingRuntimePreparation.blocked;
       }
@@ -69,10 +65,8 @@ extension _WindowsStartPreparationSupport on _WindowsCoreLifecycle {
     await Directory(tmpDir).create(recursive: true);
     _ensureStartCurrent(startToken);
     final environment = {'TMPDIR': tmpDir, 'TMP': tmpDir, 'TEMP': tmpDir};
-    if (!await _validateConfig(environment)) {
-      setLastStartError(
-        lastStartError ?? 'Mihomo 配置校验失败，请打开运行日志查看具体配置错误',
-      );
+    if (!await validateConfig(environment)) {
+      setLastStartError(lastStartError ?? 'Mihomo 配置校验失败，请打开运行日志查看具体配置错误');
       return null;
     }
     _ensureStartCurrent(startToken);

--- a/SSRVPN_Windows/test/clash_service_lifecycle_test.dart
+++ b/SSRVPN_Windows/test/clash_service_lifecycle_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ssrvpn_shared/ssrvpn_shared.dart';
 import 'package:ssrvpn_windows/services/clash_service.dart';
 import 'package:ssrvpn_windows/services/system_proxy_service.dart';
+import 'package:ssrvpn_windows/src/services/windows_core_pid_record.dart';
 
 ClashService _createTestService() => ClashService(
       // Lifecycle unit tests must never inspect or restore the developer's
@@ -20,6 +21,18 @@ void main() {
     final service = _InspectableHealthTimeoutClashService();
 
     expect(service.exposedHealthCheckTimeout, const Duration(seconds: 25));
+  });
+
+  test('one unhealthy periodic result does not disconnect a live intent', () {
+    final service = _InspectablePeriodicHealthClashService()
+      ..requestConnectionIntent(true)
+      ..setRunning(true);
+    addTearDown(service.dispose);
+
+    service.publishPeriodicHealth(false);
+
+    expect(service.isRunning, isTrue);
+    expect(service.connectionDesired, isTrue);
   });
 
   test('fresh lifecycle reports safe idle diagnostics', () async {
@@ -79,74 +92,70 @@ void main() {
     );
   });
 
-  test('uninitialized lifecycle fails start without spawning a process',
-      () async {
-    final service = _createTestService();
+  test(
+    'uninitialized lifecycle fails start without spawning a process',
+    () async {
+      final service = _createTestService();
 
-    expect(await service.start(), isFalse);
-    expect(service.lastStartError, contains('尚未初始化'));
-  });
+      expect(await service.start(), isFalse);
+      expect(service.lastStartError, contains('尚未初始化'));
+    },
+  );
 
-  test('automatic recovery fails safely before lifecycle initialization',
-      () async {
-    final service = _createTestService();
+  test(
+    'automatic recovery fails safely before lifecycle initialization',
+    () async {
+      final service = _createTestService();
 
-    expect(await service.startForAutomaticRecovery(), isFalse);
-    expect(service.lastStartError, contains('尚未初始化'));
-  });
+      expect(await service.startForAutomaticRecovery(), isFalse);
+      expect(service.lastStartError, contains('尚未初始化'));
+    },
+  );
 
-  test('config validator execution failure keeps the actionable process error',
-      () async {
-    final temp = await Directory.systemTemp.createTemp(
-      'ssrvpn_windows_config_validation_error_',
-    );
-    final fakeCore = File('${temp.path}${Platform.pathSeparator}mihomo.exe');
-    final config = File('${temp.path}${Platform.pathSeparator}config.yaml');
-    await fakeCore.writeAsString('not an executable');
-    await config.writeAsString('mixed-port: 7890\n');
-    final service = _createTestService();
-    addTearDown(() async {
+  test(
+    'config validator execution failure keeps the actionable process error',
+    () async {
+      final temp = await Directory.systemTemp.createTemp(
+        'ssrvpn_windows_config_validation_error_',
+      );
+      final fakeCore = File('${temp.path}${Platform.pathSeparator}mihomo.exe');
+      final config = File('${temp.path}${Platform.pathSeparator}config.yaml');
+      await fakeCore.writeAsString('not an executable');
+      await config.writeAsString('mixed-port: 7890\n');
+      final service = _createTestService();
+      addTearDown(() async {
+        await service.flushLogs();
+        service.dispose();
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      await service.init(
+        AppSettings(),
+        dataDir: temp.path,
+        skipCoreProbes: true,
+      );
+      service
+        ..setCorePath(fakeCore.path)
+        ..setPaths(configDir: temp.path, configPath: config.path);
+
+      expect(await service.start(), isFalse);
+      expect(service.lastStartError, isNot(contains('配置校验失败，请打开运行日志')));
+      expect(
+        service.lastStartError,
+        anyOf(contains('安全软件'), contains('执行权限'), contains('架构不兼容')),
+      );
+      expect(
+        AppFailure.fromMessage(service.lastStartError).code,
+        anyOf(AppErrorCode.permissionRequired, AppErrorCode.coreMissing),
+      );
       await service.flushLogs();
-      service.dispose();
-      if (await temp.exists()) await temp.delete(recursive: true);
-    });
-    await service.init(
-      AppSettings(),
-      dataDir: temp.path,
-      skipCoreProbes: true,
-    );
-    service
-      ..setCorePath(fakeCore.path)
-      ..setPaths(configDir: temp.path, configPath: config.path);
-
-    expect(await service.start(), isFalse);
-    expect(
-      service.lastStartError,
-      isNot(contains('配置校验失败，请打开运行日志')),
-    );
-    expect(
-      service.lastStartError,
-      anyOf(
-        contains('安全软件'),
-        contains('执行权限'),
-        contains('架构不兼容'),
-      ),
-    );
-    expect(
-      AppFailure.fromMessage(service.lastStartError).code,
-      anyOf(
-        AppErrorCode.permissionRequired,
-        AppErrorCode.coreMissing,
-      ),
-    );
-    await service.flushLogs();
-    final logs = await File(
-      '${temp.path}${Platform.pathSeparator}ssrvpn.log',
-    ).readAsString();
-    expect(logs, contains('event=windows_config_validation_launch_failed'));
-    expect(logs, isNot(contains('ProcessException:')));
-    expect(logs, isNot(contains('Command:')));
-  });
+      final logs = await File(
+        '${temp.path}${Platform.pathSeparator}ssrvpn.log',
+      ).readAsString();
+      expect(logs, contains('event=windows_config_validation_launch_failed'));
+      expect(logs, isNot(contains('ProcessException:')));
+      expect(logs, isNot(contains('Command:')));
+    },
+  );
 
   test('stop hook fails closed when proxy cleanup is unavailable', () async {
     final service = _createTestService();
@@ -165,35 +174,400 @@ void main() {
     expect(service.isRunning, isFalse);
   });
 
-  test('pending proxy recovery fails closed when its state path is unavailable',
-      () async {
+  test(
+    'pending proxy recovery fails closed when its state path is unavailable',
+    () async {
+      final temp = await Directory.systemTemp.createTemp(
+        'ssrvpn_windows_lifecycle_recovery_',
+      );
+      final proxy = SystemProxyService.forTesting(
+        isWindows: true,
+        localAppData: '',
+        scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+      );
+      final service = ClashService(systemProxyService: proxy);
+      addTearDown(() async {
+        await service.flushLogs();
+        service.dispose();
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      await service.init(
+        AppSettings(),
+        dataDir: temp.path,
+        skipCoreProbes: true,
+      );
+
+      expect(service.hasPendingSystemProxyRecovery, isTrue);
+      expect(await service.recoverPendingSystemProxy(), isFalse);
+      expect(service.lastStartError, contains('尚未初始化'));
+      expect(service.hasPendingSystemProxyRecovery, isTrue);
+    },
+  );
+
+  test(
+    'core PID identity record is published once and deleted by exact identity',
+    () async {
+      final temp = await Directory.systemTemp.createTemp(
+        'ssrvpn_windows_pid_identity_',
+      );
+      final service = _InspectableLifecycleClashService(
+        systemProxyService: SystemProxyService.forTesting(
+          isWindows: false,
+          scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+        ),
+      );
+      addTearDown(() async {
+        await service.flushLogs();
+        service.dispose();
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      await service.init(
+        AppSettings(),
+        dataDir: temp.path,
+        skipCoreProbes: true,
+      );
+      const record = WindowsCorePidRecord(
+        pid: 4242,
+        creationTimeUtcFileTime: '133700000000000000',
+        canonicalExecutablePath: r'C:\Program Files\SSRVPN\mihomo.exe',
+      );
+      const differentRecord = WindowsCorePidRecord(
+        pid: 4243,
+        creationTimeUtcFileTime: '133700000000000001',
+        canonicalExecutablePath: r'C:\Program Files\SSRVPN\mihomo.exe',
+      );
+      final pidFile = File('${temp.path}${Platform.pathSeparator}mihomo.pid');
+
+      await service.persistCorePid(record);
+      expect(
+        WindowsCorePidRecord.tryParse(await pidFile.readAsString()),
+        record,
+      );
+      await expectLater(
+        service.persistCorePid(record),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('拒绝覆盖'),
+          ),
+        ),
+      );
+      expect(await service.removeCorePid(differentRecord), isFalse);
+      expect(await pidFile.exists(), isTrue);
+      expect(await service.removeCorePid(record), isTrue);
+      expect(await pidFile.exists(), isFalse);
+      expect(await service.removeCorePid(record), isTrue);
+    },
+  );
+
+  test(
+    'core PID cleanup preserves every unverified filesystem object',
+    () async {
+      final temp = await Directory.systemTemp.createTemp(
+        'ssrvpn_windows_pid_identity_reject_',
+      );
+      final service = _InspectableLifecycleClashService(
+        systemProxyService: SystemProxyService.forTesting(
+          isWindows: false,
+          scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+        ),
+      );
+      addTearDown(() async {
+        await service.flushLogs();
+        service.dispose();
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      await service.init(
+        AppSettings(),
+        dataDir: temp.path,
+        skipCoreProbes: true,
+      );
+      const record = WindowsCorePidRecord(
+        pid: 4242,
+        creationTimeUtcFileTime: '133700000000000000',
+        canonicalExecutablePath: r'C:\SSRVPN\mihomo.exe',
+      );
+      final path = '${temp.path}${Platform.pathSeparator}mihomo.pid';
+
+      await Directory(path).create();
+      expect(await service.removeCorePid(record), isFalse);
+      expect(await Directory(path).exists(), isTrue);
+      await Directory(path).delete();
+
+      for (final contents in <String>[
+        '',
+        'not-json',
+        List.filled(maxWindowsCorePidRecordBytes + 1, 'x').join(),
+      ]) {
+        await File(path).writeAsString(contents);
+        expect(
+          await service.removeCorePid(record),
+          isFalse,
+          reason: 'must preserve an unverified ${contents.length}-byte record',
+        );
+        expect(await File(path).exists(), isTrue);
+        await File(path).delete();
+      }
+    },
+  );
+
+  test(
+    'idle initialized lifecycle stops after a terminal proxy recovery',
+    () async {
+      final temp = await Directory.systemTemp.createTemp(
+        'ssrvpn_windows_safe_idle_stop_',
+      );
+      final proxy = SystemProxyService.forTesting(
+        isWindows: true,
+        localAppData: temp.path,
+        scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+      );
+      final service = ClashService(systemProxyService: proxy);
+      addTearDown(() async {
+        await service.flushLogs();
+        service.dispose();
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      await service.init(
+        AppSettings(),
+        dataDir: '${temp.path}${Platform.pathSeparator}data',
+        skipCoreProbes: true,
+      );
+
+      service.setRunning(true);
+      await service.stop();
+
+      expect(service.isRunning, isFalse);
+      expect(proxy.recoveryPending, isFalse);
+      expect(
+        await FileSystemEntity.type(
+          '${temp.path}${Platform.pathSeparator}data'
+          '${Platform.pathSeparator}mihomo.pid',
+          followLinks: false,
+        ),
+        FileSystemEntityType.notFound,
+      );
+    },
+  );
+
+  test('config validation reports a real non-zero validator result', () async {
     final temp = await Directory.systemTemp.createTemp(
-      'ssrvpn_windows_lifecycle_recovery_',
+      'ssrvpn_windows_config_validator_result_',
     );
-    final proxy = SystemProxyService.forTesting(
-      isWindows: true,
-      localAppData: '',
-      scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+    final config = File('${temp.path}${Platform.pathSeparator}config.yaml');
+    await config.writeAsString('mixed-port: 7890\n');
+    final service = _InspectableLifecycleClashService(
+      systemProxyService: SystemProxyService.forTesting(
+        isWindows: false,
+        scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+      ),
     );
-    final service = ClashService(systemProxyService: proxy);
     addTearDown(() async {
       await service.flushLogs();
       service.dispose();
       if (await temp.exists()) await temp.delete(recursive: true);
     });
-    await service.init(
-      AppSettings(),
-      dataDir: temp.path,
-      skipCoreProbes: true,
+    await service.init(AppSettings(), dataDir: temp.path, skipCoreProbes: true);
+    service
+      ..setCorePath(_dartExecutable())
+      ..setPaths(configDir: temp.path, configPath: config.path);
+
+    expect(await service.runConfigValidation(), isFalse);
+    expect(service.lastStartError, allOf(isNotNull, contains('配置校验失败')));
+    await service.flushLogs();
+    final logs = await File(service.logPath).readAsString();
+    expect(logs, contains('配置校验 stderr'));
+    expect(logs, contains('退出码'));
+  });
+
+  test(
+    'core version probe converts launch failures into bounded diagnostics',
+    () async {
+      final temp = await Directory.systemTemp.createTemp(
+        'ssrvpn_windows_core_version_failure_',
+      );
+      final service = _InspectableLifecycleClashService(
+        systemProxyService: SystemProxyService.forTesting(
+          isWindows: false,
+          scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+        ),
+      );
+      addTearDown(() async {
+        await service.flushLogs();
+        service.dispose();
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      await service.init(
+        AppSettings(),
+        dataDir: temp.path,
+        skipCoreProbes: true,
+      );
+      service.setCorePath(
+        '${temp.path}${Platform.pathSeparator}missing-mihomo.exe',
+      );
+
+      await service.probeCoreVersion();
+
+      await service.flushLogs();
+      final logs = await File(service.logPath).readAsString();
+      expect(logs, contains('核心无法执行'));
+    },
+  );
+
+  test(
+    'packaged core passes config validation and version probing',
+    () async {
+      final temp = await Directory.systemTemp.createTemp(
+        'ssrvpn_windows_packaged_core_probe_',
+      );
+      final config = File('${temp.path}${Platform.pathSeparator}config.yaml');
+      await config.writeAsString('mixed-port: 17890\n');
+      final service = _InspectableLifecycleClashService(
+        systemProxyService: SystemProxyService.forTesting(
+          isWindows: false,
+          scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+        ),
+      );
+      addTearDown(() async {
+        await service.flushLogs();
+        service.dispose();
+        if (await temp.exists()) await temp.delete(recursive: true);
+      });
+      await service.init(
+        AppSettings(),
+        dataDir: temp.path,
+        skipCoreProbes: true,
+      );
+      service
+        ..setCorePath(await _preparePackagedCore(temp))
+        ..setPaths(configDir: temp.path, configPath: config.path);
+
+      expect(await service.runConfigValidation(), isTrue);
+      expect(service.lastStartError, isNull);
+      await service.probeCoreVersion();
+
+      await service.flushLogs();
+      final logs = await File(service.logPath).readAsString();
+      expect(logs, contains('配置校验通过'));
+      expect(logs, contains('核心版本:'));
+    },
+    skip: !Platform.isMacOS && !Platform.isWindows,
+  );
+
+  test('non-zero version command is recorded without becoming a start error',
+      () async {
+    final temp = await Directory.systemTemp.createTemp(
+      'ssrvpn_windows_core_version_nonzero_',
+    );
+    final service = _InspectableLifecycleClashService(
+      systemProxyService: SystemProxyService.forTesting(
+        isWindows: false,
+        scriptRunner: (_) async => ProcessResult(0, 0, '', ''),
+      ),
+    );
+    addTearDown(() async {
+      await service.flushLogs();
+      service.dispose();
+      if (await temp.exists()) await temp.delete(recursive: true);
+    });
+    await service.init(AppSettings(), dataDir: temp.path, skipCoreProbes: true);
+    service.setCorePath(
+      Platform.isWindows
+          ? '${Platform.environment['WINDIR'] ?? r'C:\Windows'}'
+              r'\System32\where.exe'
+          : '/usr/bin/false',
     );
 
-    expect(service.hasPendingSystemProxyRecovery, isTrue);
-    expect(await service.recoverPendingSystemProxy(), isFalse);
-    expect(service.lastStartError, contains('尚未初始化'));
-    expect(service.hasPendingSystemProxyRecovery, isTrue);
+    await service.probeCoreVersion();
+
+    expect(service.lastStartError, isNull);
+    await service.flushLogs();
+    final logs = await File(service.logPath).readAsString();
+    expect(logs, allOf(contains('核心版本检查失败'), contains('退出码')));
   });
 }
 
 class _InspectableHealthTimeoutClashService extends ClashService {
   Duration get exposedHealthCheckTimeout => healthCheckTimeout;
+}
+
+class _InspectablePeriodicHealthClashService extends ClashService {
+  void publishPeriodicHealth(bool healthy) =>
+      onPeriodicHealthCheckResult(healthy);
+}
+
+class _InspectableLifecycleClashService extends ClashService {
+  _InspectableLifecycleClashService({required super.systemProxyService});
+
+  Future<void> persistCorePid(WindowsCorePidRecord record) =>
+      writeCorePid(record);
+
+  Future<bool> removeCorePid(WindowsCorePidRecord record) =>
+      deleteCorePid(expectedRecord: record);
+
+  Future<bool> runConfigValidation() => validateConfig(const {});
+
+  Future<void> probeCoreVersion() => logCoreVersion();
+}
+
+String _dartExecutable() {
+  if (File(
+    Platform.resolvedExecutable,
+  ).uri.pathSegments.last.startsWith('dart')) {
+    return Platform.resolvedExecutable;
+  }
+  final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+  if (flutterRoot != null) {
+    final candidate = '$flutterRoot${Platform.pathSeparator}bin'
+        '${Platform.pathSeparator}cache${Platform.pathSeparator}dart-sdk'
+        '${Platform.pathSeparator}bin${Platform.pathSeparator}dart'
+        '${Platform.isWindows ? '.exe' : ''}';
+    if (File(candidate).existsSync()) return candidate;
+  }
+  var directory = File(Platform.resolvedExecutable).parent;
+  for (var depth = 0; depth < 8; depth++) {
+    final candidate = '${directory.path}${Platform.pathSeparator}dart-sdk'
+        '${Platform.pathSeparator}bin${Platform.pathSeparator}dart'
+        '${Platform.isWindows ? '.exe' : ''}';
+    if (File(candidate).existsSync()) return candidate;
+    directory = directory.parent;
+  }
+  throw StateError('Dart executable is unavailable to the lifecycle test');
+}
+
+Future<String> _preparePackagedCore(Directory temp) async {
+  final roots = <Directory>[Directory.current, Directory.current.parent];
+  if (Platform.isWindows) {
+    for (final root in roots) {
+      for (final relative in <String>[
+        'SSRVPN_Windows${Platform.pathSeparator}assets'
+            '${Platform.pathSeparator}mihomo.exe',
+        'assets${Platform.pathSeparator}mihomo.exe',
+      ]) {
+        final candidate = File(
+          '${root.path}${Platform.pathSeparator}$relative',
+        );
+        if (await candidate.exists()) return candidate.path;
+      }
+    }
+  } else if (Platform.isMacOS) {
+    for (final root in roots) {
+      final archive = File(
+        '${root.path}${Platform.pathSeparator}SSRVPN_MacOS'
+        '${Platform.pathSeparator}assets${Platform.pathSeparator}AtlasCore.gz',
+      );
+      if (!await archive.exists()) continue;
+      final executable = File(
+        '${temp.path}${Platform.pathSeparator}AtlasCore',
+      );
+      await executable.writeAsBytes(gzip.decode(await archive.readAsBytes()));
+      final chmod = await Process.run('chmod', ['700', executable.path]);
+      if (chmod.exitCode != 0) {
+        throw StateError('Cannot make packaged macOS core executable');
+      }
+      return executable.path;
+    }
+  }
+  throw StateError('Packaged core asset is unavailable to lifecycle tests');
 }

--- a/SSRVPN_Windows/test/tun_runtime_health_test.dart
+++ b/SSRVPN_Windows/test/tun_runtime_health_test.dart
@@ -310,6 +310,22 @@ void main() {
     expect(service.connectionDesired, isTrue);
   });
 
+  test('data-plane observation is throttled within one route session',
+      () async {
+    final service = _AdvisoryTunDataPlaneClashService()
+      ..observationInterval = const Duration(hours: 1)
+      ..updateSettings(AppSettings(enableTun: true))
+      ..requestConnectionIntent(true)
+      ..setRunning(true);
+    addTearDown(service.dispose);
+
+    await service.runDataPlaneObservation();
+    await service.runDataPlaneObservation();
+
+    expect(service.probeCalls, 1);
+    expect(service.shouldContinueResult, isTrue);
+  });
+
   test('a route change starts one fresh probe and rejects the old result',
       () async {
     final service = _ControllableDataPlaneClashService()
@@ -341,6 +357,8 @@ class _AdvisoryTunDataPlaneClashService extends ClashService {
   String? nextWarning = 'external endpoint blocked';
   int probeCalls = 0;
   bool recoveryListenerActive = false;
+  bool? shouldContinueResult;
+  Duration observationInterval = Duration.zero;
 
   @override
   bool get proxyRecoveryListenerActive => recoveryListenerActive;
@@ -350,7 +368,7 @@ class _AdvisoryTunDataPlaneClashService extends ClashService {
   void beginNewDataPlaneSession() => resetTunDataPlaneObservationSession();
 
   @override
-  Duration get tunDataPlaneObservationInterval => Duration.zero;
+  Duration get tunDataPlaneObservationInterval => observationInterval;
 
   @override
   Future<String?> verifyUserConnectivity({
@@ -360,6 +378,7 @@ class _AdvisoryTunDataPlaneClashService extends ClashService {
     bool Function()? shouldContinue,
   }) async {
     probeCalls++;
+    shouldContinueResult = shouldContinue?.call();
     return nextWarning;
   }
 }

--- a/SSRVPN_Windows/test/unexpected_core_exit_recovery_test.dart
+++ b/SSRVPN_Windows/test/unexpected_core_exit_recovery_test.dart
@@ -243,6 +243,19 @@ void main() {
     expect(service.proxyOwnershipInspectionCalls, 0);
   });
 
+  test('a successful recovery health recheck restores the running state',
+      () async {
+    final service = _HealthyHealthRecoveryClashService();
+    addTearDown(service.dispose);
+    final generation = service.requestConnectionIntent(true);
+    service.setRunning(false);
+
+    expect(await service.recoverAfterHealthCheckFailure(generation), isTrue);
+    expect(service.isRunning, isTrue);
+    expect(service.connectionDesired, isTrue);
+    expect(service.stopCalls, 0);
+  });
+
   test(
       'unexpected core exit clears external takeover state without restarting or reacquiring',
       () async {
@@ -627,6 +640,79 @@ void main() {
     expect(service.automaticRecoveryStartCalls, 0);
     expect(notices, isEmpty);
   });
+
+  test('current TUN teardown timeout cancels recovery with an actionable error',
+      () async {
+    final notices = <RuntimeNotice>[];
+    final service = _SerializedUnexpectedExitRecoveryClashService()
+      ..onRuntimeNotice = notices.add;
+    addTearDown(service.dispose);
+    final generation = service.requestConnectionIntent(true);
+    service.setRunning(false);
+
+    final recovery = service.simulateUnexpectedTunExit(generation);
+    await service.tunTeardownStarted.future;
+    service.tunTeardownResult.complete(false);
+    await recovery;
+
+    expect(service.connectionDesired, isFalse);
+    expect(service.automaticRecoveryStartCalls, 0);
+    expect(service.lastStartError, contains('TUN'));
+    expect(notices.single.message, contains('TUN'));
+  });
+
+  test('a third unexpected exit exhausts the bounded automatic recovery budget',
+      () async {
+    final notices = <RuntimeNotice>[];
+    final service = _SerializedUnexpectedExitRecoveryClashService()
+      ..onRuntimeNotice = notices.add;
+    addTearDown(service.dispose);
+    service.rememberDesktopConnectionRecoveryPlan(
+      preferredSettings: AppSettings(),
+      generateConfig: (runtimeSettings, preferredNodeName) async =>
+          'mixed-port: ${runtimeSettings.proxyPort}',
+      isRevisionCurrent: () => true,
+    );
+    final generation = service.requestConnectionIntent(true);
+    service.setRunning(false);
+
+    await service.simulateUnexpectedExit(generation);
+    service.setRunning(false);
+    await service.simulateUnexpectedExit(generation);
+    service.setRunning(false);
+    await service.simulateUnexpectedExit(generation);
+
+    expect(service.automaticRecoveryStartCalls, 2);
+    expect(service.connectionDesired, isFalse);
+    expect(
+      notices.last.message,
+      allOf(contains('再次异常退出'), contains('请重新连接')),
+    );
+  });
+
+  test('automatic restart failure clears connection intent and reports it',
+      () async {
+    final notices = <RuntimeNotice>[];
+    final service = _FailedAutomaticRecoveryClashService()
+      ..onRuntimeNotice = notices.add;
+    addTearDown(service.dispose);
+    service.rememberDesktopConnectionRecoveryPlan(
+      preferredSettings: AppSettings(),
+      generateConfig: (runtimeSettings, preferredNodeName) async =>
+          'mixed-port: ${runtimeSettings.proxyPort}',
+      isRevisionCurrent: () => true,
+    );
+    final generation = service.requestConnectionIntent(true);
+    service.setRunning(false);
+
+    await service.simulateUnexpectedExit(generation);
+
+    expect(service.automaticRecoveryStartCalls, 1);
+    expect(service.connectionDesired, isFalse);
+    expect(service.isRunning, isFalse);
+    expect(service.lastStartError, contains('拒绝启动'));
+    expect(notices.single.message, contains('正在自动恢复'));
+  });
 }
 
 class _ExternalProxyTakeoverRecoveryClashService extends ClashService {
@@ -732,6 +818,19 @@ class _StaleHealthProbeRecoveryClashService
   }
 }
 
+class _HealthyHealthRecoveryClashService extends ClashService {
+  int stopCalls = 0;
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+    setRunning(false);
+  }
+}
+
 class _ProxyChangedDuringCleanupRecoveryClashService
     extends _ExternalProxyTakeoverRecoveryClashService {
   @override
@@ -827,5 +926,15 @@ class _SerializedUnexpectedExitRecoveryClashService extends ClashService {
     automaticRecoveryStartCalls++;
     setRunning(true);
     return true;
+  }
+}
+
+class _FailedAutomaticRecoveryClashService
+    extends _SerializedUnexpectedExitRecoveryClashService {
+  @override
+  Future<bool> startForAutomaticRecovery() async {
+    automaticRecoveryStartCalls++;
+    setLastStartError('测试核心拒绝启动');
+    return false;
   }
 }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -10,6 +10,11 @@
 make verify
 ```
 
+项目精确固定 `.fvmrc` 中的 Flutter `3.44.1`。统一入口会在任何依赖解析和测试之前校验版本；
+本地可执行 `fvm install && fvm exec make verify` 或
+`mise exec flutter@3.44.1 -- make verify`。完整入口会自动引导并校验核心资产，离线测试前可先运行
+`make assets` 预取资源。
+
 当前门禁依次验证：
 
 - 全部受版本控制 Dart 源码格式、Shell 脚本 ShellCheck、共享包导入、版本同步、安装包内指南和当前文档一致性。
@@ -46,7 +51,7 @@ make verify
 
 | 关键文件 | 最低行覆盖率 | 当前锁定证据 |
 | --- | ---: | ---: |
-| Windows `clash_service_lifecycle.dart` | 25.00% | `174/655`（26.56%） |
+| Windows `clash_service_lifecycle.dart` | 50.00% | `350/700`（50.00%） |
 | macOS `clash_service_lifecycle.dart` | 60.00% | `308/485`（63.51%） |
 | macOS `system_proxy_service.dart` | 80.00% | `220/258`（85.27%） |
 
@@ -61,7 +66,7 @@ ABA、代理事务令牌延迟 Cmd+Q、严格快照 schema、保留键冲突、�
 
 覆盖率执行由 `scripts/run-flutter-coverage.sh` 统一配置。每个平台的 manifest 测试会加载所有可
 独立导入的生产库；门禁再把平台库通过真实 `part` 指令拥有的片段加入同一清单。macOS/Windows
-的 16 个 `packages/ssrvpn_shared/lib/desktop_ui` 片段因此分别计入消费平台的分母，普通 shared
+的 12 个 `packages/ssrvpn_shared/lib/desktop_ui` 片段因此分别计入消费平台的分母，普通 shared
 依赖不会抬高平台分子或分母。生产源码缺失于 LCOV、伪造或越界 `SF`、路径穿越/别名、非法
 UTF-8、注释或字符串伪装的 `part` 指令都会使门禁失败。只有明确的生成代码、纯声明文件和由
 另一目标实际拥有的片段可以按可审计分类排除。

--- a/packages/ssrvpn_shared/lib/services/subscription_fetch_policy.dart
+++ b/packages/ssrvpn_shared/lib/services/subscription_fetch_policy.dart
@@ -102,7 +102,51 @@ class SubscriptionFetchPolicy {
       if (_isIpv4Mapped(bytes)) {
         return !_isNonPublicIpv4(bytes.sublist(12));
       }
-      return (bytes[0] & 0xfe) != 0xfc;
+      // RFC 6052's well-known NAT64 prefix carries the destination IPv4
+      // address in the final 32 bits. Validate that embedded address instead
+      // of treating the translation address as an unrelated public IPv6.
+      if (_hasIpv6Prefix(
+          bytes,
+          const [
+            0x00,
+            0x64,
+            0xff,
+            0x9b,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+          ],
+          96)) {
+        return !_isNonPublicIpv4(bytes.sublist(12));
+      }
+
+      // Domain answers are fail-closed to globally routable unicast space.
+      // This excludes ULA, link-local-adjacent special-use ranges, local-use
+      // translation prefixes (including 64:ff9b:1::/48), and documentation
+      // ranges without relying on an ever-growing denylist alone.
+      if (!_hasIpv6Prefix(bytes, const [0x20], 3)) return false;
+      return !_hasIpv6Prefix(bytes, const [0x20, 0x01, 0x00, 0x00], 32) &&
+          !_hasIpv6Prefix(
+              bytes,
+              const [
+                0x20,
+                0x01,
+                0x00,
+                0x02,
+                0x00,
+                0x00,
+              ],
+              48) &&
+          !_hasIpv6Prefix(bytes, const [0x20, 0x01, 0x00, 0x10], 28) &&
+          !_hasIpv6Prefix(bytes, const [0x20, 0x01, 0x00, 0x20], 28) &&
+          !_hasIpv6Prefix(bytes, const [0x20, 0x01, 0x0d, 0xb8], 32) &&
+          !_hasIpv6Prefix(bytes, const [0x20, 0x02], 16) &&
+          !_hasIpv6Prefix(bytes, const [0x3f, 0xff, 0x00], 20);
     }
     return false;
   }
@@ -110,14 +154,20 @@ class SubscriptionFetchPolicy {
   static bool _isNonPublicIpv4(List<int> bytes) {
     final first = bytes[0];
     final second = bytes[1];
+    final third = bytes[2];
     return first == 0 ||
         first == 10 ||
         first == 127 ||
         (first == 100 && second >= 64 && second <= 127) ||
         (first == 169 && second == 254) ||
         (first == 172 && second >= 16 && second <= 31) ||
+        (first == 192 && second == 0 && third == 0) ||
+        (first == 192 && second == 0 && third == 2) ||
         (first == 192 && second == 168) ||
+        (first == 192 && second == 88 && third == 99) ||
         (first == 198 && (second == 18 || second == 19)) ||
+        (first == 198 && second == 51 && third == 100) ||
+        (first == 203 && second == 0 && third == 113) ||
         first >= 224;
   }
 
@@ -141,6 +191,21 @@ class SubscriptionFetchPolicy {
       if (bytes[i] != 0) return false;
     }
     return true;
+  }
+
+  static bool _hasIpv6Prefix(
+    List<int> bytes,
+    List<int> prefix,
+    int prefixLength,
+  ) {
+    final wholeBytes = prefixLength ~/ 8;
+    for (var i = 0; i < wholeBytes; i++) {
+      if (bytes[i] != prefix[i]) return false;
+    }
+    final remainingBits = prefixLength % 8;
+    if (remainingBits == 0) return true;
+    final mask = 0xff << (8 - remainingBits) & 0xff;
+    return (bytes[wholeBytes] & mask) == (prefix[wholeBytes] & mask);
   }
 }
 

--- a/packages/ssrvpn_shared/test/subscription_fetch_policy_test.dart
+++ b/packages/ssrvpn_shared/test/subscription_fetch_policy_test.dart
@@ -7,13 +7,10 @@ import 'package:test/test.dart';
 void main() {
   group('SubscriptionFetchPolicy', () {
     test('uses the real app UA before the single compatibility UA', () {
-      expect(
-        SubscriptionFetchPolicy.userAgents,
-        [
-          AppConstants.appUserAgent,
-          'clash-verge/v2.4.0 ${AppConstants.appUserAgent}',
-        ],
-      );
+      expect(SubscriptionFetchPolicy.userAgents, [
+        AppConstants.appUserAgent,
+        'clash-verge/v2.4.0 ${AppConstants.appUserAgent}',
+      ]);
     });
 
     test('only refusal statuses and unparseable success request compat UA', () {
@@ -49,70 +46,126 @@ void main() {
       );
     });
 
-    test('rejects non-public DNS answers for a hostname, including mixed sets',
-        () {
+    test(
+      'rejects non-public DNS answers for a hostname, including mixed sets',
+      () {
+        final uri = Uri.parse('https://subscription.example/feed');
+        for (final addresses in [
+          [InternetAddress.loopbackIPv4],
+          [InternetAddress('192.168.1.20')],
+          [InternetAddress('169.254.169.254')],
+          [InternetAddress('224.0.0.1')],
+          [InternetAddress('0.0.0.0')],
+          [InternetAddress('198.18.0.1')],
+          [InternetAddress('192.0.2.1')],
+          [InternetAddress('198.51.100.1')],
+          [InternetAddress('203.0.113.1')],
+          [InternetAddress('8.8.8.8'), InternetAddress('10.0.0.1')],
+          [InternetAddress('fc00::1')],
+          [InternetAddress('64:ff9b:1::1')],
+          [InternetAddress('100::1')],
+          [InternetAddress('2001:2::1')],
+          [InternetAddress('2001:db8::1')],
+          [InternetAddress('2002::1')],
+          [InternetAddress('3fff::1')],
+        ]) {
+          expect(
+            () => SubscriptionFetchPolicy.validateResolvedAddresses(
+              uri,
+              addresses,
+            ),
+            throwsA(isA<SubscriptionAddressException>()),
+          );
+        }
+      },
+    );
+
+    test('validates the IPv4 destination embedded by well-known NAT64', () {
       final uri = Uri.parse('https://subscription.example/feed');
-      for (final addresses in [
-        [InternetAddress.loopbackIPv4],
-        [InternetAddress('192.168.1.20')],
-        [InternetAddress('169.254.169.254')],
-        [InternetAddress('224.0.0.1')],
-        [InternetAddress('0.0.0.0')],
-        [InternetAddress('198.18.0.1')],
-        [InternetAddress('8.8.8.8'), InternetAddress('10.0.0.1')],
-        [InternetAddress('fc00::1')],
+      for (final address in [
+        '64:ff9b::7f00:1',
+        '64:ff9b::a9fe:a9fe',
+        '64:ff9b::c0a8:101',
+        '64:ff9b::c612:1',
+        '64:ff9b::c000:201',
+        '64:ff9b::cb00:7101',
       ]) {
         expect(
-          () => SubscriptionFetchPolicy.validateResolvedAddresses(
-            uri,
-            addresses,
-          ),
+          () => SubscriptionFetchPolicy.validateResolvedAddresses(uri, [
+            InternetAddress(address),
+          ]),
           throwsA(isA<SubscriptionAddressException>()),
+          reason: address,
         );
       }
+
+      expect(
+        SubscriptionFetchPolicy.validateResolvedAddresses(uri, [
+          InternetAddress('64:ff9b::808:808'),
+        ]),
+        hasLength(1),
+      );
+    });
+
+    test('allows ordinary globally routable IPv6 domain answers', () {
+      final addresses = [
+        InternetAddress('2001:4860:4860::8888'),
+        InternetAddress('2606:4700:4700::1111'),
+      ];
+
+      expect(
+        SubscriptionFetchPolicy.validateResolvedAddresses(
+          Uri.parse('https://subscription.example/feed'),
+          addresses,
+        ),
+        addresses,
+      );
     });
 
     test(
-        'allows explicit LAN and loopback literals but rejects unsafe literals',
-        () {
-      expect(
-        SubscriptionFetchPolicy.validateResolvedAddresses(
-          Uri.parse('http://192.168.1.20/feed'),
-          [InternetAddress('192.168.1.20')],
-        ),
-        hasLength(1),
-      );
-      expect(
-        SubscriptionFetchPolicy.validateResolvedAddresses(
-          Uri.parse('http://127.0.0.1/feed'),
-          [InternetAddress.loopbackIPv4],
-        ),
-        hasLength(1),
-      );
-      for (final value in ['0.0.0.0', '169.254.169.254', '224.0.0.1']) {
+      'allows explicit LAN and loopback literals but rejects unsafe literals',
+      () {
         expect(
-          () => SubscriptionFetchPolicy.validateResolvedAddresses(
-            Uri.parse('http://$value/feed'),
-            [InternetAddress(value)],
+          SubscriptionFetchPolicy.validateResolvedAddresses(
+            Uri.parse('http://192.168.1.20/feed'),
+            [InternetAddress('192.168.1.20')],
           ),
-          throwsA(isA<SubscriptionAddressException>()),
+          hasLength(1),
         );
-      }
-    });
+        expect(
+          SubscriptionFetchPolicy.validateResolvedAddresses(
+            Uri.parse('http://127.0.0.1/feed'),
+            [InternetAddress.loopbackIPv4],
+          ),
+          hasLength(1),
+        );
+        for (final value in ['0.0.0.0', '169.254.169.254', '224.0.0.1']) {
+          expect(
+            () => SubscriptionFetchPolicy.validateResolvedAddresses(
+              Uri.parse('http://$value/feed'),
+              [InternetAddress(value)],
+            ),
+            throwsA(isA<SubscriptionAddressException>()),
+          );
+        }
+      },
+    );
 
-    test('recognition returns parseable YAML and rejects refusal documents',
-        () {
-      expect(
-        SubscriptionFetchPolicy.normalizeRecognizedBody(_validYaml),
-        contains('Valid Node'),
-      );
-      expect(
-        () => SubscriptionFetchPolicy.normalizeRecognizedBody(
-          '{"error":"forbidden"}',
-        ),
-        throwsA(isA<SubscriptionContentException>()),
-      );
-    });
+    test(
+      'recognition returns parseable YAML and rejects refusal documents',
+      () {
+        expect(
+          SubscriptionFetchPolicy.normalizeRecognizedBody(_validYaml),
+          contains('Valid Node'),
+        );
+        expect(
+          () => SubscriptionFetchPolicy.normalizeRecognizedBody(
+            '{"error":"forbidden"}',
+          ),
+          throwsA(isA<SubscriptionContentException>()),
+        );
+      },
+    );
   });
 }
 

--- a/scripts/check-flutter-version.sh
+++ b/scripts/check-flutter-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FLUTTER_BIN="${SSRVPN_FLUTTER_BIN:-flutter}"
+
+expected="$(python3 - "$ROOT/.fvmrc" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("flutter")
+if not isinstance(value, str) or not value.strip():
+    raise SystemExit(".fvmrc does not contain a non-empty flutter version")
+print(value.strip())
+PY
+)"
+
+if ! machine="$("$FLUTTER_BIN" --version --machine 2>/dev/null)"; then
+  echo "Flutter toolchain check failed: cannot run '$FLUTTER_BIN --version --machine'." >&2
+  echo "Install Flutter $expected with FVM or mise, then retry." >&2
+  exit 1
+fi
+
+if ! actual="$(printf '%s' "$machine" | python3 -c '
+import json
+import sys
+
+value = json.load(sys.stdin).get("frameworkVersion")
+if not isinstance(value, str) or not value.strip():
+    raise SystemExit(1)
+print(value.strip())
+')"; then
+  echo "Flutter toolchain check failed: --version --machine returned invalid JSON." >&2
+  exit 1
+fi
+
+if [[ "$actual" != "$expected" ]]; then
+  echo "Flutter version mismatch: expected $expected from .fvmrc, got $actual." >&2
+  echo "Run 'fvm install && fvm exec make verify' or 'mise exec flutter@$expected -- make verify'." >&2
+  exit 1
+fi
+
+echo "Flutter toolchain version verified: $actual"

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -26,7 +26,7 @@ CRITICAL_FILE_THRESHOLDS = {
         "lib/services/system_proxy_service.dart": 80.0,
     },
     "SSRVPN_Windows": {
-        "lib/services/clash_service_lifecycle.dart": 25.0,
+        "lib/services/clash_service_lifecycle.dart": 50.0,
     },
 }
 

--- a/scripts/check_doc_consistency.py
+++ b/scripts/check_doc_consistency.py
@@ -238,6 +238,23 @@ def required_claims(relative_name: str, markdown: str) -> list[str]:
     return []
 
 
+def desktop_ui_count_claim(markdown: str, actual_count: int) -> list[str]:
+    match = re.search(
+        r"的[ \t]+(?P<count>\d+)[ \t]+个[ \t]+"
+        r"`packages/ssrvpn_shared/lib/desktop_ui`[ \t]+片段",
+        markdown,
+    )
+    if match is None:
+        return ["missing desktop_ui owned-part count"]
+    documented_count = int(match.group("count"))
+    if documented_count != actual_count:
+        return [
+            "stale desktop_ui owned-part count: "
+            f"documented {documented_count}, actual {actual_count}"
+        ]
+    return []
+
+
 def _is_external(target: str) -> bool:
     if target.startswith(("#", "//")):
         return True
@@ -283,6 +300,16 @@ def validate(root: Path, docs: list[str], *, links_only: bool = False) -> list[s
                 errors.append(f"{relative_name}: {finding}")
             for finding in required_claims(relative_name, markdown):
                 errors.append(f"{relative_name}: {finding}")
+            if relative_name == "docs/TESTING.md":
+                desktop_ui_parts = sum(
+                    1
+                    for path in (
+                        root / "packages" / "ssrvpn_shared" / "lib" / "desktop_ui"
+                    ).rglob("*.dart")
+                    if path.is_file()
+                )
+                for finding in desktop_ui_count_claim(markdown, desktop_ui_parts):
+                    errors.append(f"{relative_name}: {finding}")
     return sorted(set(errors))
 
 
@@ -330,6 +357,12 @@ def self_test() -> None:
     assert required_claims("README.md", "macOS 11 及以上")
     assert not required_claims("README.md", "macOS 仅支持 Apple M 系列芯片。")
     assert not required_claims("docs/OTHER.md", "macOS 11 及以上")
+    assert not desktop_ui_count_claim(
+        "的 12 个 `packages/ssrvpn_shared/lib/desktop_ui` 片段", 12
+    )
+    assert desktop_ui_count_claim(
+        "的 16 个 `packages/ssrvpn_shared/lib/desktop_ui` 片段", 12
+    )
 
 
 def main() -> int:

--- a/scripts/test-release-tooling.sh
+++ b/scripts/test-release-tooling.sh
@@ -19,6 +19,7 @@ python3 -m unittest \
   scripts/test_ci_docs_scope.py \
   scripts/test_classify_ci_scope.py \
   scripts/test_free_desktop_distribution.py \
+  scripts/test_flutter_version_preflight.py \
   scripts/test_geoip_workflow.py \
   scripts/test_generate_oss_release_manifest.py \
   scripts/test_generate_release_notes.py \

--- a/scripts/test_check_coverage_thresholds.py
+++ b/scripts/test_check_coverage_thresholds.py
@@ -956,7 +956,7 @@ class CheckCoverageThresholdsTests(unittest.TestCase):
         self.assertGreaterEqual(
             coverage.CRITICAL_FILE_THRESHOLDS["SSRVPN_Windows"]
             ["lib/services/clash_service_lifecycle.dart"],
-            4.19,
+            50.0,
         )
         self.assertGreaterEqual(
             coverage.CRITICAL_FILE_THRESHOLDS["SSRVPN_MacOS"]

--- a/scripts/test_flutter_version_preflight.py
+++ b/scripts/test_flutter_version_preflight.py
@@ -1,0 +1,90 @@
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECK = ROOT / "scripts" / "check-flutter-version.sh"
+EXPECTED = json.loads((ROOT / ".fvmrc").read_text(encoding="utf-8"))["flutter"]
+
+
+class FlutterVersionPreflightTest(unittest.TestCase):
+    def run_check(self, version: str, *, valid_json: bool = True) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            fake = Path(directory) / "flutter"
+            payload = json.dumps({"frameworkVersion": version}) if valid_json else "not-json"
+            fake.write_text(
+                "#!/usr/bin/env bash\n"
+                "if [[ \"${1:-}\" != --version || \"${2:-}\" != --machine ]]; then exit 9; fi\n"
+                f"printf '%s\\n' '{payload}'\n",
+                encoding="utf-8",
+            )
+            fake.chmod(0o755)
+            environment = os.environ.copy()
+            environment["SSRVPN_FLUTTER_BIN"] = str(fake)
+            return subprocess.run(
+                ["bash", str(CHECK)],
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_accepts_only_the_exact_fvm_version(self) -> None:
+        result = self.run_check(EXPECTED)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(f"version verified: {EXPECTED}", result.stdout)
+
+    def test_rejects_a_different_stable_version_with_remediation(self) -> None:
+        result = self.run_check("3.47.2")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"expected {EXPECTED}", result.stderr)
+        self.assertIn("got 3.47.2", result.stderr)
+        self.assertIn("fvm exec make verify", result.stderr)
+
+    def test_rejects_invalid_machine_output(self) -> None:
+        result = self.run_check(EXPECTED, valid_json=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid JSON", result.stderr)
+
+    def test_full_verification_checks_toolchain_before_every_other_step(self) -> None:
+        entrypoint = (ROOT / "scripts" / "verify-all.sh").read_text(
+            encoding="utf-8"
+        )
+        steps = [
+            line
+            for line in entrypoint.splitlines()
+            if line.startswith('run_step "')
+        ]
+
+        self.assertTrue(steps)
+        self.assertEqual(
+            steps[0],
+            'run_step "Flutter toolchain version" scripts/check-flutter-version.sh',
+        )
+        self.assertLess(
+            entrypoint.index("scripts/check-flutter-version.sh"),
+            entrypoint.index("flutter pub get --enforce-lockfile"),
+        )
+
+    def test_ci_and_release_use_the_same_exact_fvm_version(self) -> None:
+        for relative in (
+            ".github/workflows/ci.yml",
+            ".github/workflows/release.yml",
+        ):
+            workflow = (ROOT / relative).read_text(encoding="utf-8")
+            match = re.search(r"^  FLUTTER_VERSION: '([^']+)'$", workflow, re.MULTILINE)
+            self.assertIsNotNone(match, relative)
+            self.assertEqual(match.group(1), EXPECTED, relative)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_windows_installer_config.py
+++ b/scripts/test_windows_installer_config.py
@@ -2539,7 +2539,7 @@ class WindowsInstallerConfigTest(unittest.TestCase):
         capture = lifecycle.index(
             "capture: _captureCorePidRecord", establish
         )
-        persist = lifecycle.index("persist: _writeCorePid", establish)
+        persist = lifecycle.index("persist: writeCorePid", establish)
         current = lifecycle.index(
             "ensureStartCurrent: () => _ensureStartCurrent(startToken)",
             establish,

--- a/scripts/test_windows_proxy_shutdown_recovery.py
+++ b/scripts/test_windows_proxy_shutdown_recovery.py
@@ -444,7 +444,7 @@ class WindowsProxyShutdownRecoveryTest(unittest.TestCase):
         ]
         missing_identity = stop.index("if (expectedPidRecord == null)")
         core_exit = stop.index("await _terminateVerifiedCore(expectedPidRecord)")
-        pid_cleanup = stop.index("await _deleteCorePid(", core_exit)
+        pid_cleanup = stop.index("await deleteCorePid(", core_exit)
         expected_identity = stop.index(
             "expectedRecord: expectedPidRecord", pid_cleanup
         )

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -18,6 +18,7 @@ run_in() {
   (cd "$dir" && "$@")
 }
 
+run_step "Flutter toolchain version" scripts/check-flutter-version.sh
 run_step "Shared barrel imports" scripts/check-shared-barrel-imports.sh
 run_step "Version sync" scripts/check-version-sync.sh
 run_step "Package guides" scripts/check-package-guides.sh


### PR DESCRIPTION
## Summary

- Harden subscription destination validation for IPv6 special-use ranges and NAT64-embedded non-public IPv4 addresses.
- Expand Windows lifecycle, PID identity, validation, recovery, and TUN health behavior coverage; raise the lifecycle coverage floor to 50%.
- Enforce Flutter 3.44.1 before workspace setup and keep README/testing/CI/release toolchain documentation consistent.

## Scope

- [x] Shared package
- [x] Android
- [x] macOS
- [x] Windows
- [x] CI/release/docs

## Verification

- [x] `scripts/check-quality-hygiene.sh`
- [x] `scripts/check-shared-barrel-imports.sh`
- [x] `scripts/workspace.sh analyze`
- [x] Shared, Android, macOS, and Windows Flutter test and coverage commands
- [x] Android Gradle unit tests and macOS XCTest
- [ ] `make verify` before merge, or the PR explains why a target-platform gate must run in CI

The full verification script passed through release tooling and workspace analysis, then a transient Maven Central TLS handshake interrupted the first Android native dependency download. The Android native test passed after retrying, and all remaining Android, macOS, and Windows test/coverage steps were run individually. Windows-only native and installer gates require the GitHub Windows runner.

Coverage evidence:

- Shared: 85.08% (6288/7391), threshold 65%
- Android: 67.84% (2346/3458), threshold 30%
- macOS: 67.38% (3474/5156), threshold 30%
- Windows: 54.81% (3269/5964), threshold 30%
- Windows lifecycle: 50.00% (350/700), floor 50%

## Security and compatibility

- [x] No secrets, private subscription data, generated artifacts, or untrusted input are logged or committed.
- [x] HTTP subscription compatibility, the tested Android domestic-app bypass policy, IPv4-only routing, and the two-page product surface remain unchanged unless this PR explicitly replaces a documented decision.
- [x] Native lifecycle, system proxy, TUN, installer, or release changes include target-platform evidence.

Explicit policy change: domain-resolved IPv6 destinations now fail closed outside global unicast and for documented special-use ranges. Explicit local/loopback IP literals remain supported for compatibility.

## Release Notes

- Strengthen subscription URL address validation and Windows core lifecycle recovery coverage.
- Require the repository-pinned Flutter 3.44.1 toolchain for full verification.

## Risk

- Domain subscriptions resolving only to special-use IPv6 addresses are now rejected by design.
- The Windows lifecycle coverage floor is exactly 50%, so future lifecycle changes must add or preserve corresponding tests.
- Windows-native behavior still depends on required CI checks before merge.