### PR TITLE
fix(android): allow bounded TUN teardown grace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 修复
 
-- Android 停止 VPN 时继续要求 Bridge 与原始 TUN 描述符完成关闭，但只把仍处于活动状态的自有 TUN 接口视为未释放；Android 11 短暂保留的非活动接口名称不再误触发 fail-closed 进程终止，未知基线、活动接口或描述符仍存在时仍会安全失败。
+- Android 停止 VPN 时继续要求 Bridge 与原始 TUN 描述符完成关闭，只把仍处于活动状态的自有 TUN 接口视为未释放，并为 Android 11 的异步接口回收保留最多约 6 秒的有界等待；未知基线、活动接口或描述符仍存在时仍会安全失败。
 - Windows 在安装事务成功后、原用户启动通道仍可用时立即启动可信更新包清理助手；助手绑定当前安装器进程并等待其实际退出，再复用原有 sidecar、SHA-256、NTFS owner stream、普通文件与路径身份校验删除应用内更新包。手动包、失败包和身份不匹配文件继续保留。
 
 ### 验收

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeRuntimeDiagnostics.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeRuntimeDiagnostics.kt
@@ -167,7 +167,8 @@ internal class NativeRuntimeDiagnosticsTracker {
 }
 
 internal object TunReleaseVerifier {
-    private const val DEFAULT_ATTEMPTS = 21
+    // Android 11 can keep a closed TUN visible for more than two seconds.
+    private const val DEFAULT_ATTEMPTS = 61
     private const val DEFAULT_RETRY_DELAY_MILLIS = 100L
 
     fun waitUntilReleased(

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeRuntimeDiagnosticsTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeRuntimeDiagnosticsTest.kt
@@ -198,6 +198,21 @@ class NativeRuntimeDiagnosticsTest {
     }
 
     @Test
+    fun `default release grace covers delayed Android 11 TUN teardown`() {
+        var probes = 0
+
+        val released = TunReleaseVerifier.waitUntilReleased(
+            retryDelayMillis = 0
+        ) {
+            probes += 1
+            probes == 61
+        }
+
+        assertTrue(released)
+        assertEquals(61, probes)
+    }
+
+    @Test
     fun `failed bridge stop still closes the retained VPN lease`() {
         var closeCount = 0
         var verifierCalled = false


### PR DESCRIPTION
## 背景

PR #169 的正式候选 APK 在 Redmi Note 8 / Android 11 真机复测时，正常断开仍出现 fail-closed SIGKILL。日志证明 Bridge 已停止，但 Android 11 在现有约 2.1 秒窗口结束后仍把已关闭的 TUN 接口报告为 UP。

## 修改

- 保留 Bridge、TUN 描述符和活动接口三重 fail-closed 校验。
- 仅把 TUN 接口异步回收的有界等待从 21 次延长为 61 次（100 ms 间隔，最多约 6 秒）。
- 增加第 61 次探测才释放的单元测试，并更新 Unreleased 变更说明。

## 验证

- `git diff --check`
- `bash scripts/check-android-native-bridge-guards.sh`（13/13）
- `mise exec flutter@3.44.1 -- bash scripts/test-android-native.sh`（BUILD SUCCESSFUL）
- `mise exec flutter@3.44.1 -- make verify`（全部完成，退出码 0）

## 放行边界

本 PR 不直接关闭问题。合并后必须使用正式候选 APK，在同一台 Android 11 真机完成 20/20 连接/断开、快速取消和快速设置磁贴回归；若仍触发进程终止，则停止发版并继续修复。

Refs #167