### PR TITLE
test(windows): wait deterministically for update dialogs

### DIFF
--- a/SSRVPN_Windows/test/update_dialog_accessibility_test.dart
+++ b/SSRVPN_Windows/test/update_dialog_accessibility_test.dart
@@ -62,14 +62,7 @@ void main() {
       },
     );
     final completionTitle = find.text('下载完成');
-    for (var attempt = 0;
-        attempt < 100 && completionTitle.evaluate().isEmpty;
-        attempt++) {
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 10)),
-      );
-      await tester.pump(const Duration(milliseconds: 20));
-    }
+    await _pumpUntilFound(tester, completionTitle);
 
     expect(completionTitle, findsOneWidget);
     expect(find.textContaining(desktop.path), findsOneWidget);
@@ -86,4 +79,14 @@ void main() {
     await tester.pumpAndSettle();
     await task;
   });
+}
+
+Future<void> _pumpUntilFound(WidgetTester tester, Finder finder) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 10));
+  while (finder.evaluate().isEmpty && DateTime.now().isBefore(deadline)) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 10)),
+    );
+    await tester.pump(const Duration(milliseconds: 20));
+  }
 }

--- a/SSRVPN_Windows/test/update_service_dialog_test.dart
+++ b/SSRVPN_Windows/test/update_service_dialog_test.dart
@@ -741,57 +741,24 @@ void main() {
     expect(find.text('立即更新'), findsNothing);
     await tester.tap(find.text('下载到桌面'));
     await tester.pump();
-    for (var attempt = 0; attempt < 100; attempt++) {
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 10)),
-      );
-      await tester.pump(const Duration(milliseconds: 20));
-      if (find
-          .text(
-            '下载并通过 SHA-256 校验后保存到桌面，不会自动启动；'
-            '仅带有效专属标记的应用内安装包会在安装成功后自动清理；'
-            '未带标记的已有文件会保留。',
-          )
-          .evaluate()
-          .isNotEmpty) {
-        break;
-      }
-    }
+    final progressDescription = find.text(
+      '下载并通过 SHA-256 校验后保存到桌面，不会自动启动；'
+      '仅带有效专属标记的应用内安装包会在安装成功后自动清理；'
+      '未带标记的已有文件会保留。',
+    );
+    await _pumpUntilFound(tester, progressDescription);
 
-    final showedDesktopProgress = find
-        .text(
-          '下载并通过 SHA-256 校验后保存到桌面，不会自动启动；'
-          '仅带有效专属标记的应用内安装包会在安装成功后自动清理；'
-          '未带标记的已有文件会保留。',
-        )
-        .evaluate()
-        .isNotEmpty;
+    final showedDesktopProgress = progressDescription.evaluate().isNotEmpty;
     final stalePartSurvivedUntilDownloadStarted = stalePart.existsSync();
 
     response.complete(http.Response.bytes(bytes, HttpStatus.ok));
-    for (var attempt = 0; attempt < 100; attempt++) {
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 10)),
-      );
-      await tester.pump(const Duration(milliseconds: 20));
-      if (find
-          .text(
-            '最新版安装包已下载到桌面并完成安全标记。请手动安装；'
-            '安装成功后会自动清理，取消或失败时保留。',
-          )
-          .evaluate()
-          .isNotEmpty) {
-        break;
-      }
-    }
+    final completionMessage = find.text(
+      '最新版安装包已下载到桌面并完成安全标记。请手动安装；'
+      '安装成功后会自动清理，取消或失败时保留。',
+    );
+    await _pumpUntilFound(tester, completionMessage);
 
-    final showedCompletion = find
-        .text(
-          '最新版安装包已下载到桌面并完成安全标记。请手动安装；'
-          '安装成功后会自动清理，取消或失败时保留。',
-        )
-        .evaluate()
-        .isNotEmpty;
+    final showedCompletion = completionMessage.evaluate().isNotEmpty;
 
     final installers = desktop
         .listSync()
@@ -892,13 +859,7 @@ void main() {
 
       const retainedMessage = '桌面已有通过 SHA-256 校验的同版本安装包。请手动安装；'
           '该文件未由本次下载认领，安装后会保留。';
-      for (var attempt = 0; attempt < 100; attempt++) {
-        await tester.runAsync(
-          () => Future<void>.delayed(const Duration(milliseconds: 10)),
-        );
-        await tester.pump(const Duration(milliseconds: 20));
-        if (find.text(retainedMessage).evaluate().isNotEmpty) break;
-      }
+      await _pumpUntilFound(tester, find.text(retainedMessage));
       expect(find.text(retainedMessage), findsOneWidget);
       expect(marker.existsSync(), isFalse);
       await tester.tap(find.text('知道了').last);
@@ -950,14 +911,7 @@ void main() {
         },
       );
 
-      for (var attempt = 0;
-          attempt < 100 && find.text('下载完成').evaluate().isEmpty;
-          attempt++) {
-        await tester.runAsync(
-          () => Future<void>.delayed(const Duration(milliseconds: 10)),
-        );
-        await tester.pump(const Duration(milliseconds: 20));
-      }
+      await _pumpUntilFound(tester, find.text('下载完成'));
 
       const expectedMessage = '安装包已下载到桌面并通过 SHA-256 校验，但安装后无法自动删除。'
           '请手动安装；安装完成后请自行删除桌面安装包。';
@@ -971,4 +925,14 @@ void main() {
       expect(showedExpectedMessage, isTrue);
     },
   );
+}
+
+Future<void> _pumpUntilFound(WidgetTester tester, Finder finder) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 10));
+  while (finder.evaluate().isEmpty && DateTime.now().isBefore(deadline)) {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 10)),
+    );
+    await tester.pump(const Duration(milliseconds: 20));
+  }
 }


### PR DESCRIPTION
## 背景

PR #170 首轮和合并后 `main` CI 分别在 Windows 更新弹窗测试中出现同类时序失败：文件发布已经完成，但固定 100 次短轮询先于弹窗动画/异步 I/O 结束，随后导致同文件的模态框测试级联失败。

## 修改

- 仅修改两份 Windows 更新弹窗测试。
- 将固定次数轮询替换为按可见条件等待，保留明确 10 秒上限。
- 不修改产品代码、下载流程、安装器、网络行为或发布产物。

## 本地验证

- `mise exec flutter@3.44.1 -- dart format ...`
- 两份目标测试：19 项通过
- `mise exec flutter@3.44.1 -- bash scripts/run-flutter-coverage.sh SSRVPN_Windows`：273 项通过，8 项条件跳过
- `mise exec flutter@3.44.1 -- bash scripts/check-coverage-thresholds.sh SSRVPN_Windows`：通过
- `git diff --check`：通过

合并后重新要求 `main` 全量 CI 通过，再继续候选构建与真机 UAT。