### PR TITLE
fix: close final TUN release verification gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 修复
 
-- Android 停止 VPN 时继续要求 Bridge 与原始 TUN 描述符完成关闭，只把仍处于活动状态的自有 TUN 接口视为未释放，并为 Android 11 的异步接口回收保留最多约 6 秒的有界等待；未知基线、活动接口或描述符仍存在时仍会安全失败。
+- Android 停止 VPN 时继续要求 Bridge 与自有 TUN 完成关闭，并为 Android 11 的异步接口回收保留最多约 6 秒的有界等待；描述符编号被内核复用时，会通过 `/proc/self/fdinfo` 区分仍绑定自有 TUN、已解除绑定和其他既有 TUN，避免把已释放连接误判为残留。未知基线、不可读证据、活动接口或仍绑定自有 TUN 的描述符继续安全失败。
 - Windows 在安装事务成功后、原用户启动通道仍可用时立即启动可信更新包清理助手；助手绑定当前安装器进程并等待其实际退出，再复用原有 sidecar、SHA-256、NTFS owner stream、普通文件与路径身份校验删除应用内更新包。手动包、失败包和身份不匹配文件继续保留。
 
 ### 验收

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeRuntimeDiagnostics.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeRuntimeDiagnostics.kt
@@ -3,6 +3,7 @@ package com.ssrvpn.android
 import android.system.Os
 import android.system.ErrnoException
 import android.system.OsConstants
+import java.io.File
 import java.net.NetworkInterface
 
 internal data class NativeRuntimeDiagnostics(
@@ -21,6 +22,17 @@ internal data class NativeRuntimeDiagnostics(
         "protectMonitorAlive" to protectMonitorAlive
     )
 }
+
+internal data class TunReleaseEvidence(
+    val ownedInterfaceActive: Boolean?,
+    val descriptorTargetsTun: Boolean?,
+    val descriptorAttachedToOwnedInterface: Boolean?
+)
+
+internal data class TunDescriptorInterface(
+    val readable: Boolean,
+    val name: String?
+)
 
 internal class NativeRuntimeDiagnosticsTracker {
     private data class TunOwnershipClaim(
@@ -59,7 +71,8 @@ internal class NativeRuntimeDiagnosticsTracker {
 
     fun releaseTunDescriptorIfClosed(
         tunInterfaces: () -> Set<String>? = ::activeTunInterfaceNames,
-        descriptorTarget: (Long) -> String? = ::descriptorTarget
+        descriptorTarget: (Long) -> String? = ::descriptorTarget,
+        descriptorInterface: (Long) -> TunDescriptorInterface = ::descriptorInterface
     ): Boolean {
         val claim = tunOwnershipClaim
         if (claim == null) {
@@ -72,14 +85,55 @@ internal class NativeRuntimeDiagnosticsTracker {
         if (ownedInterfaces.any(currentInterfaces::contains)) return false
         val target = descriptorTarget(claim.descriptor)
         if (target == UNKNOWN_DESCRIPTOR_TARGET ||
-            target == "/dev/tun" ||
-            target?.startsWith("/dev/tun") == true
+            target == "/dev/tun" || target?.startsWith("/dev/tun") == true
         ) {
-            return false
+            if (target == UNKNOWN_DESCRIPTOR_TARGET) return false
+            val currentDescriptorInterface = descriptorInterface(claim.descriptor)
+            if (!currentDescriptorInterface.readable) return false
+            val interfaceName = currentDescriptorInterface.name
+            if (interfaceName != null &&
+                descriptorBelongsToClaim(claim, interfaceName) != false
+            ) return false
         }
         if (tunOwnershipClaim !== claim) return false
         tunOwnershipClaim = null
         return true
+    }
+
+    fun tunReleaseEvidence(
+        tunInterfaces: () -> Set<String>? = ::activeTunInterfaceNames,
+        descriptorTarget: (Long) -> String? = ::descriptorTarget,
+        descriptorInterface: (Long) -> TunDescriptorInterface = ::descriptorInterface
+    ): TunReleaseEvidence {
+        val claim = tunOwnershipClaim
+            ?: return TunReleaseEvidence(false, false, false)
+        val currentInterfaces = tunInterfaces()
+        val ownedInterfaceActive = currentInterfaces?.let { current ->
+            resolveOwnedTunInterfaces(claim, current)?.any(current::contains)
+        }
+        val target = descriptorTarget(claim.descriptor)
+        val descriptorTargetsTun = when {
+            target == UNKNOWN_DESCRIPTOR_TARGET -> null
+            target == null -> false
+            else -> target == "/dev/tun" || target.startsWith("/dev/tun")
+        }
+        val descriptorAttachedToOwnedInterface = when (descriptorTargetsTun) {
+            null -> null
+            false -> false
+            true -> {
+                val currentDescriptorInterface = descriptorInterface(claim.descriptor)
+                if (!currentDescriptorInterface.readable) null else {
+                    currentDescriptorInterface.name?.let {
+                        descriptorBelongsToClaim(claim, it)
+                    } ?: false
+                }
+            }
+        }
+        return TunReleaseEvidence(
+            ownedInterfaceActive,
+            descriptorTargetsTun,
+            descriptorAttachedToOwnedInterface
+        )
     }
 
     fun snapshot(
@@ -118,6 +172,16 @@ internal class NativeRuntimeDiagnosticsTracker {
             tunOwnershipClaim = claim.copy(interfaceNames = resolvedInterfaces)
         }
         return resolvedInterfaces
+    }
+
+    private fun descriptorBelongsToClaim(
+        claim: TunOwnershipClaim,
+        interfaceName: String
+    ): Boolean? {
+        val knownInterfaces = claim.interfaceNames ?: return null
+        if (interfaceName in knownInterfaces) return true
+        val baselineInterfaces = claim.baselineInterfaceNames ?: return null
+        return interfaceName !in baselineInterfaces
     }
 
     private companion object {
@@ -162,6 +226,20 @@ internal class NativeRuntimeDiagnosticsTracker {
                 ) null else UNKNOWN_DESCRIPTOR_TARGET
             } catch (_: Exception) {
                 UNKNOWN_DESCRIPTOR_TARGET
+            }
+
+        fun descriptorInterface(descriptor: Long): TunDescriptorInterface =
+            try {
+                val interfaceName = File("/proc/self/fdinfo/$descriptor").useLines { lines ->
+                    lines.take(32)
+                        .firstOrNull { it.startsWith("iff:") }
+                        ?.substringAfter(':')
+                        ?.trim()
+                        ?.takeIf(String::isNotEmpty)
+                }
+                TunDescriptorInterface(readable = true, name = interfaceName)
+            } catch (_: Exception) {
+                TunDescriptorInterface(readable = false, name = null)
             }
     }
 }

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/SsrvpnVpnService.kt
@@ -871,7 +871,8 @@ class SsrvpnVpnService : VpnService() {
             isReleased = runtimeDiagnostics::releaseTunDescriptorIfClosed
         )
         if (bridgeStopped && !tunReleased)
-            Log.e(TAG, "Bridge stopped but the owned TUN lease is still present")
+            Log.e(TAG, "Bridge stopped but the owned TUN lease is still present " +
+                runtimeDiagnostics.tunReleaseEvidence())
         val protectMonitorStopped = waitForProtectMonitor(activeProtectMonitor?.thread)
         val stopDecision = CoreStopDecision.afterBridgeCheck(
             pendingStartStopped,

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeRuntimeDiagnosticsTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeRuntimeDiagnosticsTest.kt
@@ -96,7 +96,10 @@ class NativeRuntimeDiagnosticsTest {
         assertFalse(
             tracker.releaseTunDescriptorIfClosed(
                 tunInterfaces = { emptySet() },
-                descriptorTarget = { "/dev/tun" }
+                descriptorTarget = { "/dev/tun" },
+                descriptorInterface = {
+                    TunDescriptorInterface(readable = true, name = "tun0")
+                }
             )
         )
         assertTrue(
@@ -157,6 +160,70 @@ class NativeRuntimeDiagnosticsTest {
             tracker.releaseTunDescriptorIfClosed(
                 tunInterfaces = { emptySet() },
                 descriptorTarget = { null }
+            )
+        )
+    }
+
+    @Test
+    fun `unbound reused TUN descriptor does not retain the old lease`() {
+        tracker.beginTunLease { emptySet() }
+        tracker.claimTunDescriptor(42) { setOf("tun0") }
+
+        assertTrue(
+            tracker.releaseTunDescriptorIfClosed(
+                tunInterfaces = { emptySet() },
+                descriptorTarget = { "/dev/tun" },
+                descriptorInterface = {
+                    TunDescriptorInterface(readable = true, name = null)
+                }
+            )
+        )
+    }
+
+    @Test
+    fun `descriptor still attached to the owned TUN remains fail closed`() {
+        tracker.beginTunLease { emptySet() }
+        tracker.claimTunDescriptor(42) { setOf("tun0") }
+
+        assertFalse(
+            tracker.releaseTunDescriptorIfClosed(
+                tunInterfaces = { emptySet() },
+                descriptorTarget = { "/dev/tun" },
+                descriptorInterface = {
+                    TunDescriptorInterface(readable = true, name = "tun0")
+                }
+            )
+        )
+    }
+
+    @Test
+    fun `descriptor reused by a baseline TUN does not retain the owned lease`() {
+        tracker.beginTunLease { setOf("tun0") }
+        tracker.claimTunDescriptor(42) { setOf("tun0", "tun1") }
+
+        assertTrue(
+            tracker.releaseTunDescriptorIfClosed(
+                tunInterfaces = { setOf("tun0") },
+                descriptorTarget = { "/dev/tun" },
+                descriptorInterface = {
+                    TunDescriptorInterface(readable = true, name = "tun0")
+                }
+            )
+        )
+    }
+
+    @Test
+    fun `unreadable descriptor interface remains fail closed`() {
+        tracker.beginTunLease { emptySet() }
+        tracker.claimTunDescriptor(42) { setOf("tun0") }
+
+        assertFalse(
+            tracker.releaseTunDescriptorIfClosed(
+                tunInterfaces = { emptySet() },
+                descriptorTarget = { "/dev/tun" },
+                descriptorInterface = {
+                    TunDescriptorInterface(readable = false, name = null)
+                }
             )
         )
     }

--- a/SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart
+++ b/SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart
@@ -494,7 +494,9 @@ void main() {
       );
     },
     skip: Platform.isWindows ? false : 'Windows network cmdlets are required',
-    timeout: const Timeout(Duration(seconds: 45)),
+    // Includes the baseline PowerShell probe before the 30-second production
+    // teardown budget; loaded CI runners need margin for process startup.
+    timeout: const Timeout(Duration(seconds: 60)),
   );
 
   test('runtime probe rejects a missing or duplicate TUN address', () {


### PR DESCRIPTION
## 说明

本 PR 关闭最终候选验证中发现的两个独立问题。

### Android TUN 释放误判

Android 停止 VPN 时，数字文件描述符可能在原 TUN 租约释放后被内核复用。此前只检查 `/proc/self/fd/<n>` 是否仍指向 `/dev/tun`，会把已解除绑定或复用到既有 TUN 的描述符误判为自有租约残留，并触发 fail-closed 进程终止。

修复读取有界的 `/proc/self/fdinfo/<n>` `iff:` 证据：

- 仍绑定自有 TUN、接口证据未知或不可读时继续 fail closed；
- 已解除绑定，或明确复用到租约开始前已存在的 TUN 时，确认旧租约已释放；
- 不增加等待时间、不改核心、不引入依赖。

### Windows 真实探测测试边界

Windows 真实系统测试先执行 PowerShell 基线探测，再进入 30 秒生产清理预算；原测试总上限仅 45 秒，繁忙 runner 会在产品断言前被测试框架截断。只将测试外层上限调整为 60 秒，生产 30 秒预算和产品代码均不变。

## 验证

- `mise exec flutter@3.44.1 -- bash scripts/test-android-native.sh`
- `mise exec flutter@3.44.1 -- make verify`
- `mise exec flutter@3.44.1 -- flutter test SSRVPN_Windows/test/windows_tun_runtime_probe_test.dart`
- `git diff --check`

本地均通过。真实发行候选 APK 的 20 轮连接/断开回归将在合并后的 Release workflow 产物上执行。最终采用 squash merge，合并为一个整改提交。