### PR TITLE
fix(android): extend bounded TUN release grace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 修复
 
-- Android 停止 VPN 时继续要求 Bridge 与自有 TUN 完成关闭，并为 Android 11 的异步接口回收保留最多约 6 秒的有界等待；描述符编号被内核复用时，会通过 `/proc/self/fdinfo` 区分仍绑定自有 TUN、已解除绑定和其他既有 TUN，避免把已释放连接误判为残留。未知基线、不可读证据、活动接口或仍绑定自有 TUN 的描述符继续安全失败。
+- Android 停止 VPN 时继续要求 Bridge 与自有 TUN 完成关闭，并为 Android 11 的异步接口回收保留最多约 10 秒的有界等待；描述符编号被内核复用时，会通过 `/proc/self/fdinfo` 区分仍绑定自有 TUN、已解除绑定和其他既有 TUN，避免把已释放连接误判为残留。未知基线、不可读证据、活动接口或仍绑定自有 TUN 的描述符继续安全失败。
 - Windows 在安装事务成功后、原用户启动通道仍可用时立即启动可信更新包清理助手；助手绑定当前安装器进程并等待其实际退出，再复用原有 sidecar、SHA-256、NTFS owner stream、普通文件与路径身份校验删除应用内更新包。手动包、失败包和身份不匹配文件继续保留。
 
 ### 验收

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeRuntimeDiagnostics.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeRuntimeDiagnostics.kt
@@ -245,8 +245,8 @@ internal class NativeRuntimeDiagnosticsTracker {
 }
 
 internal object TunReleaseVerifier {
-    // Android 11 can keep a closed TUN visible for more than two seconds.
-    private const val DEFAULT_ATTEMPTS = 61
+    // Android 11 can keep a closed TUN visible beyond the previous six-second grace.
+    private const val DEFAULT_ATTEMPTS = 101
     private const val DEFAULT_RETRY_DELAY_MILLIS = 100L
 
     fun waitUntilReleased(

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeRuntimeDiagnosticsTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeRuntimeDiagnosticsTest.kt
@@ -272,11 +272,11 @@ class NativeRuntimeDiagnosticsTest {
             retryDelayMillis = 0
         ) {
             probes += 1
-            probes == 61
+            probes == 101
         }
 
         assertTrue(released)
-        assertEquals(61, probes)
+        assertEquals(101, probes)
     }
 
     @Test


### PR DESCRIPTION
## 真实候选复现

合并 #172 后，从 `main` 提交 `0a8a8714` 构建并验证了正式签名候选 APK。Redmi Note 8 / Android 11 在 App 正常节奏连接/断开回归第 12 轮仍触发 fail-closed 进程终止。新增日志明确显示：6 秒窗口结束时 `ownedInterfaceActive=true`，因此这不是描述符复用误判，而是 Android 11 的异步接口回收仍未结束。

## 修改

- 将 TUN 释放验证从 61 次探测（约 6 秒）调整为 101 次（约 10 秒）。
- 轮询间隔仍为 100ms。
- 证据未知、活动自有接口或仍绑定描述符在 10 秒后继续 fail closed。
- 不修改核心、连接协议、VPN 配置或其他平台行为。

## 本地验证

- `mise exec flutter@3.44.1 -- bash scripts/test-android-native.sh`
- `bash scripts/check-android-native-bridge-guards.sh`
- `mise exec flutter@3.44.1 -- make verify`
- `git diff --check`

全部通过。合并后必须从精确 `main` 重新构建正式候选，并在同一真机重新执行 20/20 轮。