### PR TITLE
fix(android): rebuild TUN listener after stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 修复
 
-- Android 停止 VPN 时继续要求 Bridge 与自有 TUN 完成关闭，并为 Android 11 的异步接口回收保留最多约 10 秒的有界等待；描述符编号被内核复用时，会通过 `/proc/self/fdinfo` 区分仍绑定自有 TUN、已解除绑定和其他既有 TUN，避免把已释放连接误判为残留。未知基线、不可读证据、活动接口或仍绑定自有 TUN 的描述符继续安全失败。
+- Android 停止 VPN 时继续要求 Bridge 与自有 TUN 完成关闭，并为 Android 11 的异步接口回收保留最多约 10 秒的有界等待；停止时同时清空 Mihomo 已关闭的 TUN 配置，避免后续连接复用相同描述符编号时跳过 listener 重建。描述符编号被内核复用时，会通过 `/proc/self/fdinfo` 区分仍绑定自有 TUN、已解除绑定和其他既有 TUN；未知基线、不可读证据、活动接口或仍绑定自有 TUN 的描述符继续安全失败。
 - Windows 在安装事务成功后、原用户启动通道仍可用时立即启动可信更新包清理助手；助手绑定当前安装器进程并等待其实际退出，再复用原有 sidecar、SHA-256、NTFS owner stream、普通文件与路径身份校验删除应用内更新包。手动包、失败包和身份不匹配文件继续保留。
 
 ### 验收

--- a/SSRVPN_Android/assets/libgojni-source.txt
+++ b/SSRVPN_Android/assets/libgojni-source.txt
@@ -3,7 +3,7 @@ Source commit: 7031b7569831677a8d89ad8a8a3347db116ba1a8
 Source tree: 023ddee8f965c54a263a16df68580585aa12c0f8
 Source corroboration: gunzi-666/Clash.Meta has the same commit and tree
 Bridge source: SSRVPN_Android/native/bridge/bridge.go
-Bridge SHA256: e5474079742118b77dc50855f89b008777d70dfa7590355b00d891342ef5480f
+Bridge SHA256: a1172882fd3af6cd6e3741ffb36cacd106ca98e324f350ee9e39b24b40914622
 Build recipe: scripts/build-android-core.sh
 Go version: go1.25.11
 Go mobile version: v0.0.0-20260602190626-68735029466e
@@ -17,6 +17,6 @@ Android API: 24
 NDK version: 28.2.13676358 (r28c)
 Mirror repo: Elegying/SSRVPN
 Mirror release tag: core-assets-v1
-Mirror asset name: libgojni-cc0202fa56282801a5f6a9e452b08faaac9e89b86c0a5207c013f19150138724.so
-Mirror URL: https://github.com/Elegying/SSRVPN/releases/download/core-assets-v1/libgojni-cc0202fa56282801a5f6a9e452b08faaac9e89b86c0a5207c013f19150138724.so
-Library SHA256: cc0202fa56282801a5f6a9e452b08faaac9e89b86c0a5207c013f19150138724
+Mirror asset name: libgojni-91ff824ce78a2382a8b852ef68acd2c45a919b1bdcac011ad6e20f3844368220.so
+Mirror URL: https://github.com/Elegying/SSRVPN/releases/download/core-assets-v1/libgojni-91ff824ce78a2382a8b852ef68acd2c45a919b1bdcac011ad6e20f3844368220.so
+Library SHA256: 91ff824ce78a2382a8b852ef68acd2c45a919b1bdcac011ad6e20f3844368220

--- a/SSRVPN_Android/native/bridge/bridge.go
+++ b/SSRVPN_Android/native/bridge/bridge.go
@@ -21,7 +21,9 @@ import (
 	"github.com/metacubex/mihomo/hub"
 	"github.com/metacubex/mihomo/hub/executor"
 	"github.com/metacubex/mihomo/listener"
+	LC "github.com/metacubex/mihomo/listener/config"
 	"github.com/metacubex/mihomo/log"
+	"github.com/metacubex/mihomo/tunnel"
 )
 
 var (
@@ -288,6 +290,10 @@ func Stop() {
 	if running {
 		listener.ReCreateMixed(0, nil)
 		listener.ReCreateSocks(0, nil)
+		// Cleanup closes the active TUN listener but retains LastTunConf. Reset
+		// it through the listener lock so a later start that reuses the same
+		// numeric Android fd cannot be mistaken for an unchanged configuration.
+		listener.ReCreateTun(LC.Tun{}, tunnel.Tunnel)
 		executor.Shutdown()
 		running = false
 	}

--- a/SSRVPN_Android/native/bridge/bridge_test.go
+++ b/SSRVPN_Android/native/bridge/bridge_test.go
@@ -7,6 +7,9 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/metacubex/mihomo/listener"
+	LC "github.com/metacubex/mihomo/listener/config"
 )
 
 type fixedRawConn uintptr
@@ -111,6 +114,26 @@ func TestStopCancelsProtectBeforeCoreLock(t *testing.T) {
 	case <-stopReturned:
 	case <-time.After(time.Second):
 		t.Fatal("Stop did not return after coreMu was released")
+	}
+}
+
+func TestStopResetsTunConfigForRepeatedDescriptor(t *testing.T) {
+	listener.LastTunConf = LC.Tun{
+		Enable:         true,
+		FileDescriptor: 128,
+	}
+	running = true
+
+	Stop()
+
+	if listener.LastTunConf.Enable {
+		t.Fatal("TUN config remained enabled after Stop")
+	}
+	if listener.LastTunConf.FileDescriptor != 0 {
+		t.Fatalf(
+			"TUN descriptor after Stop = %d, want 0",
+			listener.LastTunConf.FileDescriptor,
+		)
 	}
 }
 


### PR DESCRIPTION
## 结果

修复 Android 重复连接时相同数字 TUN fd 被 Mihomo 误判为未变化配置的问题。Bridge 停止时通过 Mihomo 自带锁的 TUN 重建入口关闭并清空已结束配置，下一次连接会重新创建 listener；现有有界释放验证与 fail-closed 保持不变。

## 根因

Mihomo 的 listener.Cleanup() 会关闭 TUN listener，但保留 LastTunConf。Android 后续连接若复用相同 fd 数字，ReCreateTun() 会提前返回，导致该 fd 无人接管和关闭，最终触发进程终止恢复。

## 验证

- 固定 Go 1.25.11 / Mihomo 源提交构建和 Go bridge 测试通过
- Android 核心 ELF AArch64/JNI/16 KiB 对齐通过
- 新内容寻址核心资产经 GitHub API 回读 SHA-256 一致
- Android 原生 bridge guard 与 Kotlin/JUnit 测试通过
- mise exec flutter@3.44.1 -- make verify 通过
- git diff --check 通过

合并后将从受保护 main 构建正式签名候选 APK，并在 Redmi Note 8 / Android 11 上重新执行 20 轮连接/断开 UAT 后再决定公开发版。