### PR TITLE
fix(android): accept closed TUN descriptor proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 修复
 
-- Android 停止 VPN 时继续要求 Bridge 与自有 TUN 完成关闭，并为 Android 11 的异步接口回收保留最多约 10 秒的有界等待；停止时同时清空 Mihomo 已关闭的 TUN 配置，避免后续连接复用相同描述符编号时跳过 listener 重建。描述符编号被内核复用时，会通过 `/proc/self/fdinfo` 区分仍绑定自有 TUN、已解除绑定和其他既有 TUN；未知基线、不可读证据、活动接口或仍绑定自有 TUN 的描述符继续安全失败。
+- Android 停止 VPN 时继续要求 Bridge 与自有 TUN 完成关闭，并为 Android 11 的异步接口回收保留最多约 10 秒的有界等待；停止时同时清空 Mihomo 已关闭的 TUN 配置，避免后续连接复用相同描述符编号时跳过 listener 重建。描述符编号被内核复用时，会通过 `/proc/self/fdinfo` 区分仍绑定自有 TUN、已解除绑定和其他既有 TUN；描述符已关闭或已被非 TUN 资源复用时，不再被 MIUI 延迟移除的接口误判为泄漏。未知基线、不可读证据、描述符仍指向活动自有 TUN 时继续安全失败。
 - Windows 在安装事务成功后、原用户启动通道仍可用时立即启动可信更新包清理助手；助手绑定当前安装器进程并等待其实际退出，再复用原有 sidecar、SHA-256、NTFS owner stream、普通文件与路径身份校验删除应用内更新包。手动包、失败包和身份不匹配文件继续保留。
 
 ### 验收

--- a/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeRuntimeDiagnostics.kt
+++ b/SSRVPN_Android/android/app/src/main/kotlin/com/ssrvpn/android/NativeRuntimeDiagnostics.kt
@@ -79,22 +79,28 @@ internal class NativeRuntimeDiagnosticsTracker {
             tunInterfaceBaseline = null
             return true
         }
+        if (claim.baselineInterfaceNames == null && claim.interfaceNames == null) {
+            return false
+        }
+        val target = descriptorTarget(claim.descriptor)
+        if (target == UNKNOWN_DESCRIPTOR_TARGET) return false
+        if (target == null ||
+            target != "/dev/tun" && !target.startsWith("/dev/tun")
+        ) {
+            if (tunOwnershipClaim !== claim) return false
+            tunOwnershipClaim = null
+            return true
+        }
         val currentInterfaces = tunInterfaces() ?: return false
         val ownedInterfaces = resolveOwnedTunInterfaces(claim, currentInterfaces)
             ?: return false
         if (ownedInterfaces.any(currentInterfaces::contains)) return false
-        val target = descriptorTarget(claim.descriptor)
-        if (target == UNKNOWN_DESCRIPTOR_TARGET ||
-            target == "/dev/tun" || target?.startsWith("/dev/tun") == true
-        ) {
-            if (target == UNKNOWN_DESCRIPTOR_TARGET) return false
-            val currentDescriptorInterface = descriptorInterface(claim.descriptor)
-            if (!currentDescriptorInterface.readable) return false
-            val interfaceName = currentDescriptorInterface.name
-            if (interfaceName != null &&
-                descriptorBelongsToClaim(claim, interfaceName) != false
-            ) return false
-        }
+        val currentDescriptorInterface = descriptorInterface(claim.descriptor)
+        if (!currentDescriptorInterface.readable) return false
+        val interfaceName = currentDescriptorInterface.name
+        if (interfaceName != null &&
+            descriptorBelongsToClaim(claim, interfaceName) != false
+        ) return false
         if (tunOwnershipClaim !== claim) return false
         tunOwnershipClaim = null
         return true

--- a/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeRuntimeDiagnosticsTest.kt
+++ b/SSRVPN_Android/android/app/src/test/kotlin/com/ssrvpn/android/NativeRuntimeDiagnosticsTest.kt
@@ -111,7 +111,7 @@ class NativeRuntimeDiagnosticsTest {
     }
 
     @Test
-    fun `delayed TUN discovery is captured before release`() {
+    fun `delayed TUN discovery does not outlive a closed descriptor`() {
         tracker.beginTunLease { emptySet() }
         tracker.claimTunDescriptor(42) { emptySet() }
 
@@ -124,15 +124,9 @@ class NativeRuntimeDiagnosticsTest {
         ).toMap()
 
         assertTrue(connected["tunEstablished"] as Boolean)
-        assertFalse(
-            tracker.releaseTunDescriptorIfClosed(
-                tunInterfaces = { setOf("tun0") },
-                descriptorTarget = { null }
-            )
-        )
         assertTrue(
             tracker.releaseTunDescriptorIfClosed(
-                tunInterfaces = { emptySet() },
+                tunInterfaces = { setOf("tun0") },
                 descriptorTarget = { null }
             )
         )
@@ -160,6 +154,32 @@ class NativeRuntimeDiagnosticsTest {
             tracker.releaseTunDescriptorIfClosed(
                 tunInterfaces = { emptySet() },
                 descriptorTarget = { null }
+            )
+        )
+    }
+
+    @Test
+    fun `Android retained interface releases after owned fd closes`() {
+        tracker.beginTunLease { emptySet() }
+        tracker.claimTunDescriptor(42) { setOf("tun0") }
+
+        assertTrue(
+            tracker.releaseTunDescriptorIfClosed(
+                tunInterfaces = { setOf("tun0") },
+                descriptorTarget = { null }
+            )
+        )
+    }
+
+    @Test
+    fun `Android retained interface releases after fd is reused outside TUN`() {
+        tracker.beginTunLease { emptySet() }
+        tracker.claimTunDescriptor(42) { setOf("tun0") }
+
+        assertTrue(
+            tracker.releaseTunDescriptorIfClosed(
+                tunInterfaces = { setOf("tun0") },
+                descriptorTarget = { "socket:[1234]" }
             )
         )
     }


### PR DESCRIPTION
## 结果

修复 Android 11/MIUI 在自有 TUN 描述符已经关闭或被非 TUN 资源复用后，仍因系统延迟移除 `tun0` 而误判泄漏并终止应用进程的问题。

## 边界

- Bridge 停止、保护线程停止和数据端口释放门槛保持不变。
- 未知基线、不可读描述符证据以及仍绑定自有 TUN 的描述符继续安全失败。
- 不修改代理协议、路由、DNS 或其他平台行为。

## 验证

- `mise exec flutter@3.44.1 -- ./scripts/test-android-native.sh`：171 项通过。
- `mise exec flutter@3.44.1 -- make verify`：完整通过。
- Redmi Note 8 / Android 11 实机先复现证据：`descriptorTargetsTun=false`、`descriptorAttachedToOwnedInterface=false`，但 MIUI 暂留接口导致旧判定在 10 秒后误杀进程。
- 合并后将使用正式签名候选包继续执行 20 轮连接/断开 UAT。