### PR TITLE
docs: record v4.0.20 release evidence

### DIFF
--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -4,11 +4,11 @@
 
 当前应用版本：`v4.0.20`
 
-最新正式版本：[`v4.0.19`](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.19)
+最新正式版本：[`v4.0.20`](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.20)
 
 ## 当前结论
 
-`v4.0.20` 是针对 v4.0.19 两项实机问题的补丁候选：Android 停止事务现在能区分仍由应用
+`v4.0.20` 已正式发布，修复了 v4.0.19 暴露的两项实机问题：Android 停止事务现在能区分仍由应用
 持有的 TUN 与 MIUI 延迟移除但描述符已经关闭的接口，继续对未知或活动自有 TUN 失败关闭；
 Windows 安装事务会在成功提交后启动可信更新包清理助手，同时继续保留手动包、失败包和
 身份不匹配文件。“智能”、全局、订阅、节点格式和连接协议没有变化。
@@ -18,8 +18,8 @@ Windows 安装事务会在成功提交后启动可信更新包清理助手，同
 进程终止复现；完整证据见
 [v4.0.20 Android 修复候选报告](uat/SSRVPN_Android_v4.0.20_修复候选实机验收报告_20260902.md)。
 Windows 修复已通过正式安装器在线 smoke，但没有把线上自动化冒充新的桌面人工 UAT。
-当前最新公开版本仍是 v4.0.19；v4.0.20 需在版本提交合并后完成标签、Release、七项资产、
-摘要、provenance 和公共下载终验。
+受保护主分支、正式标签、GitHub Release、七项公开资产、摘要、provenance、GitHub
+Attestations 和 OSS 公共下载均已完成独立终验。
 
 本文件只记录当前状态和仍需跟进的证据边界。版本变更明细以
 [CHANGELOG](../CHANGELOG.md) 为准，硬性产品约束以
@@ -30,13 +30,14 @@ Windows 修复已通过正式安装器在线 smoke，但没有把线上自动化
 
 | 项目 | 当前结果 |
 | --- | --- |
-| 当前候选版本 | `4.0.20+4020`，三端 pubspec、共享常量和 CHANGELOG 一致；尚未创建标签或 Release |
+| 当前正式版本 | `4.0.20+4020`，三端 pubspec、共享常量、CHANGELOG、正式资产身份一致 |
 | 当前版本本地门禁 | Flutter `3.44.1` 下完整 `make verify` 退出码 0；版本、文档、格式、三端测试和覆盖率门禁全部通过 |
-| 修复源码 | 受保护 `main` 提交 [`ae83e52`](https://github.com/Elegying/SSRVPN/commit/ae83e529a60830e51054b710db764293dcf53732)；版本提升只允许修改版本和证据文件 |
-| 精确修复 `main` CI | [`33543771035`](https://github.com/Elegying/SSRVPN/actions/runs/33543771035) 成功；工作区、Android、macOS、Windows、安全与原生门禁全部通过 |
-| 三端候选构建 | [`33545476322`](https://github.com/Elegying/SSRVPN/actions/runs/33545476322) 成功；Android APK、macOS DMG、Windows 安装器和 shared 全部通过，发布步骤按非标签运行设计跳过 |
-| Android 实机候选 | APK SHA-256 `432e385f…6ae`；App 20/20、快速取消 10/10、后台/Doze 与真实 HTTPS 通过 |
-| 最新正式版本 | [`v4.0.19`](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.19) 仍公开；v4.0.20 标签、七项资产和公共通道待本轮正式发布 |
+| 正式源码与标签 | 受保护 `main` 提交 [`c7667ff`](https://github.com/Elegying/SSRVPN/commit/c7667ff0075ae9b5c4848cb72de842b9b7bcbe07)；带注释标签 `v4.0.20` 精确解引用到该提交 |
+| 精确正式 `main` CI | [`33553184498`](https://github.com/Elegying/SSRVPN/actions/runs/33553184498) 成功；工作区、Android、macOS、Windows、安全与原生门禁全部通过 |
+| 标签与正式构建 | [`Prepare Release 33554832427`](https://github.com/Elegying/SSRVPN/actions/runs/33554832427) 和 [`Release 33554866473`](https://github.com/Elegying/SSRVPN/actions/runs/33554866473) 均成功 |
+| Android 实机 | 修复候选 App 20/20、快速取消 10/10、后台/Doze 与真实 HTTPS 通过；正式 APK 与候选之间只有版本和证据变更 |
+| 正式公开资产 | [`v4.0.20`](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.20) 共七项资产；APK `f6cae87c…f977`、DMG `2c988fb8…fa1f9`、EXE `3f662fb2…fba3`，摘要、provenance 与 attestation 一致 |
+| OSS 公共通道 | `latest.json` 已指向 `4.0.20`；三端版本化资产完整下载后的 SHA-256 与 GitHub Release 逐项一致 |
 
 发布流程在三平台产物和 shared 测试全部成功后才获准进入 `release` 环境；
 Draft Release、不可变 OSS 目录、公共通道提升和 GitHub Release 最终发布按事务顺序完成。
@@ -49,9 +50,9 @@ Draft Release、不可变 OSS 目录、公共通道提升和 GitHub Release 最�
 | 安全、隐私与供应链 | 19/20 | 订阅和更新输入有界，日志与诊断脱敏，进程和系统设置按所有权处理，正式资产可校验来源 |
 | 架构与可维护性 | 18/20 | 以描述符证据和现有清理助手完成局部修复，没有放宽所有权边界或引入新依赖 |
 | 测试与 CI | 19/20 | 九项受保护检查、完整三端门禁、候选构建和 Android 真实故障机回归通过；仍缺部分硬件矩阵 |
-| 发布工程 | 10/12 | 候选资产、摘要、签名谱系和 provenance 已预验；v4.0.20 正式标签、公开资产与通道终验待执行 |
+| 发布工程 | 12/12 | 精确标签、三端正式构建、七项公开资产、摘要、provenance、attestation 和 OSS 公共通道均已终验 |
 | 文档与治理 | 8/8 | README、用户指南、安全策略、ADR、UAT、维护手册与正式发布证据齐全 |
-| **综合** | **93/100** | **修复候选达到补丁发版条件；正式发布事务和发布后公开资产复验尚未完成** |
+| **综合** | **95/100** | **达到成熟正式发布状态；剩余缺口是扩大设备与人工场景证据，不阻断当前补丁版本** |
 
 ## 自动化验证摘要
 
@@ -87,11 +88,11 @@ Draft Release、不可变 OSS 目录、公共通道提升和 GitHub Release 最�
 
 ## 下一阶段优先级
 
-1. 合并 v4.0.20 版本与证据提交，等待精确 `main` 的九项必需检查全部成功。
-2. 通过 `Prepare Release` 创建不可变 `v4.0.20` 标签，等待三端正式构建和发布事务完成。
-3. 重新下载七项公开资产，核对 SHA-256、Android 签名谱系、三端版本身份、provenance、attestation 和 OSS 公共通道。
-4. 发布后回填精确标签、CI、Release、资产摘要和公共下载证据，并关闭已完成的 Android 故障 Issue。
-5. 后续补齐原生 16 KiB Android、可靠的 MIUI 磁贴 20 轮、蜂窝/第二 VPN/更多 OEM，以及 Windows 被策略阻塞的人工场景。
+1. 在可可靠记录独立单击的 MIUI 环境中补做快捷磁贴 20 轮连接/断开，证明 UI、Service、TUN 和最终状态始终一致。
+2. 在原生 16 KiB page-size Android 设备上完成安装、连接、真实数据路径、断开和覆盖升级，补齐结构检查无法替代的硬件证据。
+3. 扩展 Android 真机矩阵：补做蜂窝/Wi-Fi 切换、第二 VPN 竞争、至少一种其他 OEM 后台策略，并建立同机同口径空闲电量基线。
+4. 在普通 Windows 桌面会话补做修复后 UAT，重点保留 UAC 取消、托盘正常退出和可信更新安装器清理的可复核证据。
+5. 在 macOS 补做持续离线后的取消与网络恢复专项；如需更早发现现场问题，可在不上传用户流量内容的前提下建立可选本地诊断趋势基线。
 
 ## 更新规则
 

--- a/docs/UAT_MATRIX.md
+++ b/docs/UAT_MATRIX.md
@@ -21,6 +21,30 @@ VPN、代理、TUN、安装、无障碍及电量在目标系统上实际成立�
 每个失败必须附最小复现步骤、发生时间、应用诊断、系统日志和预期结果；禁止上传原始订阅、
 节点密码、Token、API secret、用户名路径或未脱敏截图。
 
+## 2026-09-02 v4.0.20 正式发布证据
+
+- 正式版本 `4.0.20+4020` 的受保护 `main` 和标签 `v4.0.20` 精确指向提交
+  `c7667ff0075ae9b5c4848cb72de842b9b7bcbe07`；精确主分支 CI
+  [33553184498](https://github.com/Elegying/SSRVPN/actions/runs/33553184498)、
+  [Prepare Release 33554832427](https://github.com/Elegying/SSRVPN/actions/runs/33554832427) 和
+  [正式 Release 33554866473](https://github.com/Elegying/SSRVPN/actions/runs/33554866473) 均成功。
+- [GitHub Release v4.0.20](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.20) 已公开，非
+  draft、非 prerelease，共七项资产。完整下载后 APK SHA-256 为
+  `f6cae87cd42825bdae68dc9879605a5749414d357cea6b932883bbfc5497f977`，DMG 为
+  `2c988fb8b7563591763c2798e43a26d3f7587d2301390fa1e96a65dca59fa1f9`，Windows 安装器为
+  `3f662fb2670b3d2247ba170d024458a4c6d43a6f65633125771c29a55bf3fba3`；三份 sidecar、
+  Release API digest 和 provenance 逐项一致。
+- provenance 精确记录标签、提交和三端摘要；APK、DMG、EXE 的 GitHub Attestations 均通过
+  Sigstore/SLSA 验证，workflow ref、源码摘要和 run attempt 与正式发布一致。
+- 正式 APK 为 `com.ssrvpn.android`、`versionName=4.0.20`、`versionCode=4020`、
+  `minSdk=24`、`targetSdk=36`、arm64-v8a；APK v2 签名、单一 signer，证书 SHA-256 为
+  `caf5bb670e4513c4e3d7815a7314f489281c37f02827db07d0a59e1242f2cc0c`，16 KiB zipalign
+  检查通过。正式 DMG 可校验和挂载，应用版本为 `4.0.20+4020`、arm64，继续使用项目明确的
+  ad-hoc、未公证免费分发边界。
+- OSS `latest.json` 已指向 `4.0.20`，三个公开版本化资产独立完整下载后的 SHA-256 与 GitHub
+  Release 完全一致。正式资产、构建和公共通道证据证明发布事务完整，不替代下方仍标记为
+  `BLOCKED` 或“未执行”的硬件、OEM 与人工桌面 UAT。
+
 ## 2026-09-02 v4.0.20 Android 修复候选增量验收快照
 
 - 修复候选提交 `ae83e529a60830e51054b710db764293dcf53732` 的 APK 在同一 Redmi Note 8 /
@@ -32,8 +56,8 @@ VPN、代理、TUN、安装、无障碍及电量在目标系统上实际成立�
   `cmd statusbar click-tile` 连续注入两次点击，面板收起时不投递；因此自动 20 轮保持
   `BLOCKED`，不把系统双击包装成人工单击验收。
 - 候选来自版本提升前的精确修复提交，APK 身份仍为 `4.0.19+4019`；provenance 和 SHA-256
-  将二进制绑定到该提交。v4.0.20 版本提交只允许修改版本、变更日志和发布证据，正式包仍需
-  受保护 `main` 重建和终验。
+  将二进制绑定到该提交。正式 v4.0.20 已由受保护 `main` 重建并通过上方发布终验；候选与
+  正式提交之间只有版本、变更日志和证据文件变化，没有改变本表实测的 Android 运行路径。
 - 原生 16 KiB page-size 设备、蜂窝切换、第二 VPN、更多 OEM 继续保持未执行；本机 4 KiB
   设备和 ELF 16 KiB 对齐不替代硬件 UAT。
 - 完整步骤、候选包身份、日志摘要和现场恢复见

--- a/docs/uat/SSRVPN_Android_v4.0.20_修复候选实机验收报告_20260902.md
+++ b/docs/uat/SSRVPN_Android_v4.0.20_修复候选实机验收报告_20260902.md
@@ -28,8 +28,8 @@ App 入口连续 20/20 轮连接与断开、10/10 轮连接中快速取消均保
 
 候选 APK 的版本仍是 4.0.19，因为它来自版本提升之前的精确修复提交；provenance 已把 APK
 绑定到上述 `main` 提交。v4.0.20 的版本提交只修改版本号、变更日志和发布证据，不改变该实测
-Android 运行路径；正式包仍必须由受保护 `main` 重新构建并完成摘要、签名谱系和 provenance
-终验。
+Android 运行路径。正式包已经由受保护 `main` 重新构建，并完成摘要、签名谱系、provenance、
+attestation 和公共下载终验。
 
 ## 候选包与供应链证据
 
@@ -78,6 +78,30 @@ Android 运行路径；正式包仍必须由受保护 `main` 重新构建并完�
 - 非标签 Release candidate
   [33545476322](https://github.com/Elegying/SSRVPN/actions/runs/33545476322) 从同一提交完成三端
   正式形态构建和产物验证；发布步骤按设计未执行。
+
+## 正式发布闭环
+
+- 正式版本 `4.0.20+4020` 的受保护 `main` 与标签 `v4.0.20` 精确指向
+  `c7667ff0075ae9b5c4848cb72de842b9b7bcbe07`；精确主分支 CI
+  [33553184498](https://github.com/Elegying/SSRVPN/actions/runs/33553184498)、
+  [Prepare Release 33554832427](https://github.com/Elegying/SSRVPN/actions/runs/33554832427) 和
+  [Release 33554866473](https://github.com/Elegying/SSRVPN/actions/runs/33554866473) 均成功。
+- [v4.0.20 正式 Release](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.20) 已公开，共七项
+  资产。APK SHA-256 为
+  `f6cae87cd42825bdae68dc9879605a5749414d357cea6b932883bbfc5497f977`，DMG 为
+  `2c988fb8b7563591763c2798e43a26d3f7587d2301390fa1e96a65dca59fa1f9`，Windows 安装器为
+  `3f662fb2670b3d2247ba170d024458a4c6d43a6f65633125771c29a55bf3fba3`；三份 sidecar、
+  Release API digest 和 provenance 一致。
+- 正式 APK 身份为 `com.ssrvpn.android`、`4.0.20+4020`，APK v2 单一 signer，证书 SHA-256
+  仍为 `caf5bb670e4513c4e3d7815a7314f489281c37f02827db07d0a59e1242f2cc0c`，16 KiB zipalign
+  通过。正式 DMG 为 `4.0.20+4020`、arm64，可校验和挂载，继续使用既定 ad-hoc 签名；
+  Windows 安装器摘要与 provenance 一致。
+- APK、DMG、EXE 的 Sigstore/SLSA attestation 均验证到同一标签、提交和正式工作流；OSS
+  `latest.json` 已指向 `4.0.20`，三个版本化资产独立完整下载后的摘要与 GitHub Release 一致。
+- 候选实机结论可以沿用到正式包：从实测提交 `ae83e52` 到正式提交 `c7667ff` 只修改三端版本、
+  共享版本常量、CHANGELOG 和发布证据，没有修改 Android TUN、VPN Service 或配置运行路径。
+  该差异边界不扩大实机结论；本报告保留的快捷磁贴 20 轮、原生 16 KiB、蜂窝/第二 VPN 和
+  其他 OEM 缺口仍保持原状态。
 
 ## 最终现场恢复
 


### PR DESCRIPTION
## 目的

回填已经完成的 v4.0.20 正式发布、公开资产、供应链和 Android 实机证据，移除发布前候选状态。

## 变更

- 将项目健康状态更新为 v4.0.20 正式发布，综合评分更新为 95/100
- 记录精确 main、标签、三个工作流、七项资产、SHA-256、provenance、attestation 和 OSS 终验
- 保留快捷磁贴 20 轮、原生 16 KiB、蜂窝/第二 VPN/其他 OEM、Windows 人工场景与 macOS 长离线取消等真实证据缺口
- 将下一阶段收敛为五项可验收工作

## 验证

- `bash scripts/check-doc-consistency.sh`
- `git diff --check`
- 旧候选状态与待发布文案定向搜索无残留

本 PR 仅修改文档，不修改产品代码、版本或发布资产。