### PR TITLE
记录 v4.0.23 正式发布与验收证据

### DIFF
--- a/docs/PROJECT_HEALTH.md
+++ b/docs/PROJECT_HEALTH.md
@@ -1,25 +1,29 @@
 # SSRVPN 项目健康与发布状态
 
-最近更新：2026-09-02
+最近更新：2026-09-03
 
 当前应用版本：`v4.0.23`
 
-最新正式版本：[`v4.0.22`](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.22)
+最新正式版本：[`v4.0.23`](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.23)
 
 ## 当前结论
 
-`v4.0.22` 已正式发布：在 v4.0.21 Telegram 修复基础上，将三端“智能”模式升级为
-用户规则优先、海外服务代理、国内企业域名/ASN 直连、GFW/CN/GeoIP 兜底和未知流量默认代理
-的统一分层。六份带版本与 SHA-256 清单的规则随包内置，远程刷新失败不阻断连接；Android
-普通用户应用全部进入 TUN，使手动强制代理不再被应用级旁路绕过。
+`v4.0.23` 已正式发布：保留 v4.0.22 的分层智能规则与未知流量代理兜底，同时只在 Android
+“智能”模式恢复 178 个经审查的国内应用包名旁路，覆盖抖音及其轻量版、微信、QQ、国内
+电商、支付、影音、出行、银行和国内 AI。浏览器、Telegram、ChatGPT、Claude、Lark 国际版
+及不确定包名明确不旁路；“全局”模式不启用国内应用旁路，仍允许用户在需要时让全部应用
+进入 TUN。
 
-Android v4.0.20 实机日志确认 Telegram 三处数据中心地址被旧规则判为 `DIRECT` 后超时，
-同一节点经代理访问全部成功；因此根因是分流遗漏，不是节点不可用。v4.0.22 正式 APK
-发布前手机已断开 USB，未把未执行的正式 APK 原地升级和 Telegram 复验冒充实机通过。
+桌面端已把“运行日志”从节点选择页移到订阅页右上角，并在“关于”页增加手动“检查更新”；
+未连接时允许用户主动检查，自动检查仍只在连接成功后执行。macOS 系统代理连接去掉了三次
+由 `networksetup -set*proxy` 已隐式完成的重复启用调用，保留代理快照、网络服务身份复核、
+guardian、回读确认和失败回滚。Windows/macOS 其余连接门禁未为追求耗时数字而删除。
 
 当前版本已在固定 Flutter 3.44.1 工具链通过完整 `make verify`，覆盖共享规则、三端 Flutter、
-Android 原生构建、macOS 原生测试和内置 Mihomo 配置校验；受保护 PR #183、精确主分支 CI、
+Android 原生构建、macOS 原生测试和内置 Mihomo 配置校验；受保护 PR #186、精确主分支 CI、
 正式三端构建、标签、公开七项资产、GitHub Attestations 与 OSS 公共通道均已完成终验。
+发布时 USB 手机不在线，因此未把自动回归或旧版本实机证据冒充 v4.0.23 抖音/Telegram 真机
+复验。
 
 本文件只记录当前状态和仍需跟进的证据边界。版本变更明细以
 [CHANGELOG](../CHANGELOG.md) 为准，硬性产品约束以
@@ -30,38 +34,38 @@ Android 原生构建、macOS 原生测试和内置 Mihomo 配置校验；受保�
 
 | 项目 | 当前结果 |
 | --- | --- |
-| 当前代码版本 | `4.0.22+4022`，三端 pubspec、共享常量、CHANGELOG 一致；七项正式资产已发布 |
-| 当前版本本地门禁 | `mise exec flutter@3.44.1 -- make verify` 全部通过：Release tooling 396 项、Shared 658 项（85.68%）、macOS 284 项（67.28%）、Windows 273 项（54.80%），并包含 Android Flutter/原生构建、规则清单离线校验与 macOS 内置 Mihomo 配置加载；8 项 Windows 主机专属用例按设计留给线上 CI |
-| 正式源码与标签 | 受保护 PR [#183](https://github.com/Elegying/SSRVPN/pull/183) 已 squash 合并；`main` 提交 [`eb3d161`](https://github.com/Elegying/SSRVPN/commit/eb3d161015f1abdb154c370b0c2de3bc2b0be57d)，标签 `v4.0.22` 精确解引用到同一提交 |
-| 精确正式 `main` CI | [`33625677508`](https://github.com/Elegying/SSRVPN/actions/runs/33625677508) 成功；工作区、Android、macOS、Windows、安全与原生门禁全部通过 |
-| 标签与正式构建 | [`Prepare Release 33627188347`](https://github.com/Elegying/SSRVPN/actions/runs/33627188347) 和 [`Release 33627219065`](https://github.com/Elegying/SSRVPN/actions/runs/33627219065) 均成功 |
-| Android 实机 | v4.0.20 旧规则根因与同节点代理可达性已实机确认；v4.0.22 正式 APK 发布前手机断开 USB，正式包原地升级与 Telegram 复验保持未执行 |
-| 正式公开资产 | [`v4.0.22`](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.22) 共七项资产；完整下载后 APK `81faed6d…1ac72`、DMG `c66039fb…1c3ef`、EXE `5a15890d…80152`，实际文件、sidecar、Release API digest、provenance 与 GitHub Attestations 一致 |
-| OSS 公共通道 | `latest.json` 已指向 `4.0.22`；三个版本化资产完整下载后的 SHA-256 与 GitHub 一致，版本化与公共 `latest.json` 逐字节一致 |
+| 当前代码版本 | `4.0.23+4023`，三端 pubspec、共享常量、CHANGELOG 一致；七项正式资产已发布 |
+| 当前版本本地门禁 | `mise exec flutter@3.44.1 -- make verify` 全部通过：Release tooling 396 项、Shared 659 项（84.98%）、macOS 286 项（66.75%）、Windows 本地 274 项（54.46%，另有 8 项主机专属用例按设计跳过），并包含 Android Flutter/原生构建、规则清单离线校验与 macOS 内置 Mihomo 配置加载 |
+| 正式源码与标签 | 受保护 PR [#186](https://github.com/Elegying/SSRVPN/pull/186) 已 squash 合并；`main` 提交 [`2fe43b5`](https://github.com/Elegying/SSRVPN/commit/2fe43b56b1e45f3462e4362aabcecd6140f3d9aa)，标签 `v4.0.23` 精确解引用到同一提交 |
+| 精确正式 `main` CI | [`33713779646`](https://github.com/Elegying/SSRVPN/actions/runs/33713779646) 成功；工作区、Android、macOS、Windows、安全、安装器 smoke 与原生门禁全部通过 |
+| 标签与正式构建 | [`Prepare Release 33714753378`](https://github.com/Elegying/SSRVPN/actions/runs/33714753378) 和 [`Release 33714772096`](https://github.com/Elegying/SSRVPN/actions/runs/33714772096) 均成功 |
+| Android 实机 | 国内应用旁路、浏览器/国外应用负例、“智能”/“全局”作用域和旧快照兼容均有自动回归；发布时 `adb devices` 无在线设备，v4.0.23 正式 APK 原地升级、抖音评论/私信图片与 Telegram 复验保持未执行 |
+| 正式公开资产 | [`v4.0.23`](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.23) 共七项资产；完整下载后 APK `7b970325…356e`、DMG `a72faf07…e398`、EXE `e0ede592…c3a1`，实际文件、sidecar、Release API digest、provenance 与 GitHub Attestations 一致 |
+| OSS 公共通道 | `latest.json` 已指向 `4.0.23`；三个版本化资产完整下载后的 SHA-256 与 GitHub 一致，且文件逐字节相同 |
 
 发布流程在三平台产物和 shared 测试全部成功后才获准进入 `release` 环境；
 Draft Release、不可变 OSS 目录、公共通道提升和 GitHub Release 最终发布按事务顺序完成。
 
-## 最近正式版本质量评分（v4.0.22）
+## 最近正式版本质量评分（v4.0.23）
 
 | 维度 | 得分 | 主要依据 |
 | --- | ---: | --- |
-| 功能正确性与失败恢复 | 18/20 | 用户规则、海外服务、国内企业、GFW/CN/GeoIP 和未知流量安全兜底均有行为测试；正式 Android 包和桌面人工流量矩阵仍未执行 |
+| 功能正确性与失败恢复 | 19/20 | 用户规则、国内应用旁路作用域、浏览器/国外应用负例、海外服务、国内企业、GFW/CN/GeoIP 和未知流量安全兜底均有行为测试；正式 Android 包和桌面人工流量矩阵仍未执行 |
 | 安全、隐私与供应链 | 19/20 | 规则下载大小、格式、条目与 SHA-256 均有界，失败保留已验证旧规则；正式资产可独立校验来源 |
 | 架构与可维护性 | 19/20 | 三端复用同一分层构建器与版本化规则包，没有替换代理核心、改变订阅格式或引入自动学习和新依赖 |
 | 测试与 CI | 19/20 | 九项受保护检查、完整三端门禁、正式构建、配置加载和安装器 smoke 通过；仍缺部分真机与人工矩阵 |
 | 发布工程 | 12/12 | 精确标签、三端正式构建、七项公开资产、摘要、provenance、attestation 和 OSS 公共通道均已终验 |
 | 文档与治理 | 8/8 | README、用户指南、安全策略、ADR、UAT、维护手册与正式发布证据齐全 |
-| **综合** | **95/100** | **达到成熟正式发布状态；剩余缺口是扩大设备与人工场景证据，不阻断当前补丁版本** |
+| **综合** | **96/100** | **达到成熟正式发布状态；剩余缺口是扩大设备与人工场景证据，不阻断当前补丁版本** |
 
 ## 自动化验证摘要
 
 - Release tooling：396 项通过。
-- Shared：658 项通过，行覆盖率 85.68%；分层顺序、冲突处理、DNS policy、六份规则清单及远程缓存失败回退均有回归。
-- Android：Flutter 配置、原生桥守卫、Kotlin 单测与原生构建通过；正式 Release 生成签名 APK 并通过包结构 smoke。
-- macOS Flutter：284 项通过，行覆盖率 67.28%；原生 RunnerTests 和内置 Mihomo v1.19.29 的系统代理/TUN 配置加载通过。
-- Windows Flutter：273 项通过（另有 8 项仅 Windows 主机执行的用例在本地门禁跳过），行覆盖率 54.80%；正式 Windows runner 执行主机专属检查、安装器构建及安装/卸载 smoke 并通过。
-- PR 首次 Workspace 尝试出现一项既有订阅刷新时序用例抖动；只重跑失败 job 后通过，同一用例随后在精确 `main` CI 与正式 Release 再次通过，没有为追求绿色结果放宽断言。
+- Shared：659 项通过，行覆盖率 84.98%；分层顺序、冲突处理、DNS policy、六份规则清单及远程缓存失败回退均有回归。
+- Android：Flutter 278 项、原生桥守卫、Kotlin 单测与原生构建通过；正式 Release 生成签名 APK，v2 signer 证书与既有版本一致，arm64 核心保持 16 KiB ELF 对齐。
+- macOS Flutter：286 项通过，行覆盖率 66.75%；生命周期关键文件 76.47%、系统代理 88.21%，原生 RunnerTests 和内置 Mihomo v1.19.29 的系统代理/TUN 配置加载通过。
+- Windows 正式 runner：282 项通过，行覆盖率 57.13%；生命周期关键文件保持 50.00% 门槛，主机专属检查、安装器构建及安装/卸载 smoke 通过。本地固定工具链执行 274 项并按设计跳过 8 项 Windows 主机专属用例。
+- 本地首次完整门禁只暴露 macOS 测试替身未模拟 `networksetup -set*proxy` 自带启用语义；修正测试替身后 83 项定向回归与完整门禁通过，没有恢复冗余生产调用或放宽断言。
 - 依赖 PR [#145](https://github.com/Elegying/SSRVPN/pull/145) 仅升级 `gradle/actions/setup-gradle` 6.2.0 → 6.3.0；独立验证后合并，提交 `5e56ed4` 的 [主分支 CI](https://github.com/Elegying/SSRVPN/actions/runs/33497028016) 全部成功。
 - 依赖 PR [#121](https://github.com/Elegying/SSRVPN/pull/121) 未与 #145 打包：`flutter_secure_storage` 11.0.0 要求 Android `compileSdk 37`，而当前 AGP 9.0.1 支持边界为 36；真实构建失败后已独立关闭，未降低平台门槛强行合并。
 - 分支保护要求严格提交同步、管理员不可绕过、禁止 force-push/删除，并固定九项必需检查。
@@ -71,10 +75,10 @@ Draft Release、不可变 OSS 目录、公共通道提升和 GitHub Release 最�
 
 以下项目是仍未补齐的人工或长期证据，不得由自动化或其他设备替代：
 
-1. v4.0.22 正式 APK 尚未在旧故障手机完成原地升级、Telegram、国内站点、海外站点和国内 AI 服务复验；旧版根因日志与自动回归不能替代正式包真机证据。
+1. v4.0.23 正式 APK 尚未在旧故障手机完成原地升级、抖音评论/私信图片、Telegram、国内站点、海外站点和国内 AI 服务复验；旧版根因日志与自动回归不能替代正式包真机证据。
 2. Android 仍缺原生 16 KiB page-size 硬件、其他 VPN 竞争、蜂窝切换、不同 OEM 和同口径电量复测；4 KiB 真机和 ELF 对齐门禁不能替代这些证据。
-3. Windows 正式安装器在线构建、安装/卸载 smoke 已通过，但 v4.0.22 尚无普通桌面 TUN/系统代理人工流量矩阵；UAC 取消和托盘正常退出仍受当前实机策略/自动化边界阻塞。
-4. macOS 已用内置核心加载 TUN/系统代理配置并通过自动生命周期测试，但 v4.0.22 尚未执行国内、海外、国内 AI、海外 CDN 与持续断网恢复的完整人工流量矩阵。
+3. Windows 正式安装器在线构建、安装/卸载 smoke 已通过，但 v4.0.23 尚无普通桌面 TUN/系统代理人工流量矩阵；UAC 取消和托盘正常退出仍受当前实机策略/自动化边界阻塞。
+4. macOS 已用内置核心加载 TUN/系统代理配置并通过自动生命周期测试，但 v4.0.23 尚未执行国内、海外、国内 AI、海外 CDN 与持续断网恢复的完整人工流量矩阵。
 5. Windows 未签名安装器、macOS ad-hoc/未公证属于既定免费分发边界；Windows Authenticode、macOS Developer ID 与 notarization 均不计划增加。
 6. 崩溃与诊断默认只保存在本机，没有自动遥测、集中聚合、规则命中上报或趋势告警；本版也未实现会自动改变路由的学习机制。
 
@@ -89,11 +93,11 @@ Draft Release、不可变 OSS 目录、公共通道提升和 GitHub Release 最�
 
 ## 下一阶段优先级
 
-1. 在旧故障 Android 手机安装 v4.0.22 正式 APK，复验 Telegram、国内/海外站点、国内 AI 海外接口、规则刷新失败和节点断开恢复。
-2. 在普通 Windows 桌面分别执行 TUN 与系统代理矩阵，补齐 DNS、TCP/UDP/QUIC、IPv6 禁用、嗅探失败兜底和系统设置恢复证据。
-3. 在 macOS 分别执行 TUN 与系统代理矩阵，补齐国内/海外/国内 AI/海外 CDN、持续离线取消和网络恢复证据。
-4. 扩展 Android 硬件矩阵：补做原生 16 KiB page size、蜂窝/Wi-Fi 切换、第二 VPN、至少一种其他 OEM 后台策略和同机电量基线。
-5. 观察版本化规则通道的更新失败率与用户反馈；只以人工审核规则更新修正误判，不引入会覆盖用户选择或静默改变路由的自动学习。
+1. 在旧故障 Android 手机安装 v4.0.23 正式 APK；完成标准：抖音评论和私信图片连续 20 轮、Telegram、国内/海外站点、国内 AI、规则刷新失败及节点断开恢复均有脱敏日志且无失败。
+2. 在普通 Windows 桌面分别执行 TUN 与系统代理矩阵；完成标准：DNS、TCP/UDP/QUIC、IPv6 禁用、嗅探失败兜底、异常退出和系统设置恢复全部记录通过。
+3. 在 macOS 分别执行 TUN 与系统代理矩阵；完成标准：国内/海外/国内 AI/海外 CDN、持续离线取消、网络恢复和连接耗时中位数/P95 全部形成同机证据。
+4. 扩展 Android 硬件矩阵；完成标准：原生 16 KiB page size、蜂窝/Wi-Fi 切换、第二 VPN、至少一种其他 OEM 后台策略和同机 30 分钟电量基线均完成。
+5. 观察版本化规则通道与国内应用名单；完成标准：每次调整都有可复现用户反馈、人工审核、包名来源、浏览器/国外应用负例和失败回退测试，不引入会覆盖用户选择的自动学习。
 
 ## 更新规则
 

--- a/docs/UAT_MATRIX.md
+++ b/docs/UAT_MATRIX.md
@@ -21,6 +21,46 @@ VPN、代理、TUN、安装、无障碍及电量在目标系统上实际成立�
 每个失败必须附最小复现步骤、发生时间、应用诊断、系统日志和预期结果；禁止上传原始订阅、
 节点密码、Token、API secret、用户名路径或未脱敏截图。
 
+## 2026-09-03 v4.0.23 国内应用旁路与桌面体验正式发布证据
+
+- 受保护 PR [#186](https://github.com/Elegying/SSRVPN/pull/186) 已 squash 合并；`main`、标签
+  `v4.0.23` 均精确指向提交 `2fe43b56b1e45f3462e4362aabcecd6140f3d9aa`。精确
+  [主分支 CI 33713779646](https://github.com/Elegying/SSRVPN/actions/runs/33713779646)、
+  [Prepare Release 33714753378](https://github.com/Elegying/SSRVPN/actions/runs/33714753378) 和
+  [Release 33714772096](https://github.com/Elegying/SSRVPN/actions/runs/33714772096) 均成功。
+- [GitHub Release v4.0.23](https://github.com/Elegying/SSRVPN/releases/tag/v4.0.23) 已公开，非
+  draft、非 prerelease，共七项资产。独立完整下载后 APK SHA-256 为
+  `7b970325eeab297558c4134cfe3d94730896b546257cce4f20c8eac7490d356e`，DMG 为
+  `a72faf077f0f22bed3a0c140b851854c56d0ee28318f2695094f27718b76e398`，Windows 安装器为
+  `e0ede592c37f51cde820e26d7e12f69bff20565260359dbcb478475228dfc3a1`；实际文件、三份
+  sidecar、Release API digest、provenance 与三个 GitHub Attestations 逐项一致。
+- OSS `latest.json` 已指向 `4.0.23`；三个版本化安装包再次独立完整下载，SHA-256 与 GitHub
+  一致且逐字节相同。发布事务证据不替代下表保持“未执行”的真实网络与人工桌面 UAT。
+- 固定 Flutter 3.44.1 的完整本地门禁通过；正式 Release 中 Shared 659 项（84.98%）、Android
+  Flutter 278 项、macOS 286 项（66.75%）和 Windows 282 项（57.13%）通过，Android Kotlin
+  原生单测/Release 构建、macOS 原生测试、Windows 安装/卸载 smoke 和三端包结构门禁均成功。
+- Android 仅在“智能”模式把 178 个经审查的国内应用排除在 TUN 外，包含抖音及轻量版；
+  Chrome 各通道、Edge、Firefox、Brave、DuckDuckGo、Opera、三星、UC、QQ、夸克、华为、
+  Vivo、百度、360、Via、Vivaldi 等浏览器，以及 Telegram、ChatGPT、Claude、Lark 国际版和
+  不确定包名均有“不旁路”负例。“全局”模式禁用国内应用旁路；ADB 调试包保留既有旁路。
+- 桌面订阅页右上角运行日志、节点页入口移除、关于页手动检查更新和紧凑宽度图标回退均有
+  Widget 回归。macOS 系统代理减少三次重复 `networksetup` 启用调用，但快照、服务身份复核、
+  guardian、回读和失败回滚仍有定向测试。Windows 连接事务未删除任何稳定性门禁。
+- 发布时 `adb devices` 没有在线设备，因此 v4.0.23 正式 APK 的原地升级、抖音评论/私信图片
+  和 Telegram 真实数据路径保持未执行；自动化不能替代该证据。
+
+正式版仍需按下表记录真实数据通道；未取得设备证据时保持“未执行”：
+
+| ID | 平台/模式 | 目标 | 通过标准 | 当前状态 |
+| --- | --- | --- | --- | --- |
+| V23-01 | Android 智能 | 抖音评论区、私信图片，微信、QQ、淘宝等国内应用 | 已维护国内包名不进入 TUN；连续 20 轮图片、评论和消息正常，无随机超时 | 自动化通过 / 真机未执行 |
+| V23-02 | Android 智能 | Chrome/Edge/Firefox 等浏览器、Telegram、ChatGPT、Claude | 浏览器和国外应用继续进入 TUN，域名规则或强制代理规则生效 | 自动化通过 / 真机未执行 |
+| V23-03 | Android 全局 | 国内与国外应用 | 国内应用旁路关闭，除既有 ADB 调试包外全部应用进入 TUN | 自动化通过 / 真机未执行 |
+| V23-04 | Android 升级/恢复 | v4.0.22 原地升级、旧原生快照、模式切换 | 数据保留；旧 v1/v2 快照按“不旁路”解码；切换模式完整重连且无残留 VPN | 自动化通过 / 真机未执行 |
+| V23-05 | macOS 系统代理 | 连接、断开、失败回滚和连接耗时 | 系统代理正确启用/恢复，失败不留脏状态；同机记录 10 次中位数和 P95 | 自动化通过 / 人工未执行 |
+| V23-06 | Windows TUN/系统代理 | 国内、海外、DNS、UDP/QUIC、异常退出 | 数据路径正常，未知流量可访问，异常退出后系统网络设置恢复 | 线上构建/安装 smoke 通过 / 人工未执行 |
+| V23-07 | Windows/macOS UI | 订阅页日志、关于页检查更新、未连接手动检查 | 键盘/读屏可达，窄窗口不溢出；手动检查可执行，自动检查仍只在连接后运行 | 自动化通过 / 人工未执行 |
+
 ## 2026-09-02 v4.0.22 智能分流正式发布与候选证据
 
 - 受保护 PR [#183](https://github.com/Elegying/SSRVPN/pull/183) 已 squash 合并；`main`、标签


### PR DESCRIPTION
## 内容
- 更新项目健康状态、综合评分与五项后续验收优先级
- 记录 v4.0.23 精确 main、tag、CI、Prepare Release 和 Release 证据
- 记录七项资产、三端 SHA-256、provenance、Attestations 与 OSS 逐字节核验
- 明确 Android 抖音/Telegram 真机复验和桌面人工矩阵仍未执行

## 本地验证
- `git diff --check`
- `bash scripts/check-doc-consistency.sh`
- `bash scripts/check-product-surface-guards.sh`