### PR TITLE
test: 修复快照并发用例的短等待竞态

### DIFF
--- a/SSRVPN_Android/test/clash_service_test.dart
+++ b/SSRVPN_Android/test/clash_service_test.dart
@@ -29,6 +29,17 @@ proxies:
 
 class _RealHttpOverrides extends HttpOverrides {}
 
+class _SnapshotWriteObservationService extends ClashService {
+  void Function(String)? onConfigWritten;
+
+  @override
+  Future<String> writeConfig(String config) async {
+    final path = await super.writeConfig(config);
+    onConfigWritten?.call(path);
+    return path;
+  }
+}
+
 class _ConnectionGenerationObservationService extends ClashService {
   bool Function()? observationStillCurrent;
 
@@ -2390,7 +2401,7 @@ void main() {
         }
         return null;
       });
-      final service = ClashService()
+      final service = _SnapshotWriteObservationService()
         ..setPaths(
           configDir: dir.path,
           configPath: '${dir.path}${Platform.pathSeparator}config.yaml',
@@ -2403,38 +2414,33 @@ void main() {
         preparedConfigPath: activeConfigPath,
       );
       await stateQueryEntered.future;
+      final replacementPrepared = Completer<String>();
+      service.onConfigWritten = replacementPrepared.complete;
       final replacementFuture = service.writePreferredNodeConfig(
         _testProxies,
         AppSettings(apiSecret: 'test-secret'),
         '新加坡节点',
       );
-      String? preparedReplacement;
-      for (var attempt = 0; attempt < 100; attempt++) {
-        final candidates = await dir
-            .list(followLinks: false)
-            .where(
-              (entity) =>
-                  entity is File &&
-                  entity.path.endsWith('.yaml') &&
-                  entity.path != activeConfigPath,
-            )
-            .map((entity) => entity.path)
-            .toList();
-        if (candidates.isNotEmpty) {
-          preparedReplacement = candidates.single;
-          break;
+      try {
+        // Wait for the actual atomic write; runner load must not decide ordering.
+        final preparedReplacement = await replacementPrepared.future;
+        releaseStateQuery.complete(connectionState());
+        expect(await start, isTrue);
+        final committedReplacement = await replacementFuture;
+
+        expect(committedReplacement, preparedReplacement);
+        expect(await File(committedReplacement).exists(), isTrue);
+        expect(syncCalls, 2);
+      } finally {
+        if (!releaseStateQuery.isCompleted) {
+          releaseStateQuery.complete(connectionState());
         }
-        await Future<void>.delayed(const Duration(milliseconds: 1));
+        try {
+          await Future.wait<Object?>([start, replacementFuture]);
+        } finally {
+          service.dispose();
+        }
       }
-      expect(preparedReplacement, isNotNull);
-
-      releaseStateQuery.complete(connectionState());
-      expect(await start, isTrue);
-      final committedReplacement = await replacementFuture;
-
-      expect(committedReplacement, preparedReplacement);
-      expect(await File(committedReplacement).exists(), isTrue);
-      expect(syncCalls, 2);
     },
   );
 


### PR DESCRIPTION
并发快照测试原先最多轮询约 100 毫秒就断言配置文件必须出现。主分支 CI 在文件仍写入时提前失败，随后的目录清理又导致异步 rename 报错。

测试专用子类现在在真实 writeConfig 完成后发送信号，测试再释放排队事务；结束时等待在途操作完成后清理。仍然断言准备的配置未被剪枝、提交路径一致和两次原生同步，没有延长产品超时或改变产品代码。

验证：原失败用例通过；完整 Android 289 项通过，覆盖率 69.07% 达门槛；相关静态分析无问题、git diff --check 通过。本修复用于继续 v4.0.30 发布，尚未创建该版本标签。
